### PR TITLE
Add mdp alias for paged markdown rendering

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -152,6 +152,7 @@ if command -v eza >/dev/null 2>&1; then
 fi
 if command -v glow >/dev/null 2>&1; then
   alias md='glow --style $HOME/.config/glow/glamour.json'
+  alias mdp='md -p'
 fi
 if command -v nvim >/dev/null 2>&1; then
   alias vim='nvim'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,8 +106,11 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
   git/delta and other tools manage their own pager.
 - **`md` renders markdown via `glow`** with a pinned Solarized JSON style at
   `.config/glow/glamour.json`. `bat`/`less`/`cat` still show source with syntax
-  highlighting; `md` shows rendered output. The alias passes `--style` directly
-  rather than relying on `glow.yml` because glow on macOS reads its yml from
+  highlighting; `md` shows rendered output. **`mdp` is `md -p`** — same render,
+  through a pager (real `less`, not the shell `less` wrapper, since glow spawns
+  the pager as a subprocess and shell functions don't apply across that
+  boundary). The alias passes `--style` directly rather than relying on
+  `glow.yml` because glow on macOS reads its yml from
   `~/Library/Preferences/glow/`, not `~/.config/glow/`. Don't swap to `mdcat`,
   `frogmouth`, or another renderer without an explicit ask. (`mdcat` was
   considered and ruled out: archived upstream as of 2025-01-10.)

--- a/docs/shell-colors-cheatsheet.html
+++ b/docs/shell-colors-cheatsheet.html
@@ -129,6 +129,7 @@
       <tr><td class="key"><code>cat</code></td><td class="desc">→ <code>bat --paging=never</code></td></tr>
       <tr><td class="key"><code>less</code></td><td class="desc">function → <code>bat</code> wrapper (file = full decoration; pipe = <code>--plain</code>)</td></tr>
       <tr><td class="key"><code>md</code></td><td class="desc">→ <code>glow --style ~/.config/glow/glamour.json</code></td></tr>
+      <tr><td class="key"><code>mdp</code></td><td class="desc">→ <code>md -p</code> (paged via real <code>less</code>)</td></tr>
       <tr><td class="key"><code>ls</code></td><td class="desc">→ <code>eza --group-directories-first --icons</code></td></tr>
       <tr><td class="key"><code>ll</code></td><td class="desc">→ <code>eza -lh --git --icons --group-directories-first</code></td></tr>
       <tr><td class="key"><code>la</code></td><td class="desc">→ <code>ll -a</code></td></tr>
@@ -317,6 +318,7 @@
     <table>
       <tr><td class="key"><code>md README.md</code></td><td class="desc">render to terminal</td></tr>
       <tr><td class="key"><code>md -p README.md</code></td><td class="desc">paged (uses <code>$PAGER</code> / less)</td></tr>
+      <tr><td class="key"><code>mdp README.md</code></td><td class="desc">same as <code>md -p</code> (dedicated alias)</td></tr>
       <tr><td class="key"><code>md -w 100 README.md</code></td><td class="desc">force width 100</td></tr>
       <tr><td class="key"><code>cat foo.md | md -</code></td><td class="desc">render from stdin</td></tr>
       <tr><td class="key"><code>command glow ...</code></td><td class="desc">bypass alias (no <code>--style</code>)</td></tr>
@@ -510,7 +512,7 @@
 </ol>
 
 <footer>
-  Built from <code>~/.zshrc</code>, <code>Brewfile</code>, and project CLAUDE.md on 2026-04-29.
+  Built from <code>~/.zshrc</code>, <code>Brewfile</code>, and project CLAUDE.md on 2026-04-30.
   Refresh after meaningful color-tooling changes.
 </footer>
 


### PR DESCRIPTION
## Summary
- New zsh alias `mdp` → `md -p`, scoped to the existing `command -v glow` guard. Chained alias means `mdp` automatically tracks any future change to `md`.
- Updates `docs/shell-colors-cheatsheet.html`: adds `mdp` to the alias summary, adds an `mdp README.md` example to the glow / md usage table, bumps footer date to 2026-04-30.
- Extends the `md` paragraph in `CLAUDE.md` with one sentence on `mdp` and the subprocess-pager nuance (real `less`, not the shell `less` wrapper).

## Test plan
- [ ] In a fresh shell after merge: `alias md mdp` shows both, with `mdp` expanding to `md -p`.
- [ ] `mdp <some-md-file>` opens a pager with rendered Solarized markdown; `q` exits cleanly.
- [ ] `docs/shell-colors-cheatsheet.html` renders with the new rows in both tables and the bumped footer date.