### PR TITLE
tmux: render claude[<name>] in window title for named Claude sessions

### DIFF
--- a/.config/tmux/bin/claude-tmux-window-name
+++ b/.config/tmux/bin/claude-tmux-window-name
@@ -22,6 +22,12 @@ case $mode in
     exit 0
     ;;
   set)
+    # NULL_GLOB: when ~/.claude/sessions/ is empty (e.g. first run on a fresh
+    # machine, before Claude has written any session file), the *.json glob
+    # below would otherwise emit "no matches found" to stderr and abort the
+    # script. With NULL_GLOB the unmatched pattern expands to nothing and jq
+    # exits cleanly with empty output.
+    setopt NULL_GLOB
     local payload session_id name
     payload="$(cat)"
     session_id="$(printf '%s' "$payload" | jq -r '.session_id // empty' 2>/dev/null)"

--- a/.config/tmux/bin/claude-tmux-window-name
+++ b/.config/tmux/bin/claude-tmux-window-name
@@ -1,0 +1,21 @@
+#!/usr/bin/env zsh
+# claude-tmux-window-name {set|clear}
+#
+# Invoked by Claude Code hooks. In `set` mode, reads JSON from stdin
+# (containing `session_id`), looks up the matching ~/.claude/sessions/<pid>.json
+# entry, and sets the tmux per-pane user variable @claude_session_name to
+# the session's `name`. In `clear` mode, unsets @claude_session_name and
+# @last_cmd on the current pane.
+#
+# Spec: tmp/specs/2026-04-30-claude-session-window-name-design.md
+# Tests: scripts/test-claude-tmux-window-name.zsh
+emulate -L zsh
+set -u
+
+[[ -z ${TMUX_PANE:-} ]] && exit 0
+mode="${1:-}"
+
+case $mode in
+  set|clear) ;;
+  *) exit 0 ;;
+esac

--- a/.config/tmux/bin/claude-tmux-window-name
+++ b/.config/tmux/bin/claude-tmux-window-name
@@ -16,6 +16,13 @@ set -u
 mode="${1:-}"
 
 case $mode in
-  set|clear) ;;
+  clear)
+    tmux set -p -t "$TMUX_PANE" -u @claude_session_name 2>/dev/null
+    tmux set -p -t "$TMUX_PANE" -u @last_cmd 2>/dev/null
+    exit 0
+    ;;
+  set)
+    : # implemented in next task
+    ;;
   *) exit 0 ;;
 esac

--- a/.config/tmux/bin/claude-tmux-window-name
+++ b/.config/tmux/bin/claude-tmux-window-name
@@ -22,7 +22,18 @@ case $mode in
     exit 0
     ;;
   set)
-    : # implemented in next task
+    local payload session_id name
+    payload="$(cat)"
+    session_id="$(printf '%s' "$payload" | jq -r '.session_id // empty' 2>/dev/null)"
+    [[ -z $session_id ]] && exit 0
+
+    name="$(jq -r --arg sid "$session_id" \
+      'select(.sessionId == $sid) | .name // empty' \
+      "$HOME"/.claude/sessions/*.json 2>/dev/null | grep -m1 -v '^$' || true)"
+
+    [[ -z $name ]] && exit 0
+    tmux set -p -t "$TMUX_PANE" @claude_session_name "$name"
+    exit 0
     ;;
   *) exit 0 ;;
 esac

--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -31,14 +31,16 @@ set -g monitor-bell off
 # ─── Window naming ──────────────────────────
 # allow-rename off: ignore OSC title escapes from apps (e.g. Claude Code,
 # which sets the title to its version string).
-# automatic-rename on: tmux drives the window name from the active pane's
-# @last_cmd user variable. The variable is set by the zsh preexec hook
-# (_tmux_record_last_cmd in .zshrc) on every typed command. When @last_cmd
-# is empty (fresh pane, non-zsh shell, env-var-only input), the format
-# falls back to pane_current_command — typically `zsh` at idle.
+# automatic-rename on: tmux drives the window name with three-tier precedence:
+#   1. @claude_session_name (per-pane) → render `claude[<name>]`. Set by the
+#      claude-tmux-window-name helper invoked from Claude Code's
+#      SessionStart/Stop/SessionEnd hooks; cleared on SessionEnd.
+#   2. @last_cmd (per-pane)            → render the last typed command. Set by
+#      the zsh preexec hook (_tmux_record_last_cmd in .zshrc).
+#   3. fallback                        → pane_current_command (typically `zsh`).
 set -g allow-rename off
 set -g automatic-rename on
