### PR TITLE
feat(bootstrap): use $PROJECTS_HOME instead of hardcoded ~/projects

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -3,7 +3,7 @@
 # Re-running is safe: every step checks "already done" and skips.
 set -euo pipefail
 
-DOTFILES="$HOME/projects/dotfiles"
+DOTFILES="$PROJECTS_HOME/dotfiles"
 
 # link <source-relative-to-DOTFILES> <target-absolute>
 link() {


### PR DESCRIPTION
## Summary

- Replace hardcoded `$HOME/projects/dotfiles` path with `$PROJECTS_HOME/dotfiles` in `bootstrap.sh`
- Allows the dotfiles root to be placed anywhere by setting `PROJECTS_HOME` in the environment

## Test plan

- [x] Set `PROJECTS_HOME` to your projects directory and run `bootstrap.sh` — symlinks should resolve correctly
- [ ] Verify re-running is still idempotent

🤖 Generated with [Claude Code](https://claude.com/claude-code)