### PR TITLE
Require full clarifying-question phase for superpowers in auto mode

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -40,6 +40,16 @@ rarely justifies. Match the existing setup instead of forcing one shape.
   path, but it is wrong here.
 - Worktree directory: `.claude/worktrees/` (project-local; gitignored).
 
+## Superpowers in auto mode
+
+Auto mode doesn't relax Superpowers' clarifying-question phase. When a
+Superpowers skill (`brainstorming`, `writing-plans`, etc.) is active,
+ask every clarifying question the skill prescribes — one at a time —
+before proposing a design, approach, or plan. Don't bundle questions,
+don't shortcut to a recommendation, don't assume on the user's behalf.
+Auto mode's "prefer action, make reasonable assumptions" applies to
+mechanical execution, not to intent gathering.
+
 
 @~/.claude/CLAUDE.local.md
 


### PR DESCRIPTION
## Summary

- Adds a new "Superpowers in auto mode" section to the global CLAUDE.md.
- Pins precedence: when a Superpowers skill (`brainstorming`, `writing-plans`, etc.) is active, the clarifying-question phase runs in full — one question at a time, no bundling, no shortcuts, no assumptions on the user's behalf.
- Why: auto mode's "prefer action, make reasonable assumptions" was shortcutting brainstorming's Socratic loop. That guidance applies to mechanical execution, not to intent gathering.

## Test plan

- [x] Open a new session in auto mode, invoke `/superpowers:brainstorming`, confirm one-question-at-a-time behavior.