### PR TITLE
Use snacks.nvim explorer in place of neo-tree

### DIFF
--- a/.config/nvim/lazy-lock.json
+++ b/.config/nvim/lazy-lock.json
@@ -19,6 +19,7 @@
   "mini.ai": { "branch": "main", "commit": "43eb2074843950a3a25aae56a5f41362ec043bfa" },
   "mini.icons": { "branch": "main", "commit": "bac6317300e205335df425296570d84322730067" },
   "mini.pairs": { "branch": "main", "commit": "42387c7fe68fc0b6e95eaf37f1bb76e7bffaa0d9" },
+  "neo-tree.nvim": { "branch": "main", "commit": "19d20a99bf0061a5ecc4343d2f09fa713306c965" },
   "neotest": { "branch": "master", "commit": "fd0b7986dd0ae04e38ec7dc0c78a432e3820839c" },
   "neotest-jest": { "branch": "main", "commit": "0e7979d51301dfae5ef839d771bd28cf593fde3f" },
   "neotest-rspec": { "branch": "main", "commit": "e7dc67c1167a9e593c804a6be6808ba9a5920d43" },

--- a/.config/nvim/lua/plugins/snacks.lua
+++ b/.config/nvim/lua/plugins/snacks.lua
@@ -1,0 +1,16 @@
+return {
+  {
+    "folke/snacks.nvim",
+    opts = {
+      picker = {
+        sources = {
+          explorer = {
+            hidden = true,
+            ignored = true,
+          },
+        },
+      },
+    },
+  },
+  { "nvim-neo-tree/neo-tree.nvim", enabled = false },
+}


### PR DESCRIPTION
## Summary
- Disable `neo-tree.nvim` (enabled by default in LazyVim)
- Configure `snacks.nvim` picker explorer to show hidden + gitignored files

## Test plan
- [ ] Open nvim, confirm `<leader>e` (or whichever key) opens the snacks explorer, not neo-tree
- [ ] Hidden + ignored files visible in the explorer
- [ ] No neo-tree autocommands or keymaps loaded (`:Lazy` shows neo-tree disabled)