### PR TITLE
feat(bootstrap): track ~/.claude/CLAUDE.md via symlink

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,18 @@
+# Global Claude Instructions
+
+## Git and GitHub
+
+Never add cloude code as git commit co-author!
+When pushing branch to remote remove "worktree-" prefix from the branch name on remote.
+
+## Superpowers
+
+  Superpowers specs and plans must be saved to `tmp/` (e.g. `tmp/specs/` and `tmp/plans/`).
+  Never write to `docs/superpowers/` — skills default to that path but it is wrong here.
+  Never commit superpowers documents.
+  Worktree directory: `.claude/worktrees/` (project-local, under `.claude/`).
+
+## Compound Engineering
+
+Design docs and specs are stored in `tmp/`.
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,8 +43,8 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
 
 ## Where things live
 
-- Sources: `$PROJECTS_HOME/dotfiles/{.config,.vimrc,.vim/colors,.zshrc,.p10k.zsh}` (`.config/` includes `nvim/`, `worktrunk/`)
-- Targets: `~/.config/{ghostty,tmux,ccstatusline,nvim,worktrunk}`, `~/.vimrc`, `~/.vim/colors`, `~/.zshrc`, `~/.p10k.zsh`
+- Sources: `$PROJECTS_HOME/dotfiles/{.config,.vimrc,.vim/colors,.zshrc,.p10k.zsh,.claude/CLAUDE.md}` (`.config/` includes `nvim/`, `worktrunk/`)
+- Targets: `~/.config/{ghostty,tmux,ccstatusline,nvim,worktrunk}`, `~/.vimrc`, `~/.vim/colors`, `~/.zshrc`, `~/.p10k.zsh`, `~/.claude/CLAUDE.md`
 - Machine-specific overrides: `~/.zshrc.local` (untracked; copy from `.zshrc.local.template`)
 - Helpers: `.config/tmux/bin/tmux-{project-name,git-status}`
 - Smoke tests for helpers: `scripts/test-helpers.sh`

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -51,6 +51,9 @@ mkdir -p "$HOME/.vim/undo" "$HOME/.vim/backup" "$HOME/.vim/swap"
 link ".zshrc"     "$HOME/.zshrc"
 link ".p10k.zsh"  "$HOME/.p10k.zsh"
 
+# --- claude
+link ".claude/CLAUDE.md" "$HOME/.claude/CLAUDE.md"
+
 # --- TPM (clone if missing; warn but don't abort if offline)
 TPM_DIR="$HOME/.config/tmux/plugins/tpm"
 if [ ! -d "$TPM_DIR/.git" ]; then


### PR DESCRIPTION
## Summary
- Add `dotfiles/.claude/CLAUDE.md` as a tracked source file (byte-identical copy of the previous live `~/.claude/CLAUDE.md`).
- Wire `bootstrap.sh` to symlink `~/.claude/CLAUDE.md` → the tracked source via the existing `link` helper (auto-backs-up the pre-existing file, idempotent on re-run).
- Document the new source/target pair in the project `CLAUDE.md` "Where things live" section.

## Test plan
- [x] `bash -n bootstrap.sh` syntax check passes
- [x] `scripts/test-helpers.sh` passes (26/26)
- [x] First `bootstrap.sh` run creates `~/.claude/CLAUDE.md.bak.<ts>` and replaces the file with a symlink to the dotfiles source
- [x] `readlink ~/.claude/CLAUDE.md` resolves to `$DOTFILES/.claude/CLAUDE.md`
- [x] Post-symlink sha256 matches pre-symlink sha256 (content unchanged)
- [x] Re-running `bootstrap.sh` is idempotent (no second backup, `ok:` line)

## Out of scope
- Tracking other `~/.claude/` content (`settings.json`, `commands/`, custom `skills/`)
- Symlinking `~/.claude/` as a directory (machine-local state would leak in)