### PR TITLE
feat(zsh): md alias renders markdown via glow

### DIFF
--- a/.config/glow/glamour.json
+++ b/.config/glow/glamour.json
@@ -1,0 +1,114 @@
+{
+  "document": {
+    "block_suffix": "\n",
+    "color": "#839496",
+    "margin": 2
+  },
+  "block_quote": {
+    "indent": 1,
+    "indent_token": "│ ",
+    "color": "#b58900",
+    "italic": true
+  },
+  "paragraph": {},
+  "list": {
+    "level_indent": 2
+  },
+  "heading": {
+    "block_suffix": "\n",
+    "color": "#268bd2",
+    "bold": true
+  },
+  "h1": {
+    "prefix": "# ",
+    "suffix": "",
+    "color": "#268bd2",
+    "bold": true
+  },
+  "h2": {
+    "prefix": "## ",
+    "color": "#2aa198",
+    "bold": true
+  },
+  "h3": {
+    "prefix": "### ",
+    "color": "#859900",
+    "bold": true
+  },
+  "h4": {
+    "prefix": "#### ",
+    "color": "#b58900",
+    "bold": true
+  },
+  "h5": {
+    "prefix": "##### ",
+    "color": "#6c71c4"
+  },
+  "h6": {
+    "prefix": "###### ",
+    "color": "#586e75"
+  },
+  "text": {},
+  "strikethrough": {
+    "crossed_out": true
+  },
+  "emph": {
+    "italic": true
+  },
+  "strong": {
+    "bold": true
+  },
+  "hr": {
+    "color": "#586e75",
+    "format": "\n──────\n"
+  },
+  "item": {
+    "block_prefix": "• "
+  },
+  "enumeration": {
+    "block_prefix": ". ",
+    "color": "#2aa198"
+  },
+  "task": {
+    "ticked": "[✓] ",
+    "unticked": "[ ] "
+  },
+  "link": {
+    "color": "#6c71c4",
+    "underline": true
+  },
+  "link_text": {
+    "color": "#6c71c4",
+    "bold": true
+  },
+  "image": {
+    "color": "#6c71c4",
+    "underline": true
+  },
+  "image_text": {
+    "color": "#6c71c4",
+    "format": "Image: {{.text}} →"
+  },
+  "code": {
+    "prefix": " ",
+    "suffix": " ",
+    "color": "#cb4b16",
+    "background_color": "#073642"
+  },
+  "code_block": {
+    "margin": 2,
+    "theme": "solarized-dark"
+  },
+  "table": {
+    "center_separator": "│",
+    "column_separator": "│",
+    "row_separator": "─"
+  },
+  "definition_list": {},
+  "definition_term": {},
+  "definition_description": {
+    "indent": 2
+  },
+  "html_block": {},
+  "html_span": {}
+}

--- a/.zshrc
+++ b/.zshrc
@@ -150,6 +150,9 @@ if command -v eza >/dev/null 2>&1; then
   alias ll='eza -lh --git --icons --group-directories-first'
   alias la='ll -a'
 fi
+if command -v glow >/dev/null 2>&1; then
+  alias md='glow --style $HOME/.config/glow/glamour.json'
+fi
 
 # ─── Plugins (order matters; syntax-highlighting MUST be last) ─
 [[ -f /opt/homebrew/share/zsh-autosuggestions/zsh-autosuggestions.zsh ]] && \

--- a/Brewfile
+++ b/Brewfile
@@ -24,6 +24,7 @@ brew "tree-sitter-cli" # nvim-treesitter parser builds
 brew "eza"                      # ls replacement with icons + git status
 brew "bat"                      # syntax-highlighted cat / man pager backend
 brew "git-delta"                # git diff/log/blame pager
+brew "glow"                     # render markdown to ANSI
 brew "vivid"                    # generates LS_COLORS palettes
 brew "zsh-syntax-highlighting"  # live command-line highlighting
 brew "zsh-autosuggestions"      # ghost-text completion from history

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,12 +51,15 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
   `bell-action/visual-bell/monitor-bell off`). Don't re-enable without
   an explicit ask.
 - **Shell colors are Solarized Dark, end-to-end.** Tools: `eza` (ls),
-  `bat` (cat + `MANPAGER`), `git-delta` (git pager), `vivid` (`LS_COLORS`),
-  `zsh-syntax-highlighting`, `zsh-autosuggestions`. Palette pins:
+  `bat` (cat + `MANPAGER`), `git-delta` (git pager), `glow` (`md` markdown
+  renderer), `vivid` (`LS_COLORS`), `zsh-syntax-highlighting`,
+  `zsh-autosuggestions`. Palette pins:
   `vivid generate solarized-dark`, `bat --theme="Solarized (dark)"`,
