### PR TITLE
Add fzf-tab for global Tab completion picker

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -188,6 +188,24 @@ if command -v zoxide >/dev/null 2>&1; then
   eval "$(zoxide init zsh)"
 fi
 
+# fzf-tab — replace zsh's default completion menu with fzf.
+# Must be sourced AFTER fzf shell integration (loses ^I race otherwise) and
+# BEFORE zsh-autosuggestions / zsh-syntax-highlighting (both wrap widgets).
+[[ -f /opt/homebrew/opt/fzf-tab/share/fzf-tab/fzf-tab.zsh ]] && \
+  source /opt/homebrew/opt/fzf-tab/share/fzf-tab/fzf-tab.zsh
+# OMZ sets `menu select`; fzf-tab needs this disabled to capture completions.
+zstyle ':completion:*' menu no
+# Group completions by tag with a labeled header.
+zstyle ':completion:*:descriptions' format '[%d]'
+# Filename colors in the picker — inherit vivid's Solarized palette via LS_COLORS.
+zstyle ':completion:*' list-colors ${(s.:.)LS_COLORS}
+# Inherit FZF_DEFAULT_OPTS so the picker matches Ctrl-R / Ctrl-T styling.
+zstyle ':fzf-tab:*' use-fzf-default-opts yes
+# Switch between completion groups.
+zstyle ':fzf-tab:*' switch-group '<' '>'
+# Preview directory contents when completing `cd`.
+zstyle ':fzf-tab:complete:cd:*' fzf-preview 'eza -1 --color=always --icons $realpath'
+
 [[ -f /opt/homebrew/share/zsh-autosuggestions/zsh-autosuggestions.zsh ]] && \
   source /opt/homebrew/share/zsh-autosuggestions/zsh-autosuggestions.zsh
 

--- a/.zshrc
+++ b/.zshrc
@@ -159,9 +159,14 @@ if command -v nvim >/dev/null 2>&1; then
   alias vimdiff='vim -d'
 fi
 
-# ─── Plugins (order matters; syntax-highlighting MUST be last) ─
-[[ -f /opt/homebrew/share/zsh-autosuggestions/zsh-autosuggestions.zsh ]] && \
-  source /opt/homebrew/share/zsh-autosuggestions/zsh-autosuggestions.zsh
+# ─── Plugins (order matters) ─────────────────────────────────────
+# Required order:
+#   fzf shell integration  → binds ^I; must come first so subsequent
+#                            plugins that wrap completion can chain to it
+#   Alt-C unbind           → adjacent to fzf since it removes a binding fzf set
+#   zoxide                 → independent; doesn't bind ^I or wrap widgets
+#   zsh-autosuggestions    → wraps widgets; must be after fzf integration
+#   zsh-syntax-highlighting → MUST be last (wraps every other widget)
 
 # fzf shell integration (Ctrl-R history, Ctrl-T file picker).
 [[ -f /opt/homebrew/opt/fzf/shell/completion.zsh ]] && \
@@ -182,6 +187,9 @@ if command -v zoxide >/dev/null 2>&1; then
   export _ZO_EXCLUDE_DIRS="$HOME:$HOME/Downloads/*:$HOME/.config/*:$HOME/Library/*"
   eval "$(zoxide init zsh)"
 fi
+
+[[ -f /opt/homebrew/share/zsh-autosuggestions/zsh-autosuggestions.zsh ]] && \
+  source /opt/homebrew/share/zsh-autosuggestions/zsh-autosuggestions.zsh
 
 # zsh-syntax-highlighting MUST be the last sourced plugin.
 [[ -f /opt/homebrew/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh ]] && \

--- a/Brewfile
+++ b/Brewfile
@@ -29,3 +29,4 @@ brew "glow"                     # render markdown to ANSI
 brew "vivid"                    # generates LS_COLORS palettes
 brew "zsh-syntax-highlighting"  # live command-line highlighting
 brew "zsh-autosuggestions"      # ghost-text completion from history
+brew "fzf-tab"                  # fzf-driven Tab completion menu

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,15 +74,18 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
 - **Shell colors are Solarized Dark, end-to-end.** Tools: `eza` (ls),
   `bat` (cat + `MANPAGER`), `git-delta` (git pager), `glow` (`md` markdown
   renderer), `vivid` (`LS_COLORS`), `zsh-syntax-highlighting`,
