### PR TITLE
feat: migrate Ctrl-R history search to atuin

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -32,6 +32,22 @@ Why: worktrees are useful when you're already invested in the parallel-task
 workflow, but adding one from a clean main checkout is overhead the work
 rarely justifies. Match the existing setup instead of forcing one shape.
 
+## Exploration scope — ignore other worktrees
+
+When exploring a repo (Read, Grep, Glob, or shell `find`/`rg`), never
+descend into `.claude/worktrees/`. Those directories are isolated checkouts
+of the same repo used for parallel task work — they are not additional
+source. Reading them duplicates results, pollutes search output with stale
+branches, and risks acting on code from an unrelated task.
+
+How to apply:
+
+- Skip `.claude/worktrees/**` when listing files, grepping, or globbing.
+- When running `rg`/`find` via Bash, exclude the path explicitly
+  (`rg --glob '!.claude/worktrees'`, `find . -path ./.claude/worktrees -prune -o ...`).
+- If a search legitimately needs to span worktrees (rare — usually only
+  when comparing branches), say so first and confirm before proceeding.
+
 ## Planning artifacts (Superpowers, Compound Engineering, etc.)
 
 - All specs, plans, and design docs go in `tmp/` (e.g. `tmp/specs/`,

--- a/.config/atuin/config.toml
+++ b/.config/atuin/config.toml
@@ -1,0 +1,23 @@
+# atuin — SQLite-backed shell history.
+# Single source of truth for atuin behaviour in this dotfiles repo.
+# Symlinked into ~/.config/atuin/ by bootstrap.sh.
+
+# UI: inline picker matching fzf-style muscle memory.
+# Ctrl-R opens a 20-row picker below the prompt.
+# Ctrl-X Ctrl-R (defined in .zshrc) opens full-screen.
+inline_height = 20
+style = "compact"
+
+# Default filter: Workspace = current git repo (any subdirectory).
+# Cycle modes inside the picker with Ctrl-R: Workspace -> Global -> Host -> Session -> Directory.
+filter_mode = "workspace"
+
+# Enter from the picker runs the selected command immediately.
+enter_accept = true
+
+# Match the zsh keymap.
+keymap_mode = "emacs"
+
+# Background daemon handles SQLite writes off the prompt path.
+[daemon]
+enabled = true

--- a/.zshrc
+++ b/.zshrc
@@ -183,6 +183,16 @@ if command -v zoxide >/dev/null 2>&1; then
   eval "$(zoxide init zsh)"
 fi
 
+# atuin — SQLite-backed shell history. Owns Ctrl-R (inline picker, Workspace filter).
+# --disable-up-arrow keeps Up-arrow on vanilla zsh history scrollback.
+# Custom widget on Ctrl-X Ctrl-R launches full-screen via inline-height override.
+if command -v atuin >/dev/null 2>&1; then
+  eval "$(atuin init zsh --disable-up-arrow)"
+  atuin-search-fullscreen() { ATUIN_INLINE_HEIGHT=0 atuin search -i }
+  zle -N atuin-search-fullscreen
+  bindkey '^X^R' atuin-search-fullscreen
+fi
+
 # zsh-syntax-highlighting MUST be the last sourced plugin.
 [[ -f /opt/homebrew/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh ]] && \
   source /opt/homebrew/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh

--- a/Brewfile
+++ b/Brewfile
@@ -11,6 +11,9 @@ tap  "joshmedeski/sesh"
 brew "joshmedeski/sesh/sesh"
 brew "zoxide"  # frecency-ranked dir jumping; sesh picker source
 
+# Shell history
+brew "atuin"  # SQLite-backed shell history with cwd/exit/time filters
+
 # Worktree manager
 brew "worktrunk"
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -42,6 +42,13 @@ link ".config/worktrunk" "$HOME/.config/worktrunk"
 # --- glow
 link ".config/glow"    "$HOME/.config/glow"
 
+# --- atuin: shared config; one-time import of legacy zsh history
+link ".config/atuin"   "$HOME/.config/atuin"
+if command -v atuin >/dev/null 2>&1 && [ ! -f "$HOME/.local/share/atuin/history.db" ]; then
+  echo "importing zsh history into atuin (one-time)..."
+  atuin import zsh || echo "WARN:   atuin import failed (continuing)"
+fi
+
 # --- sesh: shared config is symlinked; machine-local sessions in sesh.local.toml
 link ".config/sesh/sesh.toml" "$HOME/.config/sesh/sesh.toml"
 if [ ! -f "$HOME/.config/sesh/sesh.local.toml" ]; then

--- a/docs/shell-colors-cheatsheet.html
+++ b/docs/shell-colors-cheatsheet.html
@@ -73,7 +73,7 @@
 <header>
   <h1>Shell Colors — Getting Started &amp; Cheatsheet</h1>
   <div class="sub">
-    Solarized Dark, end-to-end &middot; eza · bat · git-delta · glow · vivid · fzf · zsh-autosuggestions · zsh-syntax-highlighting
+    Solarized Dark, end-to-end &middot; eza · bat · git-delta · glow · vivid · fzf · atuin · zsh-autosuggestions · zsh-syntax-highlighting
   </div>
 </header>
 
@@ -87,6 +87,7 @@
   <a href="#glow">glow / md</a>
   <a href="#vivid">vivid / LS_COLORS</a>
   <a href="#fzf">fzf</a>
+  <a href="#atuin">atuin</a>
   <a href="#autosuggestions">autosuggestions</a>
   <a href="#syntax">syntax-highlighting</a>
   <a href="#bootstrap">Bootstrap a new machine</a>
@@ -107,7 +108,8 @@
       <tr><td class="key"><code>vivid</code></td><td class="desc">generates LS_COLORS palettes</td></tr>
       <tr><td class="key"><code>zsh-autosuggestions</code></td><td class="desc">ghost-text completion from history</td></tr>
       <tr><td class="key"><code>zsh-syntax-highlighting</code></td><td class="desc">live command-line highlighting</td></tr>
-      <tr><td class="key"><code>fzf</code></td><td class="desc">fuzzy finder + Ctrl-R / Ctrl-T bindings</td></tr>
+      <tr><td class="key"><code>fzf</code></td><td class="desc">fuzzy finder + Ctrl-T file picker</td></tr>
+      <tr><td class="key"><code>atuin</code></td><td class="desc">SQLite-backed shell history; owns Ctrl-R</td></tr>
     </table>
   </div>
 
@@ -354,7 +356,7 @@
   <div class="card">
     <h3>Shell key bindings</h3>
     <table>
-      <tr><td class="key"><span class="k">Ctrl-R</span></td><td class="desc">fuzzy history search</td></tr>
+      <tr><td class="key"><span class="k">Ctrl-R</span></td><td class="desc warn">handed off to atuin (see below)</td></tr>
       <tr><td class="key"><span class="k">Ctrl-T</span></td><td class="desc">file picker → inserts paths at the cursor</td></tr>
       <tr><td class="key"><span class="k">Alt-C</span></td><td class="desc warn">UNBOUND — Alt is reserved for Polish diacritics</td></tr>
     </table>
@@ -384,6 +386,44 @@
       <tr><td class="key"><code>history | fzf</code></td><td class="desc">manual history search</td></tr>
     </table>
     <p class="note">FZF colors are pinned to Solarized via <code>$FZF_DEFAULT_OPTS</code> in <code>.zshrc</code>.</p>
+  </div>
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════════════════ -->
+<h2 id="atuin">atuin <span class="tool-tag">shell history</span></h2>
+
+<div class="grid">
+  <div class="card">
+    <h3>Shell key bindings</h3>
+    <table>
+      <tr><td class="key"><span class="k">Ctrl-R</span></td><td class="desc">inline picker, Workspace filter (current git repo)</td></tr>
+      <tr><td class="key"><span class="k">Ctrl-X Ctrl-R</span></td><td class="desc">full-screen picker with metadata columns</td></tr>
+      <tr><td class="key"><span class="k">↑</span> <span class="muted">(Up arrow)</span></td><td class="desc warn">UNCHANGED — vanilla zsh history scrollback</td></tr>
+    </table>
+    <p class="note">Init runs with <code>--disable-up-arrow</code> so Up keeps its zsh-native behaviour.</p>
+  </div>
+
+  <div class="card">
+    <h3>Inside the picker</h3>
+    <table>
+      <tr><td class="key"><span class="k">Ctrl-R</span></td><td class="desc">cycle filter mode: Workspace → Global → Host → Session → Directory</td></tr>
+      <tr><td class="key"><span class="k">Ctrl-S</span></td><td class="desc">cycle search mode: Fuzzy → Prefix → Substring</td></tr>
+      <tr><td class="key"><span class="k">Tab</span></td><td class="desc">toggle inspect view</td></tr>
+      <tr><td class="key"><span class="k">Enter</span></td><td class="desc">run selected command immediately (<code>enter_accept = true</code>)</td></tr>
+      <tr><td class="key"><span class="k">Esc</span> / <span class="k">Ctrl-C</span></td><td class="desc">cancel</td></tr>
+    </table>
+  </div>
+
+  <div class="card">
+    <h3>Setup notes</h3>
+    <table>
+      <tr><td class="key"><code>filter_mode = "workspace"</code></td><td class="desc">default scope = current git repo</td></tr>
+      <tr><td class="key"><code>inline_height = 20</code></td><td class="desc">picker rows when inline</td></tr>
+      <tr><td class="key"><code>[daemon] enabled = true</code></td><td class="desc">async SQLite writes off the prompt path</td></tr>
+      <tr><td class="key"><code>atuin import zsh</code></td><td class="desc">one-shot legacy import at bootstrap; only Global filter sees those rows</td></tr>
+      <tr><td class="key"><code>atuin stats</code></td><td class="desc">most-used commands, time spent</td></tr>
+    </table>
+    <p class="note">Config lives in <code>.config/atuin/config.toml</code>, symlinked by <code>bootstrap.sh</code>.</p>
   </div>
 </div>
 
@@ -462,11 +502,13 @@
   <li><code>zsh-autosuggestions.zsh</code></li>
   <li>fzf <code>completion.zsh</code> + <code>key-bindings.zsh</code></li>
   <li><code>bindkey -r '^[c'</code> &mdash; remove fzf's Alt-C binding (Polish diacritics)</li>
+  <li><code>zoxide init</code></li>
+  <li><code>atuin init zsh --disable-up-arrow</code> + Ctrl-X Ctrl-R widget</li>
   <li><code>zsh-syntax-highlighting.zsh</code> &mdash; <strong>must be last</strong></li>
 </ol>
 
 <footer>
-  Built from <code>~/.zshrc</code>, <code>Brewfile</code>, and project CLAUDE.md on 2026-04-28.
+  Built from <code>~/.zshrc</code>, <code>Brewfile</code>, and project CLAUDE.md on 2026-04-29.
   Refresh after meaningful color-tooling changes.
 </footer>
 

--- a/scripts/test-atuin-init.sh
+++ b/scripts/test-atuin-init.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Smoke test for atuin's zsh init wiring.
+# Asserts that .zshrc registers the custom Ctrl-X Ctrl-R widget that
+# launches atuin in full-screen mode (the only piece of custom logic
+# we add — atuin's own bindings are atuin's responsibility).
+set -euo pipefail
+
+if ! command -v atuin >/dev/null 2>&1; then
+  echo "SKIP: atuin not installed (run 'brew install atuin')"
+  exit 0
+fi
+
+echo "==> Asserting Ctrl-X Ctrl-R is bound to atuin-search-fullscreen"
+out=$(zsh -i -c "bindkey '^X^R'" 2>&1)
+echo "$out"
+if printf '%s' "$out" | grep -q atuin-search-fullscreen; then
+  echo
+  echo "OK"
+else
+  echo
+  echo "FAIL: Ctrl-X Ctrl-R is not bound to atuin-search-fullscreen"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Adds atuin (SQLite-backed shell history) as the owner of Ctrl-R; fzf keeps Ctrl-T and completions.
- Single-machine, no sync. Inline picker (`inline_height = 20`), Workspace filter default, Up-arrow stays vanilla (`--disable-up-arrow`).
- New chord: `Ctrl-X Ctrl-R` launches a full-screen picker with metadata columns.
- One-time `atuin import zsh` runs at bootstrap (idempotent, gated on `~/.local/share/atuin/history.db` absence).

## Files changed
- `Brewfile` — adds `atuin`
- `.config/atuin/config.toml` — new, single source of truth for behaviour
- `.zshrc` — atuin init + Ctrl-X Ctrl-R widget (placed after zoxide, before zsh-syntax-highlighting)
- `bootstrap.sh` — symlink + one-time import
- `scripts/test-atuin-init.sh` — smoke test for widget registration
- `docs/shell-colors-cheatsheet.html` — new atuin section, updated plugin order, refreshed date

## Test plan
- [x] \`brew bundle check\` reports atuin satisfied
- [x] \`readlink ~/.config/atuin\` resolves into the repo
- [x] \`atuin doctor\` parses the config without errors
- [x] \`scripts/test-atuin-init.sh\` passes (asserts \`bindkey '^X^R'\` → atuin-search-fullscreen)
- [x] Existing smoke tests still green: \`test-helpers.sh\` (30/0), \`test-prompt-context.zsh\` (10/0), \`test-tmux-window-label.zsh\` (11/0)
- [x] Interactive: Ctrl-R opens inline picker, Ctrl-X Ctrl-R opens full-screen, Up stays vanilla