### PR TITLE
fix(p10k): project-mode dir override silently ignored

### DIFF
--- a/.p10k.zsh
+++ b/.p10k.zsh
@@ -287,7 +287,9 @@
   # Can also be handy when the directory is shortened, as it allows you to see
   # the full directory that was used in previous commands.
   typeset -g POWERLEVEL9K_DIR_HYPERLINK=false
-  typeset -g POWERLEVEL9K_DIR_DEFAULT_CONTENT_EXPANSION='${_p9k_project_path:-${P9K_CONTENT}}'
+  # POWERLEVEL9K_DIR_CLASSES is empty (line 352), so the dir state has no
+  # `_DEFAULT` suffix; using the segment-default name instead of `_DEFAULT_*`.
+  typeset -g POWERLEVEL9K_DIR_CONTENT_EXPANSION='${_p9k_project_path:-${P9K_CONTENT}}'
 
   # Enable special styling for non-writable and non-existent directories. See POWERLEVEL9K_LOCK_ICON
   # and POWERLEVEL9K_DIR_CLASSES below.


### PR DESCRIPTION
## Summary
- PR #3 set `POWERLEVEL9K_DIR_DEFAULT_CONTENT_EXPANSION`, but `.p10k.zsh:352` declares `POWERLEVEL9K_DIR_CLASSES=()`. With no class match, p10k's `_p9k_param` looks up `_POWERLEVEL9K_DIR_CONTENT_EXPANSION` (no `_DEFAULT` suffix) and falls back to `${P9K_CONTENT}` — so the override never took effect.
- Vcs-hide worked because `POWERLEVEL9K_VCS_DISABLED_WORKDIR_PATTERN` doesn't go through state-suffixed lookup. That's why the live prompt showed full path *and* hidden git.
- Switch to `POWERLEVEL9K_DIR_CONTENT_EXPANSION` (segment-default, no state needed). Verified end-to-end in `zsh -i`: `_p9k_param prompt_dir CONTENT_EXPANSION` now returns our expansion, which expands to `dotfiles` while in `~/code/dotfiles`.

## Test plan
- [x] `zsh scripts/test-prompt-context.zsh` — 10/10 unit tests still pass
- [x] Fresh `zsh -i` after edit: `_p9k_param prompt_dir CONTENT_EXPANSION` returns `${_p9k_project_path:-${P9K_CONTENT}}`, `print -P` of that yields `dotfiles`
- [ ] `exec zsh` in tmux + `~/code/dotfiles` → dir pill shows `dotfiles`, vcs hidden
- [ ] `cd ~` → full p10k prompt + vcs back