### PR TITLE
feat(s): one-command worktree + tmux session

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,20 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
   script. Zoxide is on but `_ZO_EXCLUDE_DIRS` blocks `~/`,
   `~/Downloads/*`, `~/.config/*`, `~/Library/*` from being indexed —
   keeps the picker focused on real projects under `$PROJECTS_HOME`.
+- **`s` is the worktree+session command** (`bin/s`, symlinked to
+  `~/.local/bin/s` by `bootstrap.sh`). Surface:
+  `s [<project>] [<name>]`. Inside tmux a single arg is the worktree
+  name (project inferred from cwd's main worktree); outside tmux a
+  single arg is a project name (no worktree, attaches to project's
+  main session). Two args are always `<project> <worktree-name>`.
+  Tmux session naming uses `/` as separator (`<project>/<name>`)
+  because tmux disallows `:` and `.`. The branch name is used
+  verbatim — `s` does **not** apply the `worktree-` prefix; that
+  prefix is reserved for the `EnterWorktree` Claude Code workflow.
+  Project list comes from `sesh list -c -j` (the configured-sessions
+  source); no separate registry. Don't wrap `<prefix> t` to add
+  create-on-miss — the picker stays vanilla per the existing house
+  rule.
 - **`vim` and `vimdiff` are zsh aliases to nvim**; **`vi` is a zsh alias
   to the legacy minimal vim** (`alias vi='command vim'` — `command`
   suppresses recursive alias expansion). All three are defined in
@@ -165,4 +179,3 @@ git config --global delta.syntax-theme "Solarized (dark)"
 ## Out of scope (future work, separate spec)
 
 - Lifting API tokens out of `~/.zshrc` into `~/.secrets`
-- tmux ↔ `EnterWorktree` auto-window integration

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Personal config for Ghostty + zsh + tmux + vim, all in Solarized + JetBrainsMono
 - URL picker (current pane): `<prefix> u`
 - reload tmux: `<prefix> r`
 - TPM plugin install: `<prefix> I` (capital I)
+- worktree+session command (any shell): `s [<project>] [<name>]` — inside tmux 1 arg = worktree name in current project; outside tmux 1 arg = project name (attach), 0 args = fzf picker
 
 ## Status bar (right side)
 
@@ -42,4 +43,3 @@ Personal config for Ghostty + zsh + tmux + vim, all in Solarized + JetBrainsMono
 ## Future work
 
 - Lift API tokens out of `~/.zshrc` into a gitignored `~/.secrets`
-- `EnterWorktree` ↔ tmux integration (auto-spawn window per worktree)

--- a/bin/s
+++ b/bin/s
@@ -51,6 +51,17 @@ resolve_project_name() {
     | head -n1
 }
 
+# Final stage: switch-client (in tmux) or attach (out) to an existing session.
+# The caller is responsible for creating the session with new-session first.
+finish() {
+  local session="$1"
+  if [[ -n ${TMUX:-} ]]; then
+    exec tmux switch-client -t "$session"
+  else
+    exec tmux attach -t "$session"
+  fi
+}
+
 # Arg parsing. Final dispatch is filled in over later tasks.
 (( $# > 2 )) && usage
 
@@ -58,11 +69,13 @@ case $# in
   2)
     project="$1"
     name="$2"
+    session="$project/$name"
     project_path=$(resolve_project_path "$project")
-    target_path=$(ensure_worktree "$project_path" "$name")
-    # placeholder: tmux session create/attach lands in Task 6
-    echo "TODO: 2-arg flow project=$project name=$name target_path=$target_path" >&2
-    exit 1
+    if ! tmux has-session -t "$session" 2>/dev/null; then
+      target_path=$(ensure_worktree "$project_path" "$name")
+      tmux new-session -d -s "$session" -c "$target_path"
+    fi
+    finish "$session"
     ;;
   1)
     if [[ -n ${TMUX:-} ]]; then
@@ -79,13 +92,19 @@ case $# in
         echo "s: cwd's repo is not in your sesh config" >&2
         exit 1
       fi
-      echo "TODO: 1-arg-in-tmux flow name=$name project=$project" >&2
-      exit 1
+      session="$project/$name"
+      if ! tmux has-session -t "$session" 2>/dev/null; then
+        target_path=$(ensure_worktree "$project_path" "$name")
+        tmux new-session -d -s "$session" -c "$target_path"
+      fi
+      finish "$session"
     else
       project="$1"
       project_path=$(resolve_project_path "$project")
-      echo "TODO: 1-arg-out flow project=$project path=$project_path" >&2
-      exit 1
+      if ! tmux has-session -t "$project" 2>/dev/null; then
+        tmux new-session -d -s "$project" -c "$project_path"
+      fi
+      finish "$project"
     fi
     ;;
   0)
@@ -103,8 +122,10 @@ case $# in
       [[ -z $pick ]] && exit 0
       project="${pick%%$'\t'*}"
       project_path="${pick#*$'\t'}"
-      echo "TODO: 1-arg-out flow project=$project path=$project_path" >&2
-      exit 1
+      if ! tmux has-session -t "$project" 2>/dev/null; then
+        tmux new-session -d -s "$project" -c "$project_path"
+      fi
+      finish "$project"
     fi
     ;;
 esac

--- a/bin/s
+++ b/bin/s
@@ -62,7 +62,17 @@ case $# in
       usage
     else
       # 0-arg-out-of-tmux: fzf picker (Task 3)
-      echo "TODO: picker flow" >&2
+      pick=$(sesh list -c -j 2>/dev/null \
+        | jq -r '.[] | "\(.Name)\t\(.Path)"' \
+        | while IFS=$'\t' read -r n p; do
+            git -C "$p" rev-parse --is-inside-work-tree >/dev/null 2>&1 \
+              && printf '%s\t%s\n' "$n" "$p"
+          done \
+        | fzf --with-nth=1 --delimiter=$'\t' --prompt='project: ') || pick=""
+      [[ -z $pick ]] && exit 0
+      project="${pick%%$'\t'*}"
+      project_path="${pick#*$'\t'}"
+      echo "TODO: 1-arg-out flow project=$project path=$project_path" >&2
       exit 1
     fi
     ;;