-set -g automatic-rename-format '#{?#{==:#{@last_cmd},},#{pane_current_command},#{@last_cmd}}'
+set -g automatic-rename-format '#{?#{!=:#{@claude_session_name},},claude[#{@claude_session_name}],#{?#{==:#{@last_cmd},},#{pane_current_command},#{@last_cmd}}}'
 
 # ─── Splits keep cwd, mirror Ghostty's bindings ──
 bind | split-window -h -c "#{pane_current_path}"

--- a/Brewfile
+++ b/Brewfile
@@ -4,6 +4,7 @@
 # Core
 brew "git"
 brew "tmux"
+brew "jq"   # JSON parsing in shell helpers
 
 # Session switcher (sesh + fzf, sesh comes from a tap)
 brew "fzf"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,7 +127,7 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
 - Targets: `~/.config/{ghostty,tmux,ccstatusline,nvim,worktrunk,glow}`, `~/.vimrc`, `~/.vim/colors`, `~/.zshrc`, `~/.p10k.zsh`, `~/.claude/CLAUDE.md`
 - The repo's `.claude/CLAUDE.md` IS the user-global Claude config (symlinked to `~/.claude/CLAUDE.md`). Edits there apply to every project on this machine, not just dotfiles.
 - Machine-specific overrides: `~/.zshrc.local` (untracked; copy from `.zshrc.local.template`)
-- Helpers: `.config/tmux/bin/tmux-{project-name,git-status}`
+- Helpers: `.config/tmux/bin/{tmux-project-name,tmux-git-status,claude-tmux-window-name}`
 - Smoke tests for helpers: `scripts/test-helpers.sh`
 
 ## Cheatsheets (`docs/`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,15 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
   explicit ask. The label function `_tmux_window_label` in `.zshrc` is
   duplicated in `scripts/test-tmux-window-label.zsh` — keep both copies
   in sync.
+  When a Claude Code session is active in the pane,
+  `@claude_session_name` overrides `@last_cmd` and the window renders
+  `claude[<name>]`. Set/cleared by `~/.config/tmux/bin/claude-tmux-window-name`
+  via Claude Code hooks (`SessionStart`, `Stop`, `SessionEnd`) wired in
+  `~/.claude/settings.json`. The hook config is per-machine (not symlinked
+  from this repo — see "First-time setup on a new machine"). The script's
+  test mock and the script itself live separately —
+  `scripts/test-claude-tmux-window-name.zsh` exercises the script through a
+  temp `$HOME` and a `tmux` PATH shim, so no in-place duplication of logic.
 - **Bells are silenced at every layer** (Ghostty `bell-features =`, zsh
   `unsetopt BEEP/HIST_BEEP/LIST_BEEP`, vim `belloff=all`, tmux
   `bell-action/visual-bell/monitor-bell off`). Don't re-enable without
@@ -143,6 +152,7 @@ reference; open them locally with `open docs/<name>.html`.
 - Helper smoke tests: `scripts/test-helpers.sh`
 - Zsh prompt-context tests: `scripts/test-prompt-context.zsh`
 - Tmux window-label tests: `scripts/test-tmux-window-label.zsh`
+- Claude tmux window-name tests: `scripts/test-claude-tmux-window-name.zsh`
 - Reapply symlinks (idempotent): `$PROJECTS_HOME/dotfiles/bootstrap.sh`
 - Check brew deps without installing: `brew bundle check --file=$PROJECTS_HOME/dotfiles/Brewfile --verbose`
 - nvim plugin smoke test: `scripts/test-nvim.sh`
