### PR TITLE
tmux(fzf-url): --tac so newest URL lands at the cursor

### DIFF
--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -76,9 +76,11 @@ set -g @continuum-restore 'on'
 # Scope: visible pane + 2000 lines of scrollback (URL printed a few screens
 # ago is reachable; the full 50k history-limit is not regexed every invocation).
 # Popup geometry matches the sesh picker for visual consistency.
+# --tac reverses fzf input so the most recently printed URL lands at the
+# bottom near the cursor (plugin emits oldest→newest in pane order).
 set -g @plugin 'wfxr/tmux-fzf-url'
 set -g @fzf-url-history-limit '2000'
-set -g @fzf-url-fzf-options '-w 70% -h 70% --multi -0 --no-preview --border'
+set -g @fzf-url-fzf-options '-w 70% -h 70% --multi -0 --no-preview --border --tac'
 
 run '~/.config/tmux/plugins/tpm/tpm'
 


### PR DESCRIPTION
## Summary

One-line tweak to `@fzf-url-fzf-options`: append `--tac`.

## Why

tmux-fzf-url emits URLs in pane order (oldest → newest). fzf's default layout puts the first stdin item at the bottom of the list, right next to the cursor. Without `--tac`, that's the **oldest** URL — the cursor starts on whatever URL is furthest back in scrollback, and you have to scroll up through the list to reach the one that just landed.

`--tac` reverses fzf's input, so newest becomes "first in stdin" → bottom of the list → where the cursor sits. One Enter on the most recently printed URL.

## Diff

```diff
-set -g @fzf-url-fzf-options '-w 70% -h 70% --multi -0 --no-preview --border'
+set -g @fzf-url-fzf-options '-w 70% -h 70% --multi -0 --no-preview --border --tac'
```

Comment block extended with one sentence explaining `--tac`'s purpose.

## Test plan

- [ ] After merge: `git pull` in dotfiles, then `<prefix> r` in running tmux
- [ ] In a pane: `echo https://first.example.com; echo https://second.example.com; echo https://third.example.com`
- [ ] Press `<prefix> u` — fzf list shows third at the bottom (cursor lands here), first at the top
- [ ] Enter immediately opens `third.example.com` (the most recently printed URL)