### PR TITLE
nvim: ignore .claude/worktrees globally

### DIFF
--- a/.config/nvim/lua/config/options.lua
+++ b/.config/nvim/lua/config/options.lua
@@ -45,3 +45,8 @@ opt.undofile = true
 -- Color
 opt.termguicolors = true
 opt.background = "dark"
+
+-- Never descend into worktree directories from built-in completion (`:e <Tab>`,
+-- `:find`, netrw, wildmenu). Snacks pickers are handled separately in
+-- lua/plugins/snacks.lua.
+vim.opt.wildignore:append({ "*/.claude/worktrees/*" })

--- a/.config/nvim/lua/plugins/snacks.lua
+++ b/.config/nvim/lua/plugins/snacks.lua
@@ -7,6 +7,16 @@ return {
           explorer = {
             hidden = true,
             ignored = true,
+            exclude = { ".claude/worktrees" },
+          },
+          files = { exclude = { ".claude/worktrees" } },
+          grep = { exclude = { ".claude/worktrees" } },
+          recent = {
+            filter = {
+              filter = function(item)
+                return not (item.file and item.file:find("/%.claude/worktrees/"))
+              end,
+            },
           },
         },
       },


### PR DESCRIPTION
## Summary
- `wildignore` skips `*/.claude/worktrees/*` for built-in completion (`:e <Tab>`, `:find`, netrw, wildmenu)
- snacks `files`/`grep`/`explorer` use `exclude = { ".claude/worktrees" }` (translated to `fd -E` / `rg -g '!…'` / Lua-pattern containment match)
- snacks `recent` filters oldfiles via a Lua-pattern callback on `item.file` (works cross-project, oldfiles are absolute paths)

Closes the gap where running pickers, grep, the explorer, or the recent-files list inside a project with `.claude/worktrees/` would surface duplicate hits from worktree checkouts. Aligns nvim with the existing dotfiles `CLAUDE.md` rule that other tools already honor.

## Test plan
- [ ] `:e .claude/worktrees/<Tab>` — wildmenu does not descend
- [ ] `<leader>ff` — worktree copies absent for files known to exist in a worktree
- [ ] `<leader>/` — grep returns no hits from `.claude/worktrees/...`
- [ ] `<leader>e` (snacks explorer) — `.claude/worktrees/` is not listed
- [ ] `<leader>fr` — recently-opened worktree files do not appear