-  `delta.syntax-theme = "Solarized (dark)"`. Don't swap themes or
-  introduce alternatives (`exa`, `lsd`, `diff-so-fancy`, etc.) without
-  asking. Plugin source order in `.zshrc` is fixed: zsh-autosuggestions →
+  `delta.syntax-theme = "Solarized (dark)"`,
+  `md` alias passes `--style .config/glow/glamour.json` (chroma
+  `solarized-dark` for fenced code blocks). Don't swap themes or
+  introduce alternatives (`exa`, `lsd`, `diff-so-fancy`, `mdcat`, etc.)
+  without asking. Plugin source order in `.zshrc` is fixed: zsh-autosuggestions →
   fzf → `bindkey -r '^[c'` (Alt-C unbind) → zsh-syntax-highlighting (must
   be last). The first-time `git config` recipe wiring delta as git's pager
   lives in **First-time setup on a new machine** below.
@@ -66,11 +69,18 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
   `-R`, etc. Don't replace with `alias less='bat …'` — the function exists so
   stdin doesn't get bat's `STDIN` header. Don't set `$PAGER=bat` globally —
   git/delta and other tools manage their own pager.
+- **`md` renders markdown via `glow`** with a pinned Solarized JSON style at
+  `.config/glow/glamour.json`. `bat`/`less`/`cat` still show source with syntax
+  highlighting; `md` shows rendered output. The alias passes `--style` directly
+  rather than relying on `glow.yml` because glow on macOS reads its yml from
+  `~/Library/Preferences/glow/`, not `~/.config/glow/`. Don't swap to `mdcat`,
+  `frogmouth`, or another renderer without an explicit ask. (`mdcat` was
+  considered and ruled out: archived upstream as of 2025-01-10.)
 
 ## Where things live
 
-- Sources: `$PROJECTS_HOME/dotfiles/{.config,.vimrc,.vim/colors,.zshrc,.p10k.zsh,.claude/CLAUDE.md}` (`.config/` includes `nvim/`, `worktrunk/`)
-- Targets: `~/.config/{ghostty,tmux,ccstatusline,nvim,worktrunk}`, `~/.vimrc`, `~/.vim/colors`, `~/.zshrc`, `~/.p10k.zsh`, `~/.claude/CLAUDE.md`
+- Sources: `$PROJECTS_HOME/dotfiles/{.config,.vimrc,.vim/colors,.zshrc,.p10k.zsh,.claude/CLAUDE.md}` (`.config/` includes `nvim/`, `worktrunk/`, `glow/`)
+- Targets: `~/.config/{ghostty,tmux,ccstatusline,nvim,worktrunk,glow}`, `~/.vimrc`, `~/.vim/colors`, `~/.zshrc`, `~/.p10k.zsh`, `~/.claude/CLAUDE.md`
 - The repo's `.claude/CLAUDE.md` IS the user-global Claude config (symlinked to `~/.claude/CLAUDE.md`). Edits there apply to every project on this machine, not just dotfiles.
 - Machine-specific overrides: `~/.zshrc.local` (untracked; copy from `.zshrc.local.template`)
 - Helpers: `.config/tmux/bin/tmux-{project-name,git-status}`

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -39,6 +39,9 @@ link ".config/ccstatusline" "$HOME/.config/ccstatusline"
 # --- worktrunk
 link ".config/worktrunk" "$HOME/.config/worktrunk"
 
+# --- glow
+link ".config/glow"    "$HOME/.config/glow"
+
 # --- nvim
 link ".config/nvim"    "$HOME/.config/nvim"
 

--- a/scripts/test-helpers.sh
+++ b/scripts/test-helpers.sh
@@ -205,6 +205,61 @@ else
   rm -rf "$changes_repo" "$upstream" "$clone_dir"
 fi
 