--- a/bin/s
+++ b/bin/s
@@ -19,6 +19,15 @@ EOF
   exit 1
 }
 
+# Create or find a worktree for <name> in <project_path>. Echoes the
+# worktree path on stdout. wt is itself idempotent: if branch+worktree
+# already exist, it reports their location instead of erroring.
+ensure_worktree() {
+  local project_path="$1" name="$2" json
+  json=$(wt -C "$project_path" switch --create --no-cd --format=json "$name") || return $?
+  printf '%s\n' "$json" | jq -r '.path'
+}
+
 # Look up a project by Name in sesh's configured sessions. Echoes the
 # Path on stdout. Exits 1 with a clear error if not found.
 resolve_project_path() {
@@ -50,8 +59,9 @@ case $# in
     project="$1"
     name="$2"
     project_path=$(resolve_project_path "$project")
-    # placeholder: full session-create flow lands in Task 6
-    echo "TODO: 2-arg flow project=$project name=$name path=$project_path" >&2
+    target_path=$(ensure_worktree "$project_path" "$name")
+    # placeholder: tmux session create/attach lands in Task 6
+    echo "TODO: 2-arg flow project=$project name=$name target_path=$target_path" >&2
     exit 1
     ;;
   1)

--- a/bin/s
+++ b/bin/s
@@ -25,7 +25,7 @@ resolve_project_path() {
   local name="$1" result
   result=$(sesh list -c -j 2>/dev/null \
     | jq -r --arg n "$name" '.[] | select(.Name == $n) | .Path' \
-    | head -n1)
+    | head -n1) || true
   if [[ -z $result ]]; then
     echo "s: no project named '$name'" >&2
     exit 1

--- a/bin/s
+++ b/bin/s
@@ -33,6 +33,15 @@ resolve_project_path() {
   printf '%s\n' "$result"
 }
 
