### PR TITLE
docs(claude): add PR-only rule and wt-based worktree workflow

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -10,6 +10,38 @@ This file = cross-project rules every machine should follow (committed via the d
   branch name. Why: local worktree branches are namespaced with `worktree-`
   for the worktrunk/`EnterWorktree` workflow, but the remote should see the
   clean feature-branch name.
+- All changes go through a pull request. Never commit or merge directly to
+  `main`/`master` — open a feature branch (preferably a worktree, per below)
+  and land via PR. Applies to docs and one-line fixes too. If you find
+  yourself on `main`/`master` with uncommitted work, branch first, then commit.
+
+## Worktrees and branching
+
+Default to **worktrees over plain branches** for new task work. A new feature,
+bugfix, or experiment gets its own worktree — not a `git checkout -b` in the
+current workspace. Why: lets multiple tasks proceed in parallel (each in its
+own directory), keeps the main checkout clean for cross-cutting work (reviews,
+hotfixes), and matches the dotfiles `.claude/worktrees/` convention.
+
+When the `using-git-worktrees` skill runs (directly or via
+`subagent-driven-development` / `executing-plans`), prefer
+`wt switch --create <branch>` over the skill's default
+`git worktree add … && cd …` sequence:
+
+- wt's path template (`{{ repo_path }}/.claude/worktrees/{{ branch | sanitize }}`)
+  already matches the project convention.
+- wt runs lifecycle hooks from `.config/wt.toml` (currently none, but available
+  later).
+- The `wt` shell function propagates CWD via `WORKTRUNK_DIRECTIVE_CD_FILE`, so
+  the agent's persistent working directory updates correctly across Bash tool
+  calls.
+
+After `wt switch --create`, skip the skill's auto-setup step
+(`npm install`, `cargo build`, etc.) when a `pre-start` hook exists — the hook
+handles it. Still run the baseline test step the skill prescribes.
+
+If `wt` isn't available in the current project's environment, fall back to the
+skill's default `git worktree add … && cd …` flow.
 
 ## Planning artifacts (Superpowers, Compound Engineering, etc.)
 


### PR DESCRIPTION
## Summary
- Require all changes to land via PR — never commit or merge directly to `main`/`master` (applies to docs and one-line fixes too).
- New **Worktrees and branching** section: default to worktrees over plain branches; prefer `wt switch --create <branch>` over the `using-git-worktrees` skill's manual `git worktree add … && cd …` sequence. wt's path template, lifecycle hooks, and CWD propagation already match the project convention.
- Falls back to the skill's default flow when `wt` isn't available.

## Test plan
- [ ] After merge, confirm `~/.claude/CLAUDE.md` symlink picks up the change
- [ ] Spot-check rendered markdown (`bat ~/.claude/CLAUDE.md`)
- [ ] Verify next worktree-creating skill invocation reaches for `wt switch --create`