-  `zsh-autosuggestions`. Palette pins:
+  `zsh-autosuggestions`, `fzf-tab` (Tab completion picker). Palette pins:
   `vivid generate solarized-dark`, `bat --theme="Solarized (dark)"`,
   `delta.syntax-theme = "Solarized (dark)"`,
   `md` alias passes `--style .config/glow/glamour.json` (chroma
   `solarized-dark` for fenced code blocks). Don't swap themes or
   introduce alternatives (`exa`, `lsd`, `diff-so-fancy`, `mdcat`, etc.)
-  without asking. Plugin source order in `.zshrc` is fixed: zsh-autosuggestions →
-  fzf → `bindkey -r '^[c'` (Alt-C unbind) → zsh-syntax-highlighting (must
-  be last). The first-time `git config` recipe wiring delta as git's pager
+  without asking. Plugin source order in `.zshrc` is fixed: fzf →
+  `bindkey -r '^[c'` (Alt-C unbind) → zoxide → fzf-tab →
+  zsh-autosuggestions → zsh-syntax-highlighting (must be last).
+  fzf-tab needs fzf's `^I` binding already in place and must be sourced
+  before any plugin that wraps widgets. The first-time `git config`
+  recipe wiring delta as git's pager
   lives in **First-time setup on a new machine** below.
 - **Interactive `less` is a `bat` wrapper** (defined in `.zshrc` next to the
   `cat` alias). Files get bat's full decoration; piped input uses `--plain` so

--- a/docs/shell-colors-cheatsheet.html
+++ b/docs/shell-colors-cheatsheet.html
@@ -73,7 +73,7 @@
 <header>
   <h1>Shell Colors — Getting Started &amp; Cheatsheet</h1>
   <div class="sub">
-    Solarized Dark, end-to-end &middot; eza · bat · git-delta · glow · vivid · fzf · zsh-autosuggestions · zsh-syntax-highlighting
+    Solarized Dark, end-to-end &middot; eza · bat · git-delta · glow · vivid · fzf · fzf-tab · zsh-autosuggestions · zsh-syntax-highlighting
   </div>
 </header>
 
@@ -87,6 +87,7 @@
   <a href="#glow">glow / md</a>
   <a href="#vivid">vivid / LS_COLORS</a>
   <a href="#fzf">fzf</a>
+  <a href="#fzf-tab">fzf-tab</a>
   <a href="#autosuggestions">autosuggestions</a>
   <a href="#syntax">syntax-highlighting</a>
   <a href="#bootstrap">Bootstrap a new machine</a>
@@ -108,6 +109,7 @@
       <tr><td class="key"><code>zsh-autosuggestions</code></td><td class="desc">ghost-text completion from history</td></tr>
       <tr><td class="key"><code>zsh-syntax-highlighting</code></td><td class="desc">live command-line highlighting</td></tr>
       <tr><td class="key"><code>fzf</code></td><td class="desc">fuzzy finder + Ctrl-R / Ctrl-T bindings</td></tr>
+      <tr><td class="key"><code>fzf-tab</code></td><td class="desc">replaces zsh's Tab menu with an fzf picker</td></tr>
     </table>
   </div>
 
@@ -115,7 +117,7 @@
     <h3>House rules (per CLAUDE.md)</h3>
     <ul class="compact">
       <li><strong>Solarized Dark, end-to-end.</strong> Don't swap themes or introduce alternatives (<code>exa</code>, <code>lsd</code>, <code>diff-so-fancy</code>, …) without asking.</li>
-      <li><strong>Plugin source order in <code>.zshrc</code> is fixed:</strong> zsh-autosuggestions → fzf → <code>bindkey -r '^[c'</code> (Alt-C unbind) → zsh-syntax-highlighting (must be last).</li>
+      <li><strong>Plugin source order in <code>.zshrc</code> is fixed:</strong> fzf → <code>bindkey -r '^[c'</code> (Alt-C unbind) → zoxide → fzf-tab → zsh-autosuggestions → zsh-syntax-highlighting (must be last).</li>
       <li><strong>Palette pins:</strong> <code>vivid generate solarized-dark</code>, <code>bat --theme="Solarized (dark)"</code>, <code>delta.syntax-theme = "Solarized (dark)"</code>.</li>
       <li><strong>JetBrainsMono Nerd Font.</strong> Required for <code>eza --icons</code>.</li>
     </ul>
@@ -388,6 +390,48 @@
 </div>
 
 <!-- ═══════════════════════════════════════════════════════════════════════ -->
