### PR TITLE
Move $PROJECTS_HOME to .zshrc.local; drop fallbacks

### DIFF
--- a/.config/tmux/bin/tmux-project-name
+++ b/.config/tmux/bin/tmux-project-name
@@ -6,7 +6,7 @@
 # Usage: tmux-project-name [pwd]
 
 set -e
-projects="${PROJECTS_HOME:-$HOME/projects}"
+projects="$PROJECTS_HOME"
 pwd_in="${1:-$PWD}"
 
 case "$pwd_in/" in

--- a/.config/tmux/bin/tmux-sesh-popup
+++ b/.config/tmux/bin/tmux-sesh-popup
@@ -5,7 +5,7 @@
 # existing session or creates a new one rooted at the chosen path.
 set -eu
 
-projects="${PROJECTS_HOME:-$HOME/projects}"
+projects="$PROJECTS_HOME"
 
 # Project dirs (full path, one per line)
 project_paths=$(find "$projects" -mindepth 1 -maxdepth 1 -type d ! -name '.*' \

--- a/.vimrc
+++ b/.vimrc
@@ -1,4 +1,4 @@
-" ~/.vimrc — minimal vim config (managed in ~/projects/dotfiles)
+" ~/.vimrc — minimal vim config (managed in $PROJECTS_HOME/dotfiles)
 
 set nocompatible
 set encoding=utf-8

--- a/.zshrc
+++ b/.zshrc
@@ -20,7 +20,10 @@ export PATH="$HOME/.cargo/bin:$PATH"
 export PATH="${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"
 export PATH="$HOME/.local/bin:$PATH"
 
-export PROJECTS_HOME="$HOME/code"
+# Per-machine config (sets PROJECTS_HOME and any local PATH/env overrides).
+# Sourced after .zshrc's PATH appends so .zshrc.local's appends still win
+# precedence; sourced before any function or precmd that uses $PROJECTS_HOME.
+[[ -f ~/.zshrc.local ]] && source ~/.zshrc.local
 
 autoload -U add-zsh-hook
 load-nvmrc() {
@@ -87,4 +90,3 @@ precmd_functions=(_p9k_project_context ${precmd_functions:#_p9k_project_context}
 
 if command -v wt >/dev/null 2>&1; then eval "$(command wt config shell init zsh)"; fi
 [[ -f ~/.secrets ]] && source ~/.secrets
-[[ -f ~/.zshrc.local ]] && source ~/.zshrc.local

--- a/.zshrc
+++ b/.zshrc
@@ -68,7 +68,7 @@ add-zsh-hook preexec _tmux_rename
 
 # Keep in sync with scripts/test-prompt-context.zsh
 _p9k_project_context() {
-  local projects="${PROJECTS_HOME:-$HOME/code}"
+  local projects="$PROJECTS_HOME"
   if [[ -n $TMUX && $PWD == ${projects}/?* ]]; then
     local rel="${PWD#${projects}/}"
     local -a parts=("${(@s:/:)rel}")

--- a/.zshrc.local.template
+++ b/.zshrc.local.template
@@ -32,3 +32,7 @@
 
 # Claude Code — disable 1M context window
 # export CLAUDE_CODE_DISABLE_1M_CONTEXT=1
+
+# Projects home — REQUIRED. Without this, the prompt's project chip,
+# the tmux project segment, and the sesh popup all misbehave silently.
+# export PROJECTS_HOME="$HOME/code"

--- a/Brewfile
+++ b/Brewfile
@@ -1,5 +1,5 @@
 # Brewfile — packages this dotfiles repo depends on.
-# Run `brew bundle --file=~/projects/dotfiles/Brewfile` to install.
+# Run `brew bundle --file=$PROJECTS_HOME/dotfiles/Brewfile` to install.
 
 # Core
 brew "git"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,11 +25,18 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
 
 ## Where things live
 
-- Sources: `~/projects/dotfiles/{.config,.vimrc,.vim/colors,.zshrc,.p10k.zsh}`
-- Targets: `~/.config/{ghostty,tmux}`, `~/.vimrc`, `~/.vim/colors`, `~/.zshrc`, `~/.p10k.zsh`
+- Sources: `$PROJECTS_HOME/dotfiles/{.config,.vimrc,.vim/colors,.zshrc,.p10k.zsh}`
+- Targets: `~/.config/{ghostty,tmux,ccstatusline}`, `~/.vimrc`, `~/.vim/colors`, `~/.zshrc`, `~/.p10k.zsh`
 - Machine-specific overrides: `~/.zshrc.local` (untracked; copy from `.zshrc.local.template`)
 - Helpers: `.config/tmux/bin/tmux-{project-name,git-status}`
 - Smoke tests for helpers: `scripts/test-helpers.sh`
+
+## Verify changes
+
+- Helper smoke tests: `scripts/test-helpers.sh`
+- Zsh prompt-context tests: `scripts/test-prompt-context.zsh`
+- Reapply symlinks (idempotent): `$PROJECTS_HOME/dotfiles/bootstrap.sh`
+- Check brew deps without installing: `brew bundle check --file=$PROJECTS_HOME/dotfiles/Brewfile --verbose`
 
 ## Out of scope (future work, separate spec)
 

--- a/README.md
+++ b/README.md
@@ -2,12 +2,6 @@
 
 Personal config for Ghostty + zsh + tmux + vim, all in Solarized + JetBrainsMono Nerd Font.
 
-## On a new Mac
-
-    git clone git@github.com:martinciu/dotfiles.git ~/projects/dotfiles
-    brew bundle --file=~/projects/dotfiles/Brewfile
-    ~/projects/dotfiles/bootstrap.sh
-
 ## What's where
 
 | Tool    | Source path                          | Target              |

--- a/scripts/test-helpers.sh
+++ b/scripts/test-helpers.sh
@@ -3,7 +3,7 @@
 # Run from the repo root or anywhere — paths are absolute.
 set -u
 
-REPO="$HOME/projects/dotfiles"
+REPO="$PROJECTS_HOME/dotfiles"
 PROJ_NAME="$REPO/.config/tmux/bin/tmux-project-name"
 GIT_STATUS="$REPO/.config/tmux/bin/tmux-git-status"
 

--- a/scripts/test-prompt-context.zsh
+++ b/scripts/test-prompt-context.zsh
@@ -19,7 +19,7 @@ assert_eq() {
 # ── function under test ──────────────────────────────────────────────────────
 # Keep in sync with .zshrc
 _p9k_project_context() {
-  local projects="${PROJECTS_HOME:-$HOME/code}"
+  local projects="$PROJECTS_HOME"
   if [[ -n $TMUX && $PWD == ${projects}/?* ]]; then
     local rel="${PWD#${projects}/}"
     local -a parts=("${(@s:/:)rel}")


### PR DESCRIPTION
## Summary

- Make `.zshrc.local` the single declaration site for `$PROJECTS_HOME`; the committed repo no longer expresses an opinion on the literal directory name.
- Drop all `${PROJECTS_HOME:-…}` fallbacks across the prompt function, its test mirror, and the two tmux helpers (no validator, no error guard — accepted tradeoff for a personal repo).
- Convert `~/projects/dotfiles` mentions to `$PROJECTS_HOME/dotfiles` in `Brewfile`/`.vimrc` headers, drop the misleading README cold-start section, and fix a latent bug in `scripts/test-helpers.sh` where a hardcoded `$HOME/projects/dotfiles` made the helpers test silently skip all assertions on this machine.

## Test plan

- [x] `zsh scripts/test-prompt-context.zsh` → 10/10 PASS
- [x] `bash scripts/test-helpers.sh` → 26/26 PASS (was silently skipping before — `REPO` path bug)
- [x] `zsh -i -c 'echo $PROJECTS_HOME'` → `/Users/martinciu/code`
- [x] PATH head unchanged after sourcing `.zshrc.local` early (precedence preserved)
- [x] `grep -rn -E '~/projects|\$HOME/projects'` across tracked sources → zero stragglers
- [ ] Open a fresh terminal + tmux session, confirm prompt project chip and tmux project segment render correctly