### PR TITLE
docs(claude): drop wt references, scope worktrees to existing worktree work

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -11,37 +11,26 @@ This file = cross-project rules every machine should follow (committed via the d
   for the worktrunk/`EnterWorktree` workflow, but the remote should see the
   clean feature-branch name.
 - All changes go through a pull request. Never commit or merge directly to
-  `main`/`master` — open a feature branch (preferably a worktree, per below)
-  and land via PR. Applies to docs and one-line fixes too. If you find
-  yourself on `main`/`master` with uncommitted work, branch first, then commit.
+  `main`/`master` — open a feature branch (see branching policy below) and
+  land via PR. Applies to docs and one-line fixes too. If you find yourself
+  on `main`/`master` with uncommitted work, branch first, then commit.
 
 ## Worktrees and branching
 
-Default to **worktrees over plain branches** for new task work. A new feature,
-bugfix, or experiment gets its own worktree — not a `git checkout -b` in the
-current workspace. Why: lets multiple tasks proceed in parallel (each in its
-own directory), keeps the main checkout clean for cross-cutting work (reviews,
-hotfixes), and matches the dotfiles `.claude/worktrees/` convention.
+Branching policy depends on where you currently are:
 
-When the `using-git-worktrees` skill runs (directly or via
-`subagent-driven-development` / `executing-plans`), prefer
-`wt switch --create <branch>` over the skill's default
-`git worktree add … && cd …` sequence:
+- **Already in a worktree:** keep using worktrees. Create new task work as
+  additional worktrees rather than `git checkout -b` in the current one.
+- **Not in a worktree:** prefer a plain feature branch off `main`/`master`.
+  Run `git checkout -b <branch>` from the current checkout. Don't spin up a
+  worktree just because the task is new.
+- **Already on a feature branch (not `main`/`master`):** stay on it and commit
+  there. Don't branch off a feature branch unless the task is genuinely
+  separate.
 
-- wt's path template (`{{ repo_path }}/.claude/worktrees/{{ branch | sanitize }}`)
-  already matches the project convention.
-- wt runs lifecycle hooks from `.config/wt.toml` (currently none, but available
-  later).
-- The `wt` shell function propagates CWD via `WORKTRUNK_DIRECTIVE_CD_FILE`, so
-  the agent's persistent working directory updates correctly across Bash tool
-  calls.
-
-After `wt switch --create`, skip the skill's auto-setup step
-(`npm install`, `cargo build`, etc.) when a `pre-start` hook exists — the hook
-handles it. Still run the baseline test step the skill prescribes.
-
-If `wt` isn't available in the current project's environment, fall back to the
-skill's default `git worktree add … && cd …` flow.
+Why: worktrees are useful when you're already invested in the parallel-task
+workflow, but adding one from a clean main checkout is overhead the work
+rarely justifies. Match the existing setup instead of forcing one shape.
 
 ## Planning artifacts (Superpowers, Compound Engineering, etc.)
 


### PR DESCRIPTION
## Summary
- Replace the global \"default to worktrees\" rule with a context-aware policy: stick with worktrees when already in one, otherwise plain branch off main/master, otherwise stay on the current feature branch.
- Remove all `wt switch --create` guidance and the `using-git-worktrees` skill override block.
- Reword the PR-only rule in the Git/GitHub section so it points at the new branching policy instead of \"preferably a worktree\".

## Test plan
- [x] Re-read `.claude/CLAUDE.md` end-to-end and confirm no `wt` references remain
- [x] Confirm the Git/GitHub section and the Worktrees section agree on branching guidance