### PR TITLE
docs: catch up CLAUDE.md, README, and nvim cheatsheet drift

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,17 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
 - **tmux prefix is `C-a`** (screen-style; `C-Space` conflicts with macOS
   input-source switching). Pane nav: `<prefix> h/j/k/l` (Alt is reserved for
   Polish diacritics — never use `bind -n M-*`). Splits: `|` and `-`.
+- **TPM is the tmux plugin manager.** Loaded plugins: `tmux-sensible`,
+  `tmux-resurrect`, `tmux-continuum` (`@continuum-restore 'on'` —
+  auto-restores the last saved env on tmux start), `tmux-fzf-url`. Don't
+  remove TPM ("we hand-roll everything") without an explicit ask — the
+  status bar is hand-rolled, behavior plugins aren't.
+- **tmux URL picker is `<prefix> u` via `tmux-fzf-url`** (`wfxr/tmux-fzf-url`,
+  loaded by TPM). Scope is visible pane + 2000-line scrollback (not the full
+  50k history). Popup geometry matches the sesh picker (`-w 70% -h 70%`).
+  `--tac` is intentional so the newest URL lands at the cursor — don't drop
+  it. Don't replace with a custom shell script; the plugin already does
+  regex extraction efficiently.
 - **Sesh config is split: shared + machine-local.** The repo tracks
   `.config/sesh/sesh.toml` (symlinked into `~/.config/sesh/sesh.toml`)
   with a `Home 🏠` session for `~` and a top-level

--- a/README.md
+++ b/README.md
@@ -4,25 +4,30 @@ Personal config for Ghostty + zsh + tmux + vim, all in Solarized + JetBrainsMono
 
 ## What's where
 
-| Tool    | Source path                          | Target              |
-| ------- | ------------------------------------ | ------------------- |
-| Ghostty | `.config/ghostty/`                   | `~/.config/ghostty` |
-| tmux    | `.config/tmux/`                      | `~/.config/tmux`    |
-| vim     | `.vimrc`, `.vim/colors/`             | `~/.vimrc`, `~/.vim/colors` |
-| zsh     | (still in `~/.zshrc`, not yet here)  | —                   |
+| Tool      | Source path                          | Target              |
+| --------- | ------------------------------------ | ------------------- |
+| Ghostty   | `.config/ghostty/`                   | `~/.config/ghostty` |
+| tmux      | `.config/tmux/`                      | `~/.config/tmux`    |
+| nvim      | `.config/nvim/`                      | `~/.config/nvim`    |
+| vim       | `.vimrc`, `.vim/colors/`             | `~/.vimrc`, `~/.vim/colors` |
+| zsh       | `.zshrc`, `.p10k.zsh`                | `~/.zshrc`, `~/.p10k.zsh` |
+| sesh      | `.config/sesh/sesh.toml`             | `~/.config/sesh/sesh.toml` |
+| worktrunk | `.config/worktrunk/config.toml`      | `~/.config/worktrunk/config.toml` |
+| glow      | `.config/glow/glamour.json`          | `~/.config/glow/glamour.json` |
 
 ## Keymaps quick-ref
 
 - tmux prefix: `C-a`
-- session switcher: `<prefix> T`
+- session switcher (sesh picker): `<prefix> t`  (clock-mode moved to `<prefix> T`)
 - pane nav: `<prefix> h/j/k/l` (Alt is reserved for Polish diacritics)
 - splits: `<prefix> |` (right) / `<prefix> -` (down)
+- URL picker (current pane): `<prefix> u`
 - reload tmux: `<prefix> r`
 - TPM plugin install: `<prefix> I` (capital I)
 
 ## Status bar (right side)
 
-`<project> · <git/worktree> · <clock>`
+`<project> · <git/worktree>`
 
 - Project chip (violet) is the top-level dir under `$PROJECTS_HOME`.
 - Git chip is **cyan** in main checkout, **yellow** in a worktree.
@@ -36,7 +41,5 @@ Personal config for Ghostty + zsh + tmux + vim, all in Solarized + JetBrainsMono
 
 ## Future work
 
-- Move `~/.zshrc` and `~/.p10k.zsh` into the repo
 - Lift API tokens out of `~/.zshrc` into a gitignored `~/.secrets`
 - `EnterWorktree` ↔ tmux integration (auto-spawn window per worktree)
-- If `worktrunk` is not in homebrew-core: install via `cargo install worktrunk`

--- a/docs/nvim-cheatsheet.html
+++ b/docs/nvim-cheatsheet.html
@@ -276,6 +276,10 @@
       <li><strong>Solarized + JetBrainsMono Nerd Font</strong> only.</li>
       <li><strong>Lockfiles committed:</strong> <code>lazy-lock.json</code>, <code>mason-lock.json</code>.</li>
       <li>Mason: <code>:MasonLock</code> snapshots, <code>:MasonLockUpdate</code> upgrades + snapshots.</li>
+      <li><strong><code>.claude/worktrees/</code> is hidden from pickers and built-in completion.</strong>
+        Snacks excludes it from <code>files</code>, <code>grep</code>, <code>explorer</code>, and <code>recent</code> (see <code>lua/plugins/snacks.lua</code>);
+        <code>wildignore</code> in <code>lua/config/options.lua</code> drops it from <code>:e</code>/glob expansion.
+        If <span class="k leader">␣</span><span class="k">␣</span> or <span class="k leader">␣</span><span class="k">/</span> can't find a file under there, that's why.</li>
     </ul>
   </div>
 
@@ -761,7 +765,7 @@
 </ul>
 
 <footer>
-  Built from <code>~/.config/nvim/</code> on 2026-04-28. Refresh after meaningful config changes.
+  Built from <code>~/.config/nvim/</code> on 2026-04-29. Refresh after meaningful config changes.
   <br>
   Cheat-skill: when in doubt, press <span class="k leader">␣</span> and read which-key.
 </footer>


### PR DESCRIPTION
## Summary

- **CLAUDE.md** — Added two "don't drift from these" conventions that had been missed: TPM-managed tmux plugins (`tmux-sensible`/`-resurrect`/`-continuum`/`-fzf-url`, with `@continuum-restore 'on'`) and the `<prefix> u` URL picker (deliberate `--tac`, 2000-line scope, popup geometry matching sesh).
- **README.md** — Caught up several stale items: zsh marked "not yet here" (it is), `<prefix> T`/`t` swap was backwards, `<clock>` listed in status-bar string but not actually rendered, missing nvim/sesh/worktrunk/glow rows in the source/target table, two completed entries lingering in "Future work".
- **docs/nvim-cheatsheet.html** — Added a house-rules bullet noting that `.claude/worktrees/` is excluded from Snacks pickers (files/grep/explorer/recent) and `wildignore`. Bumped footer date.

tmux and shell-colors cheatsheets were already current — no changes needed.

## Test plan

- [ ] Open the rendered `docs/nvim-cheatsheet.html` locally; confirm the new house-rules bullet renders cleanly and the footer date reads 2026-04-29.
- [ ] Skim README.md for the table widths / keymap list / status-bar string — visually consistent.
- [ ] Re-read CLAUDE.md tmux convention block top-to-bottom; verify the new bullets fit the existing voice and don't contradict the sesh/fzf-tab rules below them.