### PR TITLE
tmux: keyboard-driven URL picker (<prefix> u)

### DIFF
--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -71,6 +71,15 @@ set -g @plugin 'tmux-plugins/tmux-sensible'
 set -g @plugin 'tmux-plugins/tmux-resurrect'
 set -g @plugin 'tmux-plugins/tmux-continuum'
 set -g @continuum-restore 'on'
+
+# tmux-fzf-url — keyboard-driven URL opener bound to <prefix> u.
+# Scope: visible pane + 2000 lines of scrollback (URL printed a few screens
+# ago is reachable; the full 50k history-limit is not regexed every invocation).
+# Popup geometry matches the sesh picker for visual consistency.
+set -g @plugin 'wfxr/tmux-fzf-url'
+set -g @fzf-url-history-limit '2000'
+set -g @fzf-url-fzf-options '-w 70% -h 70% --multi -0 --no-preview --border'
+
 run '~/.config/tmux/plugins/tpm/tpm'
 
 # ─── Status line (Solarized base16 + powerline) ──

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Personal config for Ghostty + zsh + tmux + vim, all in Solarized + JetBrainsMono
 
 - URLs in tmux panes open with **Shift+Cmd+click**, not Cmd+click.
 - Why: with `set -g mouse on`, Ghostty defers all mouse interactions (incl. URL hover/click detection) to tmux. Ghostty's default `mouse-shift-capture = false` makes Shift the bypass modifier — Shift releases the click from tmux and Cmd reaches Ghostty's URL handler.
+- Or, keyboard-only: `<prefix> u` opens an fzf picker of URLs from the current pane (visible + last 2000 lines), Enter opens in the default browser. Provided by [`wfxr/tmux-fzf-url`](https://github.com/wfxr/tmux-fzf-url).
 
 ## Future work
 

--- a/docs/tmux-cheatsheet.html
+++ b/docs/tmux-cheatsheet.html
@@ -106,10 +106,10 @@
       <tr><td class="key">Pane nav</td><td class="desc"><span class="k prefix">C-a</span> + <span class="k">h/j/k/l</span></td></tr>
       <tr><td class="key">Splits</td><td class="desc"><span class="k prefix">C-a</span> + <span class="k">|</span> / <span class="k">-</span> (cwd inherited)</td></tr>
       <tr><td class="key">Indexing</td><td class="desc">windows + panes start at <code>1</code>, auto-renumber</td></tr>
-      <tr><td class="key">Mouse</td><td class="desc">on (URLs need <span class="k">⇧⌘ click</span>)</td></tr>
+      <tr><td class="key">Mouse</td><td class="desc">on (URLs: <span class="k">⇧⌘ click</span> or <span class="k prefix">C-a</span> <span class="k">u</span> for fzf picker)</td></tr>
       <tr><td class="key">History</td><td class="desc">50,000 lines</td></tr>
       <tr><td class="key">Bells</td><td class="desc">silenced (<code>bell-action/visual-bell/monitor-bell off</code>)</td></tr>
-      <tr><td class="key">TPM plugins</td><td class="desc">tpm, tmux-sensible, tmux-resurrect, tmux-continuum</td></tr>
+      <tr><td class="key">TPM plugins</td><td class="desc">tpm, tmux-sensible, tmux-resurrect, tmux-continuum, tmux-fzf-url</td></tr>
     </table>
   </div>
 
@@ -124,6 +124,7 @@
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">r</span></td><td class="desc">reload <code>~/.config/tmux/tmux.conf</code></td></tr>
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">t</span></td><td class="desc">sesh picker popup (configured / tmux / zoxide / tmuxinator)</td></tr>
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">T</span></td><td class="desc">clock-mode <span class="muted">(swapped from default <code>t</code>)</span></td></tr>
+      <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">u</span></td><td class="desc">URL picker (fzf, current pane + 2000 lines scrollback) — opens in default browser</td></tr>
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">?</span></td><td class="desc">list all keybindings</td></tr>
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">:</span></td><td class="desc">command prompt</td></tr>
     </table>


### PR DESCRIPTION
## Summary

- Add `wfxr/tmux-fzf-url` plugin, bound to `<prefix> u` (default).
- fzf popup lists URLs from the current pane (visible + last 2000 lines of scrollback), Enter opens in the default macOS browser.
- Existing Shift+Cmd+click path still works — this adds a keyboard alternative; the README "Quirks" note now documents both.

## Why

URLs in tmux panes required Shift+Cmd+click (Ghostty's URL handler is reachable only via the Shift bypass modifier when `mouse on` lets tmux capture clicks). That forces a hand-off to the trackpad for a routine action (CI links, stack traces, `gh` output, etc.). Keyboard-only path was overdue.

## Config

```tmux
set -g @plugin 'wfxr/tmux-fzf-url'
set -g @fzf-url-history-limit '2000'
set -g @fzf-url-fzf-options '-w 70% -h 70% --multi -0 --no-preview --border'
```

`-w 70% -h 70%` matches the sesh picker; `--multi` lets you Tab-mark several URLs and open all on Enter; `-0` exits silently with no matches.

## Test plan

- [ ] In a fresh tmux session: `<prefix> r` then `<prefix> I` to install the plugin
- [ ] `echo https://example.com https://github.com` then `<prefix> u` — popup lists both, Enter opens in default browser
- [ ] Tab-mark both, Enter — both open
- [ ] Empty pane: `<prefix> u` exits silently (no dangling popup)
- [ ] Scroll URLs off-screen with `seq 1 200` — `<prefix> u` still finds them
- [ ] Shift+Cmd+click on a URL still opens it (mouse path preserved)
- [ ] Cheatsheet (`open docs/tmux-cheatsheet.html`) shows the new binding row and updated TPM list