@@ -158,6 +168,29 @@ git config --global delta.navigate true
 git config --global delta.line-numbers true
 git config --global delta.syntax-theme "Solarized (dark)"
 ```
+
+Then add the Claude Code hooks that drive the `claude[<name>]` window title.
+Open `~/.claude/settings.json` and add (or merge into) these top-level
+entries inside the `hooks` object:
+
+```json
+"SessionStart": [
+  { "hooks": [ { "type": "command",
+    "command": "~/.config/tmux/bin/claude-tmux-window-name set" } ] }
+],
+"Stop": [
+  { "hooks": [ { "type": "command",
+    "command": "~/.config/tmux/bin/claude-tmux-window-name set" } ] }
+],
+"SessionEnd": [
+  { "hooks": [ { "type": "command",
+    "command": "~/.config/tmux/bin/claude-tmux-window-name clear" } ] }
+]
+```
+
+`~/.claude/settings.json` is not symlinked from this repo (it accumulates
+machine-local permission state), so this is a one-time manual edit per
+machine.
 
 ## Out of scope (future work, separate spec)
 

--- a/docs/tmux-cheatsheet.html
+++ b/docs/tmux-cheatsheet.html
@@ -233,6 +233,7 @@
       <li><code>vim foo.rb</code> → window name: <code>vim foo.rb</code></li>
       <li><code>FOO=bar bundle exec rspec</code> → <code>bundle exec</code></li>
       <li>Idle pane / non-zsh shell → falls back to <code>pane_current_command</code> (usually <code>zsh</code>)</li>
+      <li><strong>Claude session active</strong> — window renders <code>claude[&lt;session-name&gt;]</code> (overrides last-typed-command label until Claude exits)</li>
     </ul>
     <p class="note"><code>allow-rename off</code> stays — OSC titles from apps (e.g. Claude Code) cannot override.</p>
   </div>
@@ -423,7 +424,7 @@
 </table>
 
 <footer>
-  Built from <code>~/.config/tmux/tmux.conf</code> on 2026-04-29. Refresh after meaningful config changes.
+  Built from <code>~/.config/tmux/tmux.conf</code> on 2026-04-30. Refresh after meaningful config changes.
   <br>
   When in doubt: <span class="k prefix">C-a</span> <span class="k">?</span> for the live keymap list.
 </footer>

--- a/docs/tmux-cheatsheet.html
+++ b/docs/tmux-cheatsheet.html
@@ -411,16 +411,18 @@
 <span class="kw">set</span> -g <span class="cmd">visual-bell</span>  <span class="arg">off</span>
 <span class="kw">set</span> -g <span class="cmd">monitor-bell</span> <span class="arg">off</span>
 
-<span class="c"># Window naming follows active pane via @last_cmd (set in zsh preexec)</span>
+<span class="c"># Window naming: @claude_session_name (Claude hooks) overrides</span>
+<span class="c"># @last_cmd (zsh preexec) overrides pane_current_command (fallback)</span>
 <span class="kw">set</span> -g <span class="cmd">allow-rename</span> <span class="arg">off</span>
 <span class="kw">set</span> -g <span class="cmd">automatic-rename</span> <span class="arg">on</span>
-<span class="kw">set</span> -g <span class="cmd">automatic-rename-format</span> '#{?#{==:#{@last_cmd},},#{pane_current_command},#{@last_cmd}}'</pre>
+<span class="kw">set</span> -g <span class="cmd">automatic-rename-format</span> '#{?#{!=:#{@claude_session_name},},claude[#{@claude_session_name}],#{?#{==:#{@last_cmd},},#{pane_current_command},#{@last_cmd}}}'</pre>
 
 <h3>Reload &amp; verify</h3>
 <table style="max-width:780px">
   <tr><td class="key"><span class="k prefix">C-a</span><span class="k">r</span></td><td class="desc">reload config inside running tmux</td></tr>
   <tr><td class="key"><code>scripts/test-helpers.sh</code></td><td class="desc">smoke-tests for status helpers</td></tr>
   <tr><td class="key"><code>scripts/test-tmux-window-label.zsh</code></td><td class="desc">window-label extraction tests (mirror of <code>_tmux_window_label</code> in <code>.zshrc</code>)</td></tr>
+  <tr><td class="key"><code>scripts/test-claude-tmux-window-name.zsh</code></td><td class="desc">tests for the <code>claude[&lt;name&gt;]</code> window-title helper</td></tr>
 </table>
 
 <footer>

--- a/scripts/test-claude-tmux-window-name.zsh
+++ b/scripts/test-claude-tmux-window-name.zsh
@@ -108,6 +108,36 @@ assert_eq "$ok" "1" "set writes name into @claude_session_name"
 unset TMUX_PANE
 teardown_env
 
+# 4. set mode, session file present but has no `name` field → no tmux call.
+setup_env
+TMUX_PANE="%7"; export TMUX_PANE
+cat > "$HOME/.claude/sessions/99.json" <<'JSON'
+{ "pid": 99, "sessionId": "no-name-sid" }
+JSON
+run_script set '{"session_id":"no-name-sid"}'
+assert_eq "$(tmux_call_count)" "0" "set with unnamed session → no tmux call"
+unset TMUX_PANE
+teardown_env
+
+# 5. set mode, stdin missing session_id → no tmux call.
+setup_env
+TMUX_PANE="%7"; export TMUX_PANE
+run_script set '{}'
+assert_eq "$(tmux_call_count)" "0" "set with empty payload → no tmux call"
+unset TMUX_PANE
+teardown_env
+
+# 6. set mode, no matching session file → no tmux call.
+setup_env
+TMUX_PANE="%7"; export TMUX_PANE
+cat > "$HOME/.claude/sessions/77.json" <<'JSON'
+{ "pid": 77, "sessionId": "different", "name": "elsewhere" }
+JSON
+run_script set '{"session_id":"abc-123"}'
+assert_eq "$(tmux_call_count)" "0" "set with unmatched sessionId → no tmux call"
+unset TMUX_PANE
+teardown_env
+
 # ── summary ──────────────────────────────────────────────────────────────────
 echo
 echo "───────────────────────"

--- a/scripts/test-claude-tmux-window-name.zsh
+++ b/scripts/test-claude-tmux-window-name.zsh
@@ -1,0 +1,84 @@
+#!/usr/bin/env zsh
+# Unit tests for claude-tmux-window-name.
+# Run: zsh scripts/test-claude-tmux-window-name.zsh
+set -u
+
+REPO="${PROJECTS_HOME:-$HOME/code}/dotfiles"
+SCRIPT="$REPO/.config/tmux/bin/claude-tmux-window-name"
+
+pass=0; fail=0; fail_msgs=()
+
+assert_eq() {
+  local got="$1" want="$2" desc="$3"
+  if [[ "$got" == "$want" ]]; then
+    pass=$((pass+1)); echo "  PASS  $desc"
+  else
+    fail=$((fail+1))
+    fail_msgs+=("FAIL  $desc"$'\n'"        got:  '$got'"$'\n'"        want: '$want'")
+    echo "  FAIL  $desc"
+  fi
+}
+
+# ── test harness ─────────────────────────────────────────────────────────────
+# Each test sets up a fresh fake $HOME/.claude/sessions/ dir and a mock
+# `tmux` shim on $PATH that records every invocation to $TMUX_CALLS.
+setup_env() {
+  TEST_HOME=$(mktemp -d)
+  TMUX_CALLS="$TEST_HOME/tmux-calls.log"
+  : > "$TMUX_CALLS"
+  mkdir -p "$TEST_HOME/.claude/sessions"
+  mkdir -p "$TEST_HOME/bin"
+  cat > "$TEST_HOME/bin/tmux" <<'SHIM'
+#!/usr/bin/env sh
+printf '%s\0' "$@" >> "$TMUX_CALLS"
+printf '\n' >> "$TMUX_CALLS"
+SHIM
+  chmod +x "$TEST_HOME/bin/tmux"
+  HOME="$TEST_HOME" PATH="$TEST_HOME/bin:$PATH"
+  export HOME PATH TMUX_CALLS
+}
+
+teardown_env() {
+  rm -rf "$TEST_HOME"
+  unset TEST_HOME TMUX_CALLS
+}
+
+run_script() {
+  # Usage: run_script <mode> [stdin-json]
+  local mode="$1" stdin="${2:-}"
+  if [[ -n $stdin ]]; then
+    printf '%s' "$stdin" | "$SCRIPT" "$mode"
+  else
+    "$SCRIPT" "$mode" </dev/null
+  fi
+}
+
+# Count tmux invocations recorded in TMUX_CALLS (one per line).
+tmux_call_count() {
+  if [[ ! -s $TMUX_CALLS ]]; then echo 0; return; fi
+  grep -c '' "$TMUX_CALLS"
+}
+
+# ── tests ────────────────────────────────────────────────────────────────────
+echo
+echo "claude-tmux-window-name"
+echo "───────────────────────"
+
+# 1. No $TMUX_PANE → no tmux call, exit 0.
+setup_env
+unset TMUX_PANE
+run_script set '{"session_id":"any"}'
+assert_eq "$(tmux_call_count)" "0" "no \$TMUX_PANE → script no-ops"
+teardown_env
+
+# ── summary ──────────────────────────────────────────────────────────────────
+echo
+echo "───────────────────────"
+echo "passed: $pass"
+echo "failed: $fail"
+if (( fail > 0 )); then
+  echo
+  printf '%s\n' "${fail_msgs[@]}"
+  exit 1
+fi
+exit 0

--- a/scripts/test-claude-tmux-window-name.zsh
+++ b/scripts/test-claude-tmux-window-name.zsh
@@ -91,6 +91,23 @@ assert_eq "$last_unset" "1" "clear unsets @last_cmd"
 unset TMUX_PANE
 teardown_env
 
+# 3. set mode, session has a name → @claude_session_name set to that name.
+setup_env
+TMUX_PANE="%7"; export TMUX_PANE
+cat > "$HOME/.claude/sessions/12345.json" <<'JSON'
+{ "pid": 12345, "sessionId": "abc-123", "name": "my-session" }
+JSON
+run_script set '{"session_id":"abc-123"}'
+assert_eq "$(tmux_call_count)" "1" "set with named session → one tmux call"
+calls=$(cat "$TMUX_CALLS")
+case "$calls" in
+  *@claude_session_name*my-session*) ok=1 ;;
+  *)                                  ok=0 ;;
+esac
+assert_eq "$ok" "1" "set writes name into @claude_session_name"
+unset TMUX_PANE
+teardown_env
+
 # ── summary ──────────────────────────────────────────────────────────────────
 echo
 echo "───────────────────────"

--- a/scripts/test-claude-tmux-window-name.zsh
+++ b/scripts/test-claude-tmux-window-name.zsh
@@ -138,6 +138,18 @@ assert_eq "$(tmux_call_count)" "0" "set with unmatched sessionId → no tmux cal
 unset TMUX_PANE
 teardown_env
 
+# 7. set mode, ~/.claude/sessions/ empty → no tmux call AND no stderr noise.
+#    Regression test for "zsh: no matches found" leaking when the *.json glob
+#    expands to nothing. NULL_GLOB in the script suppresses it.
+setup_env
+TMUX_PANE="%7"; export TMUX_PANE
+STDERR_LOG="$TEST_HOME/stderr.log"
+printf '%s' '{"session_id":"abc"}' | "$SCRIPT" set 2>"$STDERR_LOG"
+assert_eq "$(tmux_call_count)" "0" "set with empty sessions/ dir → no tmux call"
+assert_eq "$(wc -c <"$STDERR_LOG" | tr -d ' ')" "0" "set with empty sessions/ dir → no stderr noise"
+unset TMUX_PANE STDERR_LOG
+teardown_env
+
 # ── summary ──────────────────────────────────────────────────────────────────
 echo
 echo "───────────────────────"

--- a/scripts/test-claude-tmux-window-name.zsh
+++ b/scripts/test-claude-tmux-window-name.zsh
@@ -71,6 +71,26 @@ run_script set '{"session_id":"any"}'
 assert_eq "$(tmux_call_count)" "0" "no \$TMUX_PANE → script no-ops"
 teardown_env
 
+# 2. clear mode → tmux invoked twice (unset @claude_session_name + @last_cmd).
+setup_env
+TMUX_PANE="%42"; export TMUX_PANE
+run_script clear
+assert_eq "$(tmux_call_count)" "2" "clear → two tmux unset calls"
+# Verify each call passes -p -t %42 -u <var>
+calls=$(cat "$TMUX_CALLS")
+case "$calls" in
+  *@claude_session_name*) name_unset=1 ;;
+  *)                      name_unset=0 ;;
+esac
+case "$calls" in
+  *@last_cmd*) last_unset=1 ;;
+  *)           last_unset=0 ;;
+esac
+assert_eq "$name_unset" "1" "clear unsets @claude_session_name"
+assert_eq "$last_unset" "1" "clear unsets @last_cmd"
+unset TMUX_PANE
+teardown_env
+
 # ── summary ──────────────────────────────────────────────────────────────────
 echo
 echo "───────────────────────"


### PR DESCRIPTION
## Summary

When a Claude Code session is running in a tmux pane, the window now renders `claude[<session-name>]` (the title set via `/rename` or `claude -w <name>`). Falls back to plain `claude` for unnamed sessions, and snaps to `zsh` on clean exit.

## How it works

- New helper: `.config/tmux/bin/claude-tmux-window-name {set|clear}` reads Claude's hook payload from stdin, looks up the session name in `~/.claude/sessions/<pid>.json`, and sets a per-pane `@claude_session_name` tmux user variable.
- Wired via Claude Code hooks (`SessionStart` / `Stop` / `SessionEnd`) in `~/.claude/settings.json`. The hook config is per-machine — see CLAUDE.md "First-time setup on a new machine" for the snippet.
- `tmux.conf` `automatic-rename-format` is now three-tier: `@claude_session_name` (highest) → `@last_cmd` → `pane_current_command`.

## Test plan

- [x] `zsh scripts/test-claude-tmux-window-name.zsh` — 9/9 PASS
- [x] `bash scripts/test-helpers.sh` — 30/30 PASS, no regression
- [x] `zsh scripts/test-tmux-window-label.zsh` — PASS
- [x] `zsh scripts/test-prompt-context.zsh` — PASS
- [x] `tmux -f .config/tmux/tmux.conf …` syntax check — exit 0
- [x] **Manual (after merge, per machine):** add the SessionStart/Stop/SessionEnd hooks to `~/.claude/settings.json` (snippet in CLAUDE.md)
- [x] **Manual end-to-end (interactive tmux required):**
  - Fresh `claude` (no `-w`) → window shows `claude`; `/exit` → `zsh`
  - `/rename window-test` then send a message → window updates to `claude[window-test]` after the reply
  - `claude -w second-test` → window shows `claude[second-test]` immediately
  - Two panes with different `-w` names → switching panes flips the title

## Notes

- `~/.claude/settings.json` is intentionally not symlinked from this repo (it accumulates machine-local permission state); the hook config is documented as a one-time manual edit.
- Adds `brew "jq"` to Brewfile (already used by other helpers; was missing).
- Plan + spec live in `tmp/` (gitignored, not committed).

## Session stats

Built via subagent-driven development in a single Claude Code session.

- **Duration:** 7h 02m (2026-04-30 04:39 → 11:41 UTC)
- **Subagents dispatched:** 28 (per-task implementer + spec reviewer + code reviewer for each of 10 tasks, plus a final cross-cutting review)
- **Messages:** 879 assistant turns
- **Total billed tokens:** 45.4M
- **Public-rate cost:** ~$101.87 USD

| Model | Msgs | Input | Output | Cache read | Cache write 5m | Cache write 1h | Cost (USD) |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| opus-4-7 (controller) | 272 | 670 | 304,923 | 24,314,782 | 0 | 1,262,867 | $97.24 |
| haiku-4-5 (subagents) | 549 | 2,652 | 69,636 | 16,226,519 | 1,293,461 | 0 | $3.59 |
| sonnet-4-6 (final review) | 57 | 63 | 13,289 | 1,863,443 | 76,457 | 0 | $1.05 |
| **Total** | **879** | **3,385** | **387,848** | **42,404,744** | **1,369,918** | **1,262,867** | **$101.87** |

Cost is computed against public Anthropic API rates and is a relative guide, not an invoice (Max/Pro/Team/Enterprise plans bundle this differently).
