### PR TITLE
feat: project-mode zsh prompt inside tmux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ tmp/
 # macOS
 .DS_Store
 
+# brainstorming visual companion session files
+.superpowers/
+
 # editor swap
 *.swp
 *~

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ tmp/
 # zsh local machine config — lives at ~/.zshrc.local, never in the repo
 .zshrc.local
 
+# git worktrees (project-local, per CLAUDE.md)
+.claude/worktrees/
+
 # macOS
 .DS_Store
 

--- a/.p10k.zsh
+++ b/.p10k.zsh
@@ -287,6 +287,7 @@
   # Can also be handy when the directory is shortened, as it allows you to see
   # the full directory that was used in previous commands.
   typeset -g POWERLEVEL9K_DIR_HYPERLINK=false
+  typeset -g POWERLEVEL9K_DIR_DEFAULT_CONTENT_EXPANSION='${_p9k_project_path:-${8:+${8}:}${9}}'
 
   # Enable special styling for non-writable and non-existent directories. See POWERLEVEL9K_LOCK_ICON
   # and POWERLEVEL9K_DIR_CLASSES below.

--- a/.p10k.zsh
+++ b/.p10k.zsh
@@ -287,7 +287,7 @@
   # Can also be handy when the directory is shortened, as it allows you to see
   # the full directory that was used in previous commands.
   typeset -g POWERLEVEL9K_DIR_HYPERLINK=false
-  typeset -g POWERLEVEL9K_DIR_DEFAULT_CONTENT_EXPANSION='${_p9k_project_path:-${8:+${8}:}${9}}'
+  typeset -g POWERLEVEL9K_DIR_DEFAULT_CONTENT_EXPANSION='${_p9k_project_path:-${P9K_CONTENT}}'
 
   # Enable special styling for non-writable and non-existent directories. See POWERLEVEL9K_LOCK_ICON
   # and POWERLEVEL9K_DIR_CLASSES below.

--- a/.zshrc
+++ b/.zshrc
@@ -59,6 +59,27 @@ add-zsh-hook preexec _tmux_rename
 # To customize prompt, run `p10k configure` or edit ~/.p10k.zsh.
 [[ ! -f ~/.p10k.zsh ]] || source ~/.p10k.zsh
 