+<h2 id="fzf-tab">fzf-tab <span class="tool-tag">Tab completion picker</span></h2>
+
+<div class="grid">
+  <div class="card">
+    <h3>What it does</h3>
+    <p>Replaces zsh's default <kbd>Tab</kbd> completion menu with an fzf picker — fuzzy filter as you type, arrow-key navigation, and per-command previews. Works for <strong>every</strong> command (cd, git, kill, ssh, brew, &hellip;).</p>
+    <p class="note">For <code>z</code> with zoxide-ranked results, use <code>zi &lt;query&gt;</code> — fzf-tab won't show zoxide entries because <code>zoxide init zsh</code> doesn't register a <code>_z</code> completion function.</p>
+  </div>
+
+  <div class="card">
+    <h3>Key bindings (inside the picker)</h3>
+    <table>
+      <tr><td class="key"><span class="k">Tab</span></td><td class="desc">accept selected completion</td></tr>
+      <tr><td class="key"><span class="k">&lt;</span> / <span class="k">&gt;</span></td><td class="desc">switch between completion groups (e.g. <code>[heads]</code> ↔ <code>[tags]</code> for git checkout)</td></tr>
+      <tr><td class="key"><span class="k">Ctrl-Space</span></td><td class="desc">multi-select</td></tr>
+      <tr><td class="key"><span class="k">/</span></td><td class="desc">continuous completion (useful for deep paths)</td></tr>
+      <tr><td class="key"><span class="k">Esc</span></td><td class="desc">cancel</td></tr>
+    </table>
+  </div>
+
+  <div class="card">
+    <h3>Examples</h3>
+    <table>
+      <tr><td class="key"><code>cd &lt;Tab&gt;</code></td><td class="desc">directory picker with eza preview pane</td></tr>
+      <tr><td class="key"><code>git checkout &lt;Tab&gt;</code></td><td class="desc">branches + tags grouped with headers</td></tr>
+      <tr><td class="key"><code>kill &lt;Tab&gt;</code></td><td class="desc">process picker</td></tr>
+      <tr><td class="key"><code>brew install &lt;Tab&gt;</code></td><td class="desc">formula picker</td></tr>
+    </table>
+    <p class="note">Picker colors inherit <code>$FZF_DEFAULT_OPTS</code> via <code>use-fzf-default-opts yes</code>.</p>
+  </div>
+
+  <div class="card">
+    <h3>Commands</h3>
+    <table>
+      <tr><td class="key"><code>disable-fzf-tab</code></td><td class="desc">fall back to compsys for this shell</td></tr>
+      <tr><td class="key"><code>enable-fzf-tab</code></td><td class="desc">re-enable</td></tr>
+      <tr><td class="key"><code>toggle-fzf-tab</code></td><td class="desc">flip between the two</td></tr>
+    </table>
+  </div>
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════════════════ -->
 <h2 id="autosuggestions">zsh-autosuggestions <span class="tool-tag">ghost text from history</span></h2>
 
 <div class="grid">
@@ -466,7 +510,7 @@
 </ol>
 
 <footer>
-  Built from <code>~/.zshrc</code>, <code>Brewfile</code>, and project CLAUDE.md on 2026-04-28.
+  Built from <code>~/.zshrc</code>, <code>Brewfile</code>, and project CLAUDE.md on 2026-04-29.
   Refresh after meaningful color-tooling changes.
 </footer>
 


### PR DESCRIPTION
## Summary

- Replace zsh's default Tab completion menu with [fzf-tab](https://github.com/Aloxaf/fzf-tab), so Tab opens a fuzzy-filterable picker (with previews and grouping) for **all** commands — `cd`, `git`, `kill`, `ssh`, `brew`, etc.
- Install via Homebrew formula (one Brewfile line, one source line, no `bootstrap.sh` work). Solarized palette inherits from `FZF_DEFAULT_OPTS`; `cd` previews use `eza`.
- Reordered the curated plugin block in `.zshrc` so fzf shell integration loads first (binds `^I`), fzf-tab loads after fzf and before the widget-wrapping plugins, and `zsh-syntax-highlighting` stays last. CLAUDE.md and the shell-colors cheatsheet are updated to match.

## Test plan

- [x] `scripts/test-helpers.sh` — 30/30 pass
- [x] `scripts/test-prompt-context.zsh` — 10/10 pass
- [x] `scripts/test-tmux-window-label.zsh` — 11/11 pass
- [x] `brew bundle check --file=Brewfile --verbose` — satisfied
- [x] Fresh `zsh -ic` shows `fzf-tab-complete` bound to `^I`
- [x] Manual: `cd <Tab>` opens fzf picker with eza preview pane
- [x] Manual: `git checkout <Tab>` shows grouped `[branches]` / `[tags]` headers
- [x] Manual: `Ctrl-R` history and `Ctrl-T` file picker still work
- [x] Manual: `zsh-autosuggestions` still ghost-completes; `zsh-syntax-highlighting` still colors invalid commands red