### PR TITLE
Solarized Dark shell colors: eza, bat, delta, fzf, zsh plugins

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -21,6 +21,10 @@ unsetopt LIST_BEEP   # ambiguous completion
 export LANG=en_US.UTF-8
 export LC_ALL=en_US.UTF-8
 
+# ─── Colors & appearance ────────────────────
+# LS_COLORS for eza (and GNU ls if present); BSD `\ls` keeps OMZ default LSCOLORS.
+command -v vivid >/dev/null 2>&1 && export LS_COLORS="$(vivid generate solarized-dark)"
+
 export PATH="$HOME/.cargo/bin:$PATH"
 export PATH="${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"
 export PATH="$HOME/.local/bin:$PATH"
@@ -95,3 +99,10 @@ precmd_functions=(_p9k_project_context ${precmd_functions:#_p9k_project_context}
 
 if command -v wt >/dev/null 2>&1; then eval "$(command wt config shell init zsh)"; fi
 [[ -f ~/.secrets ]] && source ~/.secrets
+
+# ─── Aliases (color-aware tools) ────────────
+if command -v eza >/dev/null 2>&1; then
+  alias ls='eza --group-directories-first --icons'
+  alias ll='eza -lh --git --icons --group-directories-first'
+  alias la='ll -a'
+fi

--- a/.zshrc
+++ b/.zshrc
@@ -31,6 +31,9 @@ if command -v bat >/dev/null 2>&1; then
   export MANROFFOPT="-c"
 fi
 
+# zsh-autosuggestions: dim ghost text, readable on Solarized Dark.
+ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE='fg=8'
+
 export PATH="$HOME/.cargo/bin:$PATH"
 export PATH="${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"
 export PATH="$HOME/.local/bin:$PATH"
@@ -113,3 +116,7 @@ if command -v eza >/dev/null 2>&1; then
   alias ll='eza -lh --git --icons --group-directories-first'
   alias la='ll -a'
 fi
+
+# ─── Plugins (order matters; syntax-highlighting MUST be last) ─
+[[ -f /opt/homebrew/share/zsh-autosuggestions/zsh-autosuggestions.zsh ]] && \
+  source /opt/homebrew/share/zsh-autosuggestions/zsh-autosuggestions.zsh

--- a/.zshrc
+++ b/.zshrc
@@ -120,3 +120,7 @@ fi
 # ─── Plugins (order matters; syntax-highlighting MUST be last) ─
 [[ -f /opt/homebrew/share/zsh-autosuggestions/zsh-autosuggestions.zsh ]] && \
   source /opt/homebrew/share/zsh-autosuggestions/zsh-autosuggestions.zsh
+
+# zsh-syntax-highlighting MUST be the last sourced plugin.
+[[ -f /opt/homebrew/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh ]] && \
+  source /opt/homebrew/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh

--- a/.zshrc
+++ b/.zshrc
@@ -25,6 +25,12 @@ export LC_ALL=en_US.UTF-8
 # LS_COLORS for eza (and GNU ls if present); BSD `\ls` keeps OMZ default LSCOLORS.
 command -v vivid >/dev/null 2>&1 && export LS_COLORS="$(vivid generate solarized-dark)"
 
+# Use bat as MANPAGER when available; MANROFFOPT=-c keeps ANSI sequences intact.
+if command -v bat >/dev/null 2>&1; then
+  export MANPAGER="sh -c 'col -bx | bat -l man -p --paging=always'"
+  export MANROFFOPT="-c"
+fi
+
 export PATH="$HOME/.cargo/bin:$PATH"
 export PATH="${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"
 export PATH="$HOME/.local/bin:$PATH"
@@ -101,6 +107,7 @@ if command -v wt >/dev/null 2>&1; then eval "$(command wt config shell init zsh)
 [[ -f ~/.secrets ]] && source ~/.secrets
 
 # ─── Aliases (color-aware tools) ────────────
+command -v bat >/dev/null 2>&1 && alias cat='bat --paging=never'
 if command -v eza >/dev/null 2>&1; then
   alias ls='eza --group-directories-first --icons'
   alias ll='eza -lh --git --icons --group-directories-first'

--- a/.zshrc
+++ b/.zshrc
@@ -34,6 +34,13 @@ fi
 # zsh-autosuggestions: dim ghost text, readable on Solarized Dark.
 ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE='fg=8'
 
+# fzf — Solarized Dark palette.
+export FZF_DEFAULT_OPTS='
+  --color=fg:#839496,bg:#002b36,hl:#268bd2
+  --color=fg+:#eee8d5,bg+:#073642,hl+:#268bd2
+  --color=info:#b58900,prompt:#dc322f,pointer:#d33682
+  --color=marker:#2aa198,spinner:#dc322f,header:#586e75'
+
 export PATH="$HOME/.cargo/bin:$PATH"
 export PATH="${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"
 export PATH="$HOME/.local/bin:$PATH"
@@ -120,6 +127,17 @@ fi
 # ─── Plugins (order matters; syntax-highlighting MUST be last) ─
 [[ -f /opt/homebrew/share/zsh-autosuggestions/zsh-autosuggestions.zsh ]] && \
   source /opt/homebrew/share/zsh-autosuggestions/zsh-autosuggestions.zsh
+
+# fzf shell integration (Ctrl-R history, Ctrl-T file picker).
+[[ -f /opt/homebrew/opt/fzf/shell/completion.zsh ]] && \
+  source /opt/homebrew/opt/fzf/shell/completion.zsh
+[[ -f /opt/homebrew/opt/fzf/shell/key-bindings.zsh ]] && \
+  source /opt/homebrew/opt/fzf/shell/key-bindings.zsh
+# Alt-C is reserved for Polish diacritics; remove fzf's cd-widget binding in
+# every keymap fzf might have bound it in.
+bindkey -M emacs -r '^[c' 2>/dev/null
+bindkey -M viins -r '^[c' 2>/dev/null
+bindkey -M vicmd -r '^[c' 2>/dev/null
 
 # zsh-syntax-highlighting MUST be the last sourced plugin.
 [[ -f /opt/homebrew/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh ]] && \

--- a/Brewfile
+++ b/Brewfile
@@ -19,3 +19,11 @@ brew "ripgrep"   # snacks.picker live grep
 brew "fd"        # snacks.picker file find
 brew "lazygit"   # <leader>gg in LazyVim
 brew "tree-sitter-cli" # nvim-treesitter parser builds
+
+# Shell colors & appearance
+brew "eza"                      # ls replacement with icons + git status
+brew "bat"                      # syntax-highlighted cat / man pager backend
+brew "git-delta"                # git diff/log/blame pager
+brew "vivid"                    # generates LS_COLORS palettes
+brew "zsh-syntax-highlighting"  # live command-line highlighting
+brew "zsh-autosuggestions"      # ghost-text completion from history

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,20 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
   `unsetopt BEEP/HIST_BEEP/LIST_BEEP`, vim `belloff=all`, tmux
   `bell-action/visual-bell/monitor-bell off`). Don't re-enable without
   an explicit ask.
+- **Shell colors are Solarized Dark, end-to-end.** Tools: `eza` (ls),
+  `bat` (cat + `MANPAGER`), `git-delta` (git pager), `vivid` (`LS_COLORS`),
+  `zsh-syntax-highlighting`, `zsh-autosuggestions`. Palette pins:
+  `vivid generate solarized-dark`, `bat --theme="Solarized (dark)"`,
+  `delta.syntax-theme = "Solarized (dark)"`. Don't swap themes or
+  introduce alternatives (`exa`, `lsd`, `diff-so-fancy`, etc.) without
+  asking. Plugin source order in `.zshrc` is fixed: zsh-autosuggestions →
+  fzf → `bindkey -r '^[c'` (Alt-C unbind) → zsh-syntax-highlighting (must
+  be last). On a new machine, after `brew bundle`, run once:
+  `git config --global core.pager delta`,
+  `git config --global interactive.diffFilter "delta --color-only"`,
+  `git config --global delta.navigate true`,
+  `git config --global delta.line-numbers true`,
+  `git config --global delta.syntax-theme "Solarized (dark)"`.
 
 ## Where things live
 


### PR DESCRIPTION
## Summary

- Adds 6 Homebrew packages (`eza`, `bat`, `git-delta`, `vivid`, `zsh-syntax-highlighting`, `zsh-autosuggestions`) and wires them into `.zshrc` with a single Solarized Dark palette across `ls`/`cat`/`man`/`git diff`/`fzf`.
- Live typing feedback: commands turn green when valid, red when not; dim ghost-text autosuggestions from history.
- `Ctrl-R` and `Ctrl-T` enabled via fzf shell integration; `Alt-C` cd-widget explicitly unbound (Alt is reserved for Polish diacritics).
- `delta` configured via `git config --global` (run-once, machine-local, untracked); the block is documented in `CLAUDE.md` for reproducibility on a new machine.
- All sourcing is `[[ -f ... ]]`-guarded and aliases are `command -v`-guarded so a fresh checkout pre-`brew bundle` still produces a working shell.

## Test plan

- [x] `brew bundle check --file=Brewfile --verbose` → satisfied
- [x] `scripts/test-helpers.sh` → 26/0
- [x] `scripts/test-prompt-context.zsh` → 10/0
- [x] `scripts/test-nvim.sh` → passes
- [x] Manual smoke: `ls`/`ll` icons + git column; `cat .zshrc` syntax-highlighted; `man ls` paged via bat; `git diff` rendered by delta; `Ctrl-R`/`Ctrl-T` open fzf with Solarized palette; `Alt-c` produces `ć` (not fzf cd-widget); `\cat`/`\ls` escape hatches work
- [x] Plugin source order verified: zsh-autosuggestions → fzf → Alt-C unbind → zsh-syntax-highlighting (last)