+# Reverse lookup: given a path, find the matching sesh-configured project
+# Name. Echoes the Name on stdout, empty string if not found.
+resolve_project_name() {
+  local dir="$1"
+  sesh list -c -j 2>/dev/null \
+    | jq -r --arg p "$dir" '.[] | select(.Path == $p) | .Name' \
+    | head -n1
+}
+
 # Arg parsing. Final dispatch is filled in over later tasks.
 (( $# > 2 )) && usage
 
@@ -48,7 +57,19 @@ case $# in
   1)
     if [[ -n ${TMUX:-} ]]; then
       # 1-arg-in-tmux: name only, project inferred (Task 4)
-      echo "TODO: 1-arg-in-tmux flow name=$1" >&2
+      name="$1"
+      # Find the main worktree path even if cwd is inside a secondary worktree.
+      common=$(git -C "$PWD" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || {
+        echo "s: not in a git repo" >&2; exit 1
+      }
+      # Resolve symlinks so the path matches what sesh stores (real paths).
+      project_path=$(cd "$(dirname "$common")" && pwd -P)
+      project=$(resolve_project_name "$project_path")
+      if [[ -z $project ]]; then
+        echo "s: cwd's repo is not in your sesh config" >&2
+        exit 1
+      fi
+      echo "TODO: 1-arg-in-tmux flow name=$name project=$project" >&2
       exit 1
     else
       project="$1"

--- a/bin/s
+++ b/bin/s
@@ -1,0 +1,28 @@
+#!/usr/bin/env zsh
+# s — one-command worktree + tmux session.
+# See tmp/specs/2026-04-30-s-worktree-session-design.md for design rationale.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF' >&2
+Usage: s [<project>] [<name>]
+
+  Inside tmux:
+    1 arg  -> name=<arg>; project inferred from cwd's repo
+    2 args -> project=<arg1>, name=<arg2>
+
+  Outside tmux:
+    0 args -> fzf picker over sesh's configured projects
+    1 arg  -> project=<arg>, no worktree (open project's main session)
+    2 args -> project=<arg1>, name=<arg2>
+EOF
+  exit 1
+}
+
+# Arg parsing. Dispatch is filled in over later tasks; for now anything
+# beyond 2 args is rejected.
+(( $# > 2 )) && usage
+
+# Stub: until later tasks wire actual behavior, every other invocation
+# is also a usage error.
+usage

--- a/bin/s
+++ b/bin/s
@@ -29,12 +29,18 @@ ensure_worktree() {
 }
 
 # Look up a project by Name in sesh's configured sessions. Echoes the
-# Path on stdout. Exits 1 with a clear error if not found.
+# Path on stdout. Exits 1 with a clear error if sesh fails or name is
+# unknown. Distinguishing the two avoids sending users typo-hunting
+# in sesh.local.toml when sesh itself is the problem.
 resolve_project_path() {
-  local name="$1" result
-  result=$(sesh list -c -j 2>/dev/null \
+  local name="$1" sesh_out result
+  if ! sesh_out=$(sesh list -c -j 2>/dev/null); then
+    echo "s: sesh list failed (is sesh installed?)" >&2
+    exit 1
+  fi
+  result=$(printf '%s' "$sesh_out" \
     | jq -r --arg n "$name" '.[] | select(.Name == $n) | .Path' \
-    | head -n1) || true
+    | head -n1)
   if [[ -z $result ]]; then
     echo "s: no project named '$name'" >&2
     exit 1

--- a/bin/s
+++ b/bin/s
@@ -19,10 +19,51 @@ EOF
   exit 1
 }
 
-# Arg parsing. Dispatch is filled in over later tasks; for now anything
-# beyond 2 args is rejected.
+# Look up a project by Name in sesh's configured sessions. Echoes the
+# Path on stdout. Exits 1 with a clear error if not found.
+resolve_project_path() {
+  local name="$1" result
+  result=$(sesh list -c -j 2>/dev/null \
+    | jq -r --arg n "$name" '.[] | select(.Name == $n) | .Path' \
+    | head -n1)
+  if [[ -z $result ]]; then
+    echo "s: no project named '$name'" >&2
+    exit 1
+  fi
+  printf '%s\n' "$result"
+}
+
+# Arg parsing. Final dispatch is filled in over later tasks.
 (( $# > 2 )) && usage
 
-# Stub: until later tasks wire actual behavior, every other invocation
-# is also a usage error.
-usage
+case $# in
+  2)
+    project="$1"
+    name="$2"
+    project_path=$(resolve_project_path "$project")
+    # placeholder: full session-create flow lands in Task 6
+    echo "TODO: 2-arg flow project=$project name=$name path=$project_path" >&2
+    exit 1
+    ;;
+  1)
+    if [[ -n ${TMUX:-} ]]; then
+      # 1-arg-in-tmux: name only, project inferred (Task 4)
+      echo "TODO: 1-arg-in-tmux flow name=$1" >&2
+      exit 1
+    else
+      project="$1"
+      project_path=$(resolve_project_path "$project")
+      echo "TODO: 1-arg-out flow project=$project path=$project_path" >&2
+      exit 1
+    fi
+    ;;
+  0)
+    if [[ -n ${TMUX:-} ]]; then
+      usage
+    else
+      # 0-arg-out-of-tmux: fzf picker (Task 3)
+      echo "TODO: picker flow" >&2
+      exit 1
+    fi
+    ;;
+esac

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -64,6 +64,15 @@ link ".p10k.zsh"  "$HOME/.p10k.zsh"
 # --- claude
 link ".claude/CLAUDE.md" "$HOME/.claude/CLAUDE.md"
 
+# --- bin (user commands on $PATH)
+# Symlink each file individually because ~/.local/bin/ typically contains
+# other user-installed binaries that shouldn't be displaced by linking the
+# whole directory.
+for src in "$DOTFILES"/bin/*; do
+  [ -e "$src" ] || continue
+  link "bin/$(basename "$src")" "$HOME/.local/bin/$(basename "$src")"
+done
+
 # --- TPM (clone if missing; warn but don't abort if offline)
 TPM_DIR="$HOME/.config/tmux/plugins/tpm"
 if [ ! -d "$TPM_DIR/.git" ]; then

--- a/docs/tmux-cheatsheet.html
+++ b/docs/tmux-cheatsheet.html
@@ -123,6 +123,7 @@
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">d</span></td><td class="desc">detach (session keeps running)</td></tr>
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">r</span></td><td class="desc">reload <code>~/.config/tmux/tmux.conf</code></td></tr>
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">t</span></td><td class="desc">sesh picker popup (configured / tmux / zoxide / tmuxinator)</td></tr>
+      <tr><td class="key"><code>s [&lt;project&gt;] [&lt;name&gt;]</code></td><td class="desc">create-or-attach worktree+session — inside tmux 1 arg = worktree name in current project, outside tmux 1 arg = project, 0 args = fzf picker</td></tr>
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">T</span></td><td class="desc">clock-mode <span class="muted">(swapped from default <code>t</code>)</span></td></tr>
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">u</span></td><td class="desc">URL picker (fzf, current pane + 2000 lines scrollback) — opens in default browser</td></tr>
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">?</span></td><td class="desc">list all keybindings</td></tr>
@@ -423,7 +424,7 @@
 </table>
 
 <footer>
-  Built from <code>~/.config/tmux/tmux.conf</code> on 2026-04-29. Refresh after meaningful config changes.
+  Built from <code>~/.config/tmux/tmux.conf</code> on 2026-04-30. Refresh after meaningful config changes.
   <br>
   When in doubt: <span class="k prefix">C-a</span> <span class="k">?</span> for the live keymap list.
 </footer>

--- a/scripts/test-helpers.sh
+++ b/scripts/test-helpers.sh
@@ -260,6 +260,16 @@ else
   fi
 fi
 
+# ─── bin/s ──────────────────────────────────
+echo
+echo "bin/s"
+echo "─────"
+
+if ! bash "$(dirname "$0")/test-s.sh"; then
+  fail=$((fail+1))
+  fail_msgs+=("FAIL  scripts/test-s.sh reported failures")
+fi
+
 # ─── Summary ────────────────────────────────
 echo
 echo "─────────────────"

--- a/scripts/test-helpers.sh
+++ b/scripts/test-helpers.sh
@@ -260,11 +260,6 @@ else
   fi
 fi
 
-# ─── bin/s ──────────────────────────────────
-echo
-echo "bin/s"
-echo "─────"
-
 if ! bash "$(dirname "$0")/test-s.sh"; then
   fail=$((fail+1))
   fail_msgs+=("FAIL  scripts/test-s.sh reported failures")

--- a/scripts/test-s.sh
+++ b/scripts/test-s.sh
@@ -75,6 +75,25 @@ SHIM
     chmod +x "$d/sesh"
   }
 
+  write_tmux_shim() {
+    local d="$1"
+    cat >"$d/tmux" <<SHIM
+#!/usr/bin/env bash
+echo "\$@" >>"$d/tmux.log"
+case "\$1" in
+  has-session)
+    if [ -f "$d/tmux.has_session_exit" ]; then
+      exit "\$(cat "$d/tmux.has_session_exit")"
+    fi
+    exit 1
+    ;;
+  *)
+    exit 0 ;;
+esac
+SHIM
+    chmod +x "$d/tmux"
+  }
+
   # ─── project lookup: not found ─────────────
   shimdir=$(make_shimdir)
   write_sesh_shim "$shimdir" '[{"Name":"dotfiles","Path":"/tmp/dotfiles"}]'
@@ -108,6 +127,7 @@ SHIM
   json=$(printf '[{"Name":"home","Path":"%s"},{"Name":"dotfiles","Path":"%s"},{"Name":"strava","Path":"%s"}]' \
     "$fixture" "$fixture/dotfiles" "$fixture/strava")
   write_sesh_shim "$shimdir" "$json"
+  write_tmux_shim "$shimdir"
   # fzf shim: log stdin, emit the first line back (auto-pick).
   cat >"$shimdir/fzf" <<'SHIM'
 #!/usr/bin/env bash
@@ -117,8 +137,7 @@ printf '%s\n' "$input" | head -n1
 SHIM
   chmod +x "$shimdir/fzf"
   out=$(env -u TMUX PATH="$shimdir:$PATH" "$S" 2>&1); rc=$?
-  assert_eq "$rc" "1" "picker auto-pick reaches placeholder for 1-arg-out flow"
-  assert_contains "$out" "1-arg-out flow project=dotfiles" "picker selects first git-repo entry (dotfiles)"
+  assert_eq "$rc" "0" "picker auto-pick completes successfully"
   # The picker input must NOT contain the non-repo "home" entry.
   picker_in=$(cat "$shimdir/fzf.stdin")
   if printf '%s' "$picker_in" | grep -q '^home	'; then
@@ -154,10 +173,17 @@ SHIM
   fixture_real=$(cd "$fixture" && pwd -P)
   json=$(printf '[{"Name":"fixproject","Path":"%s"}]' "$fixture_real")
   write_sesh_shim "$shimdir" "$json"
+  write_tmux_shim "$shimdir"
+  cat >"$shimdir/wt" <<SHIM
+#!/usr/bin/env bash
+echo "\$@" >>"$shimdir/wt.log"
+printf '{"action":"created","branch":"feature-y","path":"$fixture_real/.claude/worktrees/feature-y"}\n'
+SHIM
+  chmod +x "$shimdir/wt"
   # Run from inside the worktree subdir.
   out=$( cd "$fixture/wt-x" && env TMUX=fake PATH="$shimdir:$PATH" "$S" feature-y 2>&1 ); rc=$?
-  assert_eq "$rc" "1" "inferred-project flow reaches placeholder"
-  assert_contains "$out" "1-arg-in-tmux flow name=feature-y project=fixproject" \
+  assert_eq "$rc" "0" "inferred-project flow completes (switch-client)"
+  assert_contains "$(cat "$shimdir/tmux.log")" "switch-client -t fixproject/feature-y" \
     "infers project name 'fixproject' from cwd's main worktree path"
   rm -rf "$shimdir" "$fixture"
 
@@ -183,6 +209,7 @@ SHIM
   # ─── worktree creation: 2-arg flow invokes wt with correct args ────
   shimdir=$(make_shimdir)
   write_sesh_shim "$shimdir" '[{"Name":"dotfiles","Path":"/tmp/fakerepo"}]'
+  write_tmux_shim "$shimdir"
   cat >"$shimdir/wt" <<SHIM
 #!/usr/bin/env bash
 echo "\$@" >>"$shimdir/wt.log"
@@ -191,13 +218,141 @@ printf '{"action":"created","branch":"feature-x","path":"/tmp/fakerepo/.claude/w
 SHIM
   chmod +x "$shimdir/wt"
   out=$(env -u TMUX PATH="$shimdir:$PATH" "$S" dotfiles feature-x 2>&1); rc=$?
-  assert_eq "$rc" "1" "2-arg flow reaches placeholder after wt"
-  assert_contains "$out" "target_path=/tmp/fakerepo/.claude/worktrees/feature-x" \
-    "2-arg flow uses worktree path from wt JSON"
+  assert_eq "$rc" "0" "2-arg flow completes after wt (attach)"
   wt_args=$(cat "$shimdir/wt.log")
   assert_contains "$wt_args" "-C /tmp/fakerepo switch --create --no-cd --format=json feature-x" \
     "wt invoked with -C <project_path> switch --create --no-cd --format=json <name>"
   rm -rf "$shimdir"
+
+  # ─── 1-arg out: session=<project>, no worktree, no wt call ─────────
+  shimdir=$(make_shimdir)
+  write_sesh_shim "$shimdir" '[{"Name":"dotfiles","Path":"/tmp/fakerepo"}]'
+  write_tmux_shim "$shimdir"
+  # wt shim that fails loudly if invoked
+  cat >"$shimdir/wt" <<SHIM
+#!/usr/bin/env bash
+echo "wt should not be called in 1-arg-out flow" >&2; exit 99
+SHIM
+  chmod +x "$shimdir/wt"
+  out=$(env -u TMUX PATH="$shimdir:$PATH" "$S" dotfiles 2>&1); rc=$?
+  assert_eq "$rc" "0" "1-arg-out happy path -> exit 0"
+  log=$(cat "$shimdir/tmux.log")
+  assert_contains "$log" "has-session -t dotfiles" "1-arg-out checks has-session for project name"
+  assert_contains "$log" "new-session -d -s dotfiles -c /tmp/fakerepo" \
+    "1-arg-out creates tmux session at project path"
+  assert_contains "$log" "attach -t dotfiles" "1-arg-out attaches (TMUX unset)"
+  rm -rf "$shimdir"
+
+  # ─── 2-arg out: session=<project>/<name>, wt creates worktree ──────
+  shimdir=$(make_shimdir)
+  write_sesh_shim "$shimdir" '[{"Name":"dotfiles","Path":"/tmp/fakerepo"}]'
+  write_tmux_shim "$shimdir"
+  cat >"$shimdir/wt" <<SHIM
+#!/usr/bin/env bash
+echo "\$@" >>"$shimdir/wt.log"
+printf '{"action":"created","branch":"feature-x","path":"/tmp/fakerepo/.claude/worktrees/feature-x"}\n'
+SHIM
+  chmod +x "$shimdir/wt"
+  out=$(env -u TMUX PATH="$shimdir:$PATH" "$S" dotfiles feature-x 2>&1); rc=$?
+  assert_eq "$rc" "0" "2-arg out happy path -> exit 0"
+  log=$(cat "$shimdir/tmux.log")
+  assert_contains "$log" "new-session -d -s dotfiles/feature-x -c /tmp/fakerepo/.claude/worktrees/feature-x" \
+    "2-arg-out creates tmux session named <project>/<name> at worktree path"
+  assert_contains "$log" "attach -t dotfiles/feature-x" "2-arg-out attaches (TMUX unset)"
+  rm -rf "$shimdir"
+
+  # ─── 2-arg in tmux: switch-client instead of attach ─────────────────
+  shimdir=$(make_shimdir)
+  write_sesh_shim "$shimdir" '[{"Name":"dotfiles","Path":"/tmp/fakerepo"}]'
+  write_tmux_shim "$shimdir"
+  cat >"$shimdir/wt" <<SHIM
+#!/usr/bin/env bash
+echo "\$@" >>"$shimdir/wt.log"
+printf '{"action":"created","branch":"feature-x","path":"/tmp/fakerepo/.claude/worktrees/feature-x"}\n'
+SHIM
+  chmod +x "$shimdir/wt"
+  out=$(env TMUX=fake PATH="$shimdir:$PATH" "$S" dotfiles feature-x 2>&1); rc=$?
+  assert_eq "$rc" "0" "2-arg in tmux happy path -> exit 0"
+  log=$(cat "$shimdir/tmux.log")
+  assert_contains "$log" "switch-client -t dotfiles/feature-x" \
+    "2-arg-in uses switch-client (TMUX set)"
+  if printf '%s' "$log" | grep -q "attach -t"; then
+    fail=$((fail+1))
+    fail_msgs+=("FAIL  in-tmux must not use 'attach -t'"$'\n'"        log: '$log'")
+    echo "  FAIL  in-tmux must not use 'attach -t'"
+  else
+    pass=$((pass+1))
+    echo "  PASS  in-tmux does not use 'attach -t'"
+  fi
+  rm -rf "$shimdir"
+
+  # ─── has-session short-circuit: no wt call, no new-session ─────────
+  shimdir=$(make_shimdir)
+  write_sesh_shim "$shimdir" '[{"Name":"dotfiles","Path":"/tmp/fakerepo"}]'
+  write_tmux_shim "$shimdir"
+  echo 0 >"$shimdir/tmux.has_session_exit"   # session "exists"
+  cat >"$shimdir/wt" <<SHIM
+#!/usr/bin/env bash
+echo "wt should not be called when session already exists" >&2; exit 99
+SHIM
+  chmod +x "$shimdir/wt"
+  out=$(env -u TMUX PATH="$shimdir:$PATH" "$S" dotfiles feature-x 2>&1); rc=$?
+  assert_eq "$rc" "0" "has-session=0 short-circuit -> exit 0"
+  log=$(cat "$shimdir/tmux.log")
+  if printf '%s' "$log" | grep -q "new-session"; then
+    fail=$((fail+1))
+    fail_msgs+=("FAIL  has-session=0 should skip new-session"$'\n'"        log: '$log'")
+    echo "  FAIL  has-session=0 should skip new-session"
+  else
+    pass=$((pass+1))
+    echo "  PASS  has-session=0 skips new-session"
+  fi
+  assert_contains "$log" "attach -t dotfiles/feature-x" "has-session=0 still attaches"
+  rm -rf "$shimdir"
+
+  # ─── 0-arg picker -> session=<project>, no worktree ────────────────
+  shimdir=$(make_shimdir)
+  fixture=$(mktemp -d)
+  mkdir -p "$fixture/dotfiles"
+  ( cd "$fixture/dotfiles" && git init -q && git -c user.email=t@t -c user.name=t commit --allow-empty -q -m i )
+  fixture_real=$(cd "$fixture/dotfiles" && pwd -P)
+  json=$(printf '[{"Name":"dotfiles","Path":"%s"}]' "$fixture_real")
+  write_sesh_shim "$shimdir" "$json"
+  write_tmux_shim "$shimdir"
+  cat >"$shimdir/fzf" <<'SHIM'
+#!/usr/bin/env bash
+head -n1
+SHIM
+  chmod +x "$shimdir/fzf"
+  out=$(env -u TMUX PATH="$shimdir:$PATH" "$S" 2>&1); rc=$?
+  assert_eq "$rc" "0" "picker happy path -> exit 0"
+  log=$(cat "$shimdir/tmux.log")
+  assert_contains "$log" "new-session -d -s dotfiles -c $fixture_real" \
+    "picker creates session at picked project path"
+  rm -rf "$shimdir" "$fixture"
+
+  # ─── 1-arg in tmux: session=<project>/<name>, wt creates worktree ──
+  shimdir=$(make_shimdir)
+  fixture=$(mktemp -d)
+  ( cd "$fixture" && git init -q && git -c user.email=t@t -c user.name=t commit --allow-empty -q -m i )
+  fixture_real=$(cd "$fixture" && pwd -P)
+  json=$(printf '[{"Name":"fixproject","Path":"%s"}]' "$fixture_real")
+  write_sesh_shim "$shimdir" "$json"
+  write_tmux_shim "$shimdir"
+  cat >"$shimdir/wt" <<SHIM
+#!/usr/bin/env bash
+echo "\$@" >>"$shimdir/wt.log"
+printf '{"action":"created","branch":"feature-y","path":"$fixture_real/.claude/worktrees/feature-y"}\n'
+SHIM
+  chmod +x "$shimdir/wt"
+  out=$( cd "$fixture" && env TMUX=fake PATH="$shimdir:$PATH" "$S" feature-y 2>&1 ); rc=$?
+  assert_eq "$rc" "0" "1-arg in-tmux happy path -> exit 0"
+  log=$(cat "$shimdir/tmux.log")
+  assert_contains "$log" "new-session -d -s fixproject/feature-y -c $fixture_real/.claude/worktrees/feature-y" \
+    "1-arg in-tmux creates session named <inferred-project>/<name> at worktree"
+  assert_contains "$log" "switch-client -t fixproject/feature-y" \
+    "1-arg in-tmux uses switch-client"
+  rm -rf "$shimdir" "$fixture"
 fi
 
 # ─── Summary ────────────────────────────────

--- a/scripts/test-s.sh
+++ b/scripts/test-s.sh
@@ -179,6 +179,25 @@ SHIM
   assert_eq "$rc" "1" "cwd repo not in sesh -> exit 1"
   assert_contains "$out" "cwd's repo is not in your sesh config" "cwd repo not in sesh -> error message"
   rm -rf "$shimdir" "$fixture"
+
+  # ─── worktree creation: 2-arg flow invokes wt with correct args ────
+  shimdir=$(make_shimdir)
+  write_sesh_shim "$shimdir" '[{"Name":"dotfiles","Path":"/tmp/fakerepo"}]'
+  cat >"$shimdir/wt" <<SHIM
+#!/usr/bin/env bash
+echo "\$@" >>"$shimdir/wt.log"
+# Emit the same JSON shape as real wt --format=json
+printf '{"action":"created","branch":"feature-x","path":"/tmp/fakerepo/.claude/worktrees/feature-x"}\n'
+SHIM
+  chmod +x "$shimdir/wt"
+  out=$(env -u TMUX PATH="$shimdir:$PATH" "$S" dotfiles feature-x 2>&1); rc=$?
+  assert_eq "$rc" "1" "2-arg flow reaches placeholder after wt"
+  assert_contains "$out" "target_path=/tmp/fakerepo/.claude/worktrees/feature-x" \
+    "2-arg flow uses worktree path from wt JSON"
+  wt_args=$(cat "$shimdir/wt.log")
+  assert_contains "$wt_args" "-C /tmp/fakerepo switch --create --no-cd --format=json feature-x" \
+    "wt invoked with -C <project_path> switch --create --no-cd --format=json <name>"
+  rm -rf "$shimdir"
 fi
 
 # ─── Summary ────────────────────────────────

--- a/scripts/test-s.sh
+++ b/scripts/test-s.sh
@@ -82,6 +82,21 @@ SHIM
   assert_eq "$rc" "1" "explicit project not in sesh -> exit 1"
   assert_contains "$out" "no project named 'nope'" "explicit project not in sesh -> error message"
   rm -rf "$shimdir"
+
+  # ─── project lookup: sesh missing -> meaningful error, not silent abort
+  # Use a shimdir that shadows sesh (and jq/head) with nothing, but keep
+  # system dirs so the zsh shebang still resolves. A no-op sesh shim that
+  # exits non-zero simulates a broken/missing tool without stripping PATH.
+  shimdir=$(make_shimdir)
+  cat >"$shimdir/sesh" <<'SHIM'
+#!/usr/bin/env bash
+exit 1
+SHIM
+  chmod +x "$shimdir/sesh"
+  out=$(env -u TMUX PATH="$shimdir:$PATH" "$S" anything 2>&1); rc=$?
+  assert_eq "$rc" "1" "sesh missing -> exit 1 (not 127)"
+  assert_contains "$out" "no project named 'anything'" "sesh missing -> error message"
+  rm -rf "$shimdir"
 fi
 
 # ─── Summary ────────────────────────────────

--- a/scripts/test-s.sh
+++ b/scripts/test-s.sh
@@ -55,6 +55,11 @@ else
   assert_eq "$rc" "1" "too many args -> exit 1"
   assert_contains "$out" "Usage:" "too many args -> usage on stderr"
 
+  # 0 args inside tmux -> usage (spec: in-tmux requires at least 1 arg)
+  out=$(env TMUX=fake "$S" 2>&1); rc=$?
+  assert_eq "$rc" "1" "0-arg in-tmux -> exit 1"
+  assert_contains "$out" "Usage:" "0-arg in-tmux -> usage on stderr"
+
   # ─── shim helpers ──────────────────────────
   # Each test creates a fresh shimdir, writes shims, and prepends to PATH.
   # Shims that record args write to "$shimdir/<name>.log".
@@ -102,10 +107,9 @@ SHIM
   assert_contains "$out" "no project named 'nope'" "explicit project not in sesh -> error message"
   rm -rf "$shimdir"
 
-  # ─── project lookup: sesh missing -> meaningful error, not silent abort
-  # Use a shimdir that shadows sesh (and jq/head) with nothing, but keep
-  # system dirs so the zsh shebang still resolves. A no-op sesh shim that
-  # exits non-zero simulates a broken/missing tool without stripping PATH.
+  # ─── project lookup: sesh broken -> distinct error (not "no project named")
+  # Without this distinction, a broken sesh sends users hunting for a typo in
+  # sesh.local.toml when the real fix is to install/repair sesh.
   shimdir=$(make_shimdir)
   cat >"$shimdir/sesh" <<'SHIM'
 #!/usr/bin/env bash
@@ -113,8 +117,8 @@ exit 1
 SHIM
   chmod +x "$shimdir/sesh"
   out=$(env -u TMUX PATH="$shimdir:$PATH" "$S" anything 2>&1); rc=$?
-  assert_eq "$rc" "1" "sesh missing -> exit 1 (not 127)"
-  assert_contains "$out" "no project named 'anything'" "sesh missing -> error message"
+  assert_eq "$rc" "1" "sesh broken -> exit 1 (not 127)"
+  assert_contains "$out" "sesh list failed" "sesh broken -> distinct error, not 'no project named'"
   rm -rf "$shimdir"
 
   # ─── picker: outside tmux, 0 args, mocked fzf auto-selects ─────────

--- a/scripts/test-s.sh
+++ b/scripts/test-s.sh
@@ -106,7 +106,7 @@ SHIM
   ( cd "$fixture/dotfiles" && git init -q && git -c user.email=t@t -c user.name=t commit --allow-empty -q -m i )
   ( cd "$fixture/strava"   && git init -q && git -c user.email=t@t -c user.name=t commit --allow-empty -q -m i )
   json=$(printf '[{"Name":"home","Path":"%s"},{"Name":"dotfiles","Path":"%s"},{"Name":"strava","Path":"%s"}]' \
-    "$HOME" "$fixture/dotfiles" "$fixture/strava")
+    "$fixture" "$fixture/dotfiles" "$fixture/strava")
   write_sesh_shim "$shimdir" "$json"
   # fzf shim: log stdin, emit the first line back (auto-pick).
   cat >"$shimdir/fzf" <<'SHIM'

--- a/scripts/test-s.sh
+++ b/scripts/test-s.sh
@@ -54,6 +54,34 @@ else
   out=$(env -u TMUX "$S" a b c 2>&1); rc=$?
   assert_eq "$rc" "1" "too many args -> exit 1"
   assert_contains "$out" "Usage:" "too many args -> usage on stderr"
+
+  # ─── shim helpers ──────────────────────────
+  # Each test creates a fresh shimdir, writes shims, and prepends to PATH.
+  # Shims that record args write to "$shimdir/<name>.log".
+  make_shimdir() { mktemp -d; }
+
+  write_sesh_shim() {
+    # $1 = shimdir, $2 = JSON to emit for `sesh list -c -j`
+    local d="$1" json="$2"
+    cat >"$d/sesh" <<SHIM
+#!/usr/bin/env bash
+echo "\$@" >>"$d/sesh.log"
+if [ "\$1" = "list" ]; then
+  printf '%s\n' '$json'
+  exit 0
+fi
+echo "sesh shim: unsupported args: \$*" >&2; exit 99
+SHIM
+    chmod +x "$d/sesh"
+  }
+
+  # ─── project lookup: not found ─────────────
+  shimdir=$(make_shimdir)
+  write_sesh_shim "$shimdir" '[{"Name":"dotfiles","Path":"/tmp/dotfiles"}]'
+  out=$(env -u TMUX PATH="$shimdir:$PATH" "$S" nope 2>&1); rc=$?
+  assert_eq "$rc" "1" "explicit project not in sesh -> exit 1"
+  assert_contains "$out" "no project named 'nope'" "explicit project not in sesh -> error message"
+  rm -rf "$shimdir"
 fi
 
 # ─── Summary ────────────────────────────────

--- a/scripts/test-s.sh
+++ b/scripts/test-s.sh
@@ -142,6 +142,43 @@ SHIM
   out=$(env -u TMUX PATH="$shimdir:$PATH" "$S" 2>&1); rc=$?
   assert_eq "$rc" "0" "fzf cancel -> exit 0"
   rm -rf "$shimdir"
+
+  # ─── infer project from cwd (inside tmux) ──────────────────────────
+  shimdir=$(make_shimdir)
+  fixture=$(mktemp -d)
+  ( cd "$fixture" && git init -q && git -c user.email=t@t -c user.name=t commit --allow-empty -q -m i )
+  # Add a worktree so we can verify --git-common-dir resolves to the main repo.
+  ( cd "$fixture" && git worktree add -q wt-x -b feat/x >/dev/null 2>&1 )
+  # Use physical path (resolves macOS /var -> /private/var symlink) to match
+  # what git rev-parse --path-format=absolute returns.
+  fixture_real=$(cd "$fixture" && pwd -P)
+  json=$(printf '[{"Name":"fixproject","Path":"%s"}]' "$fixture_real")
+  write_sesh_shim "$shimdir" "$json"
+  # Run from inside the worktree subdir.
+  out=$( cd "$fixture/wt-x" && env TMUX=fake PATH="$shimdir:$PATH" "$S" feature-y 2>&1 ); rc=$?
+  assert_eq "$rc" "1" "inferred-project flow reaches placeholder"
+  assert_contains "$out" "1-arg-in-tmux flow name=feature-y project=fixproject" \
+    "infers project name 'fixproject' from cwd's main worktree path"
+  rm -rf "$shimdir" "$fixture"
+
+  # ─── infer fail: cwd not in any git repo ───────────────────────────
+  shimdir=$(make_shimdir)
+  fixture=$(mktemp -d)  # not a git repo
+  write_sesh_shim "$shimdir" '[]'
+  out=$( cd "$fixture" && env TMUX=fake PATH="$shimdir:$PATH" "$S" feature-y 2>&1 ); rc=$?
+  assert_eq "$rc" "1" "cwd not in repo -> exit 1"
+  assert_contains "$out" "not in a git repo" "cwd not in repo -> error message"
+  rm -rf "$shimdir" "$fixture"
+
+  # ─── infer fail: cwd's repo not in sesh config ─────────────────────
+  shimdir=$(make_shimdir)
+  fixture=$(mktemp -d)
+  ( cd "$fixture" && git init -q && git -c user.email=t@t -c user.name=t commit --allow-empty -q -m i )
+  write_sesh_shim "$shimdir" '[{"Name":"otherproject","Path":"/some/other/path"}]'
+  out=$( cd "$fixture" && env TMUX=fake PATH="$shimdir:$PATH" "$S" feature-y 2>&1 ); rc=$?
+  assert_eq "$rc" "1" "cwd repo not in sesh -> exit 1"
+  assert_contains "$out" "cwd's repo is not in your sesh config" "cwd repo not in sesh -> error message"
+  rm -rf "$shimdir" "$fixture"
 fi
 
 # ─── Summary ────────────────────────────────

--- a/scripts/test-s.sh
+++ b/scripts/test-s.sh
@@ -97,6 +97,51 @@ SHIM
   assert_eq "$rc" "1" "sesh missing -> exit 1 (not 127)"
   assert_contains "$out" "no project named 'anything'" "sesh missing -> error message"
   rm -rf "$shimdir"
+
+  # ─── picker: outside tmux, 0 args, mocked fzf auto-selects ─────────
+  shimdir=$(make_shimdir)
+  # Two real-repo fixtures + one non-repo to verify filtering.
+  fixture=$(mktemp -d)
+  mkdir -p "$fixture/dotfiles" "$fixture/strava"
+  ( cd "$fixture/dotfiles" && git init -q && git -c user.email=t@t -c user.name=t commit --allow-empty -q -m i )
+  ( cd "$fixture/strava"   && git init -q && git -c user.email=t@t -c user.name=t commit --allow-empty -q -m i )
+  json=$(printf '[{"Name":"home","Path":"%s"},{"Name":"dotfiles","Path":"%s"},{"Name":"strava","Path":"%s"}]' \
+    "$HOME" "$fixture/dotfiles" "$fixture/strava")
+  write_sesh_shim "$shimdir" "$json"
+  # fzf shim: log stdin, emit the first line back (auto-pick).
+  cat >"$shimdir/fzf" <<'SHIM'
+#!/usr/bin/env bash
+input=$(cat)
+echo "$input" >"$(dirname "$0")/fzf.stdin"
+printf '%s\n' "$input" | head -n1
+SHIM
+  chmod +x "$shimdir/fzf"
+  out=$(env -u TMUX PATH="$shimdir:$PATH" "$S" 2>&1); rc=$?
+  assert_eq "$rc" "1" "picker auto-pick reaches placeholder for 1-arg-out flow"
+  assert_contains "$out" "1-arg-out flow project=dotfiles" "picker selects first git-repo entry (dotfiles)"
+  # The picker input must NOT contain the non-repo "home" entry.
+  picker_in=$(cat "$shimdir/fzf.stdin")
+  if printf '%s' "$picker_in" | grep -q '^home	'; then
+    fail=$((fail+1))
+    fail_msgs+=("FAIL  picker should filter out non-repo 'home' entry"$'\n'"        input: '$picker_in'")
+    echo "  FAIL  picker should filter out non-repo 'home' entry"
+  else
+    pass=$((pass+1))
+    echo "  PASS  picker filters non-repo entries"
+  fi
+  rm -rf "$shimdir" "$fixture"
+
+  # ─── picker: user cancels (fzf exits 130) -> clean exit 0 ──────────
+  shimdir=$(make_shimdir)
+  write_sesh_shim "$shimdir" '[{"Name":"dotfiles","Path":"/tmp"}]'
+  cat >"$shimdir/fzf" <<'SHIM'
+#!/usr/bin/env bash
+exit 130
+SHIM
+  chmod +x "$shimdir/fzf"
+  out=$(env -u TMUX PATH="$shimdir:$PATH" "$S" 2>&1); rc=$?
+  assert_eq "$rc" "0" "fzf cancel -> exit 0"
+  rm -rf "$shimdir"
 fi
 
 # ─── Summary ────────────────────────────────

--- a/scripts/test-s.sh
+++ b/scripts/test-s.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Smoke tests for bin/s.
+# Invoked from scripts/test-helpers.sh; can also be run standalone.
+#
+# Manual smoke-test checklist (run these by hand after the suite passes):
+#  1. Inside tmux session `dotfiles`, `s feature-x` -> new session
+#     `dotfiles/feature-x` at the worktree path. Repeating `s feature-x`
+#     -> switch-client to existing session, no second worktree created.
+#  2. Outside tmux, `s` -> fzf picker -> pick `dotfiles` -> attach to
+#     `dotfiles` session at ~/code/dotfiles.
+#  3. Outside tmux, `s dotfiles feature-x` -> fresh `dotfiles/feature-x`
+#     session with worktree at ~/code/dotfiles/.claude/worktrees/feature-x.
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+S="$REPO/bin/s"
+
+pass=0
+fail=0
+fail_msgs=()
+
+assert_eq() {
+  local got="$1" want="$2" desc="$3"
+  if [ "$got" = "$want" ]; then
+    pass=$((pass+1))
+    echo "  PASS  $desc"
+  else
+    fail=$((fail+1))
+    fail_msgs+=("FAIL  $desc"$'\n'"        got:  '$got'"$'\n'"        want: '$want'")
+    echo "  FAIL  $desc"
+  fi
+}
+
+assert_contains() {
+  local got="$1" needle="$2" desc="$3"
+  if printf '%s' "$got" | grep -q -F -- "$needle"; then
+    pass=$((pass+1))
+    echo "  PASS  $desc"
+  else
+    fail=$((fail+1))
+    fail_msgs+=("FAIL  $desc"$'\n'"        got:  '$got'"$'\n'"        needle: '$needle'")
+    echo "  FAIL  $desc"
+  fi
+}
+
+echo
+echo "bin/s"
+echo "─────"
+
+if [ ! -x "$S" ]; then
+  echo "  SKIP — $S not present yet"
+else
+  # too many args -> usage
+  out=$(env -u TMUX "$S" a b c 2>&1); rc=$?
+  assert_eq "$rc" "1" "too many args -> exit 1"
+  assert_contains "$out" "Usage:" "too many args -> usage on stderr"
+fi
+
+# ─── Summary ────────────────────────────────
+echo
+echo "─────────────────"
+echo "test-s.sh passed: $pass"
+echo "test-s.sh failed: $fail"
+if [ "$fail" -gt 0 ]; then
+  echo
+  printf '%s\n' "${fail_msgs[@]}"
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Adds a single user-facing `s` command that creates-or-attaches a tmux session for a git project — optionally creating a worktree+branch in one shot. Project list comes from `sesh list -c -j`; no separate registry.

- `s` (outside tmux): fzf picker over sesh-configured projects (filtered to git repos)
- `s <project>` (outside tmux): attach to project's main session
- `s <name>` (inside tmux): create worktree `<name>` in current project, switch to it
- `s <project> <name>` (anywhere): create worktree `<name>` in `<project>`, switch/attach
- Tmux session naming uses `/` separator (`<project>/<name>`) since tmux disallows `:` and `.`
- Idempotent: `tmux has-session` short-circuits before invoking `wt`, so re-running the same command attaches without creating a second worktree
- Branch name is used verbatim — no `worktree-` prefix (that's reserved for the `EnterWorktree` Claude Code workflow)

Design: spec at `tmp/specs/2026-04-30-s-worktree-session-design.md`, plan at `tmp/plans/2026-04-30-s-worktree-session.md` (both gitignored, kept locally).

## Test plan

- [x] Unit: bash scripts/test-helpers.sh passes (37 + 30 assertions, including PATH-shadowed sesh/wt/tmux/fzf shims for all 5 dispatch shapes plus negative cases)
- [x] Manual smoke (inside tmux, 1-arg inferred-project flow): s strava-timeline from inside dotfiles session created dotfiles/strava-timeline at the worktree path, switch-client worked
- [x] Manual smoke (outside tmux): user verified the project picker, 1-arg attach, and 2-arg create flows from a non-tmux terminal