+# ─── glow ───────────────────────────────────
+echo
+echo "glow"
+echo "────"
+
+if ! command -v glow >/dev/null 2>&1; then
+  echo "  SKIP — glow not installed (run 'brew bundle')"
+else
+  glamour_json="$HOME/.config/glow/glamour.json"
+
+  if [ -L "$glamour_json" ] && [ "$(readlink "$glamour_json")" = "$REPO/.config/glow/glamour.json" ]; then
+    pass=$((pass+1)); echo "  PASS  ~/.config/glow/glamour.json symlinks into dotfiles"
+  else
+    # Accept directory-level symlink (~/.config/glow -> $REPO/.config/glow) too,
+    # since bootstrap.sh links the dir, not the file. The realpath check below
+    # catches both shapes.
+    if [ -e "$glamour_json" ] && [ "$(cd "$(dirname "$glamour_json")" && pwd -P)/$(basename "$glamour_json")" = "$REPO/.config/glow/glamour.json" ]; then
+      pass=$((pass+1)); echo "  PASS  ~/.config/glow/glamour.json resolves into dotfiles"
+    else
+      fail=$((fail+1))
+      fail_msgs+=("FAIL  ~/.config/glow/glamour.json does not resolve into dotfiles")
+      echo "  FAIL  ~/.config/glow/glamour.json does not resolve into dotfiles"
+    fi
+  fi
+
+  # JSON parse check (uses python3, available on macOS by default).
+  if python3 -m json.tool "$REPO/.config/glow/glamour.json" >/dev/null 2>&1; then
+    pass=$((pass+1)); echo "  PASS  glamour.json parses as JSON"
+  else
+    fail=$((fail+1))
+    fail_msgs+=("FAIL  glamour.json failed to parse")
+    echo "  FAIL  glamour.json failed to parse"
+  fi
+
+  # End-to-end: render a small fixture from stdin via the same flag the alias
+  # uses. Exit 0, non-empty output.
+  out=$(printf '# Hi\n\n**bold**\n' | glow --style "$REPO/.config/glow/glamour.json" - 2>/dev/null)
+  if [ "$?" -eq 0 ] && [ -n "$out" ]; then
+    pass=$((pass+1)); echo "  PASS  stdin render via --style exits 0 with non-empty output"
+  else
+    fail=$((fail+1))
+    fail_msgs+=("FAIL  stdin render failed or empty"$'\n'"        out: '$out'")
+    echo "  FAIL  stdin render failed or empty"
+  fi
+
+  # Render an actual repo file (catches stylesheet parse regressions).
+  if glow --style "$REPO/.config/glow/glamour.json" "$REPO/README.md" >/dev/null 2>&1; then
+    pass=$((pass+1)); echo "  PASS  glow --style glamour.json README.md exits 0"
+  else
+    fail=$((fail+1))
+    fail_msgs+=("FAIL  glow refused glamour.json on README.md")
+    echo "  FAIL  glow refused glamour.json on README.md"
+  fi
+fi
+
 # ─── Summary ────────────────────────────────
 echo
 echo "─────────────────"


### PR DESCRIPTION
## Summary
- Add `md` zsh alias backed by `glow`, themed with a hand-rolled Solarized Dark glamour stylesheet at `.config/glow/glamour.json` so headings/links/code/blockquotes match the Solarized palette pinned across bat/delta/vivid/eza
- Wire `bootstrap.sh` to symlink `.config/glow` and pin `glow` in the Brewfile (alongside bat/delta/vivid)
- Pass `--style` directly in the alias rather than via `glow.yml` because glow on macOS reads its yml from `~/Library/Preferences/glow/`, not `~/.config/glow/` — keeping all glow config under `~/.config/glow/` where the rest of the dotfiles live
- Extend `scripts/test-helpers.sh` with glow smoke checks (symlink resolves into dotfiles, JSON parses, stdin render via --style produces non-empty output, README renders without error)
- Pin convention in `CLAUDE.md`: `md` is rendered markdown, `bat`/`less`/`cat` stay as syntax-highlighted source; don't swap to `mdcat` (archived upstream 2025-01-10) or other renderers without an explicit ask

## Test plan
- [x] `command -v glow && glow --version` → glow 2.1.2
- [x] `readlink ~/.config/glow` → resolves into dotfiles
- [x] `bootstrap.sh` → idempotent re-run, all `ok:`
- [x] `scripts/test-helpers.sh` → 30 PASS, 0 FAIL (incl. 4 new glow checks)
- [x] `brew bundle check` → satisfied
- [x] `type md` (interactive zsh) → `md is an alias for glow --style $HOME/.config/glow/glamour.json`
- [x] `md CLAUDE.md` → rendered Solarized output
- [x] `gh pr view 9 | md -` → renders PR body
- [x] `cat CLAUDE.md` / `less CLAUDE.md` → unchanged (still bat source)