+_p9k_project_context() {
+  local projects="${PROJECTS_HOME:-$HOME/code}"
+  if [[ -n $TMUX && $PWD == ${projects}/?* ]]; then
+    local rel="${PWD#${projects}/}"
+    local -a parts=("${(@s:/:)rel}")
+    local out="${parts[1]}"
+    local i
+    for (( i=2; i<${#parts[@]}; i++ )); do
+      out+="/${parts[i][1]}"
+    done
+    (( ${#parts[@]} > 1 )) && out+="/${parts[-1]}"
+    _p9k_project_path="$out"
+    typeset -g POWERLEVEL9K_VCS_DISABLED_WORKDIR_PATTERN='*'
+  else
+    unset _p9k_project_path
+    typeset -g POWERLEVEL9K_VCS_DISABLED_WORKDIR_PATTERN='~'
+  fi
+}
+add-zsh-hook chpwd _p9k_project_context
+precmd_functions=(_p9k_project_context "${precmd_functions[@]}")
+
 if command -v wt >/dev/null 2>&1; then eval "$(command wt config shell init zsh)"; fi
 [[ -f ~/.secrets ]] && source ~/.secrets
 [[ -f ~/.zshrc.local ]] && source ~/.zshrc.local

--- a/.zshrc
+++ b/.zshrc
@@ -59,6 +59,7 @@ add-zsh-hook preexec _tmux_rename
 # To customize prompt, run `p10k configure` or edit ~/.p10k.zsh.
 [[ ! -f ~/.p10k.zsh ]] || source ~/.p10k.zsh
 
+# Keep in sync with scripts/test-prompt-context.zsh
 _p9k_project_context() {
   local projects="${PROJECTS_HOME:-$HOME/code}"
   if [[ -n $TMUX && $PWD == ${projects}/?* ]]; then
@@ -78,7 +79,7 @@ _p9k_project_context() {
   fi
 }
 add-zsh-hook chpwd _p9k_project_context
-precmd_functions=(_p9k_project_context "${precmd_functions[@]}")
+precmd_functions=(_p9k_project_context ${precmd_functions:#_p9k_project_context})
 
 if command -v wt >/dev/null 2>&1; then eval "$(command wt config shell init zsh)"; fi
 [[ -f ~/.secrets ]] && source ~/.secrets

--- a/scripts/test-prompt-context.zsh
+++ b/scripts/test-prompt-context.zsh
@@ -1,0 +1,87 @@
+#!/usr/bin/env zsh
+# Unit tests for _p9k_project_context.
+# Run: zsh scripts/test-prompt-context.zsh
+set -u
+
+pass=0; fail=0; fail_msgs=()
+
+assert_eq() {
+  local got="$1" want="$2" desc="$3"
+  if [[ "$got" == "$want" ]]; then
+    pass=$((pass+1)); echo "  PASS  $desc"
+  else
+    fail=$((fail+1))
+    fail_msgs+=("FAIL  $desc"$'\n'"        got:  '$got'"$'\n'"        want: '$want'")
+    echo "  FAIL  $desc"
+  fi
+}
+
+# ── function under test (stub — replace with real implementation in Task 3) ──
+_p9k_project_context() {
+  local projects="${PROJECTS_HOME:-$HOME/code}"
+  if [[ -n $TMUX && $PWD == ${projects}/?* ]]; then
+    local rel="${PWD#${projects}/}"
+    local -a parts=("${(@s:/:)rel}")
+    local out="${parts[1]}"
+    local i
+    for (( i=2; i<${#parts[@]}; i++ )); do
+      out+="/${parts[i][1]}"
+    done
+    (( ${#parts[@]} > 1 )) && out+="/${parts[-1]}"
+    _p9k_project_path="$out"
+    typeset -g POWERLEVEL9K_VCS_DISABLED_WORKDIR_PATTERN='*'
+  else
+    unset _p9k_project_path
+    typeset -g POWERLEVEL9K_VCS_DISABLED_WORKDIR_PATTERN='~'
+  fi
+}
+
+# ── helper: run context function with controlled env ─────────────────────────
+# Uses zsh dynamic scoping: local TMUX/PWD/PROJECTS_HOME are visible inside
+# _p9k_project_context when called from this helper.
+_run() {
+  local TMUX="$1" PWD="$2" PROJECTS_HOME="$3"
+  unset _p9k_project_path POWERLEVEL9K_VCS_DISABLED_WORKDIR_PATTERN
+  _p9k_project_context
+}
+
+# ── tests ────────────────────────────────────────────────────────────────────
+echo
+echo "_p9k_project_context"
+echo "─────────────────────"
+
+_run "1" "/p/myapp" "/p"
+assert_eq "${_p9k_project_path:-__unset__}"          "myapp"  "project root → myapp"
+assert_eq "${POWERLEVEL9K_VCS_DISABLED_WORKDIR_PATTERN:-__unset__}" "*" "project mode disables vcs"
+
+_run "1" "/p/myapp/src" "/p"
+assert_eq "${_p9k_project_path:-__unset__}"          "myapp/src"  "one subdir → myapp/src (no middle to shorten)"
+
+_run "1" "/p/myapp/src/components" "/p"
+assert_eq "${_p9k_project_path:-__unset__}"          "myapp/s/components"  "two subdirs → shorten middle"
+
+_run "1" "/p/myapp/src/components/ui" "/p"
+assert_eq "${_p9k_project_path:-__unset__}"          "myapp/s/c/ui"  "three subdirs → shorten two middle"
+
+_run "" "/p/myapp" "/p"
+assert_eq "${_p9k_project_path:-__unset__}"          "__unset__"  "no TMUX → project path unset"
+assert_eq "${POWERLEVEL9K_VCS_DISABLED_WORKDIR_PATTERN:-__unset__}" "~" "no TMUX → vcs pattern restored to ~"
+
+_run "1" "/p" "/p"
+assert_eq "${_p9k_project_path:-__unset__}"          "__unset__"  "at PROJECTS_HOME root → not project mode"
+
+_run "1" "/tmp/other" "/p"
+assert_eq "${_p9k_project_path:-__unset__}"          "__unset__"  "outside PROJECTS_HOME → project path unset"
+assert_eq "${POWERLEVEL9K_VCS_DISABLED_WORKDIR_PATTERN:-__unset__}" "~" "outside PROJECTS_HOME → vcs pattern restored to ~"
+
+# ── summary ──────────────────────────────────────────────────────────────────
+echo
+echo "─────────────────────"
+echo "passed: $pass"
+echo "failed: $fail"
+if (( fail > 0 )); then
+  echo
+  printf '%s\n' "${fail_msgs[@]}"
+  exit 1
+fi
+exit 0

--- a/scripts/test-prompt-context.zsh
+++ b/scripts/test-prompt-context.zsh
@@ -16,7 +16,8 @@ assert_eq() {
   fi
 }
 
-# ── function under test (stub — replace with real implementation in Task 3) ──
+# ── function under test ──────────────────────────────────────────────────────
+# Keep in sync with .zshrc
 _p9k_project_context() {
   local projects="${PROJECTS_HOME:-$HOME/code}"
   if [[ -n $TMUX && $PWD == ${projects}/?* ]]; then


### PR DESCRIPTION
## Summary
- Show a project-relative truncated path in the p10k `dir` pill when both inside tmux **and** under `\$PROJECTS_HOME` (`~/code/<project>/…`); hide the `vcs` segment in that mode.
- Outside either condition, the prompt renders identically to before.
- Driven by a single `_p9k_project_context` hook (registered in `chpwd_functions` and prepended idempotently to `precmd_functions`) that toggles two p10k variables p10k re-evaluates per render: `POWERLEVEL9K_DIR_DEFAULT_CONTENT_EXPANSION` (with `\${P9K_CONTENT}` as the correct fallback) and `POWERLEVEL9K_VCS_DISABLED_WORKDIR_PATTERN`.

## Path truncation
Project root and last component stay full; middle components shorten to first letter.
Example: `~/code/myapp/src/components/ui` → `myapp/s/c/ui`.

## Test plan
- [x] `zsh scripts/test-prompt-context.zsh` — 10/10 unit tests pass
- [ ] `source ~/.zshrc` outside tmux → prompt unchanged (full path + vcs)
- [ ] Inside tmux, `cd ~/code/<project>/src/components/ui` → dir pill shows truncated project path, vcs hidden
- [ ] Inside tmux, `cd ~` → full p10k prompt restored, vcs visible