### PR TITLE
feat(zsh): less() wraps bat for paged, syntax-highlighted output

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -135,7 +135,16 @@ if command -v wt >/dev/null 2>&1; then eval "$(command wt config shell init zsh)
 [[ -f ~/.secrets ]] && source ~/.secrets
 
 # ─── Aliases (color-aware tools) ────────────
-command -v bat >/dev/null 2>&1 && alias cat='bat --paging=never'
+if command -v bat >/dev/null 2>&1; then
+  alias cat='bat --paging=never'
+  less() {
+    if [[ -t 0 ]]; then
+      command bat --paging=always "$@"
+    else
+      command bat --paging=always --plain "$@"
+    fi
+  }
+fi
 if command -v eza >/dev/null 2>&1; then
   alias ls='eza --group-directories-first --icons'
   alias ll='eza -lh --git --icons --group-directories-first'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,12 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
   `git config --global delta.navigate true`,
   `git config --global delta.line-numbers true`,
   `git config --global delta.syntax-theme "Solarized (dark)"`.
+- **Interactive `less` is a `bat` wrapper** (defined in `.zshrc` next to the
+  `cat` alias). Files get bat's full decoration; piped input uses `--plain` so
+  `cmd | less` stays clean. `command less` reaches real `less` for `less +F`,
+  `-R`, etc. Don't replace with `alias less='bat …'` — the function exists so
+  stdin doesn't get bat's `STDIN` header. Don't set `$PAGER=bat` globally —
+  git/delta and other tools manage their own pager.
 
 ## Where things live
 


### PR DESCRIPTION
## Summary
- Define `less()` zsh function next to the existing `cat='bat --paging=never'` alias, under the same `command -v bat` guard
- File input gets bat's full decoration (line numbers, header, Solarized syntax); piped input uses `--plain` so `cmd | less` stays clean (no `STDIN` header)
- `command less` remains the escape hatch to real `less` for `less +F`, `-R`, etc.
- Pin the convention in `CLAUDE.md` so future sessions don't drift to `alias less='bat …'` or `$PAGER=bat`

## Test plan
- [x] `source ~/.zshrc && type less` → `less is a shell function`
- [x] `less ~/.zshrc` → paged, line numbers, header, Solarized syntax
- [x] `echo -e "alpha\nbeta\ngamma" | less` → paged, no `STDIN` header, no line numbers
- [x] `command less ~/.zshrc` → plain `less` (no colors)
- [x] `PATH=/usr/bin:/bin zsh -c 'source ~/.zshrc; type less'` → not defined (graceful skip when bat missing)