### PR TITLE
feat(tmux): pass OSC 8 hyperlinks through to Ghostty

### DIFF
--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -11,7 +11,9 @@ if-shell 'infocmp tmux-256color >/dev/null 2>&1' \
   'set -g default-terminal "tmux-256color"' \
   'set -g default-terminal "screen-256color"'
 set -as terminal-features ",xterm-ghostty:RGB"
+set -as terminal-features ",xterm-ghostty:hyperlinks"
 set -as terminal-features ",xterm-256color:RGB"
+set -as terminal-features ",xterm-256color:hyperlinks"
 
 # ─── General ────────────────────────────────
 set -g mouse on  # URLs need Shift+Cmd+click in tmux — see README "Quirks"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,15 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
   `--tac` is intentional so the newest URL lands at the cursor — don't drop
   it. Don't replace with a custom shell script; the plugin already does
   regex extraction efficiently.
+- **OSC 8 hyperlinks pass through tmux to Ghostty.** Two `terminal-features`
+  declarations in `.config/tmux/tmux.conf` (`xterm-ghostty:hyperlinks` and
+  `xterm-256color:hyperlinks`) enable hyperlink passthrough; without them
+  tmux strips OSC 8 sequences and Claude Code's file-reference links don't
+  render. Don't remove. Routing of `file://` clicks is handled by the user's
+  existing macOS file-type defaults — the repo deliberately ships no `duti`
+  config, no Claude Code setting override, no Ghostty `link` rule. If the
+  user wants VS Code (or another editor) for a given extension, they set it
+  via Finder → Get Info → Open with → Change All.
 - **Sesh config is split: shared + machine-local.** The repo tracks
   `.config/sesh/sesh.toml` (symlinked into `~/.config/sesh/sesh.toml`)
   with a `Home 🏠` session for `~` and a top-level

--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ Personal config for Ghostty + zsh + tmux + vim, all in Solarized + JetBrainsMono
 - URLs in tmux panes open with **Shift+Cmd+click**, not Cmd+click.
 - Why: with `set -g mouse on`, Ghostty defers all mouse interactions (incl. URL hover/click detection) to tmux. Ghostty's default `mouse-shift-capture = false` makes Shift the bypass modifier — Shift releases the click from tmux and Cmd reaches Ghostty's URL handler.
 - Or, keyboard-only: `<prefix> u` opens an fzf picker of URLs from the current pane (visible + last 2000 lines), Enter opens in the default browser. Provided by [`wfxr/tmux-fzf-url`](https://github.com/wfxr/tmux-fzf-url).
+- File-reference links printed by Claude Code (OSC 8 hyperlinks to `file:///abs/path`) open with **Shift+Cmd+click** — same modifier as URLs. Routing to VS Code (or whichever editor) happens via the existing macOS file-type defaults (Finder → Get Info → "Open with" → "Change All"); no extra config in this repo.
+- Smoke-test that the chain works end-to-end:
+
+  ```sh
+  printf '\e]8;;file://%s/.zshrc\e\\.zshrc\e]8;;\e\\\n' "$HOME"
+  ```
+
+  Shift+Cmd+click the rendered "`.zshrc`" — your default `.zshrc` editor should open the file.
 
 ## Future work
 

--- a/docs/tmux-cheatsheet.html
+++ b/docs/tmux-cheatsheet.html
@@ -125,6 +125,7 @@
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">t</span></td><td class="desc">sesh picker popup (configured / tmux / zoxide / tmuxinator)</td></tr>
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">T</span></td><td class="desc">clock-mode <span class="muted">(swapped from default <code>t</code>)</span></td></tr>
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">u</span></td><td class="desc">URL picker (fzf, current pane + 2000 lines scrollback) — opens in default browser</td></tr>
+      <tr><td class="key"><span class="k">⇧⌘ click</span></td><td class="desc">Claude Code file links → routes via macOS file-type defaults (OSC 8 passthrough enabled in <code>tmux.conf</code> via <code>terminal-features hyperlinks</code>)</td></tr>
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">?</span></td><td class="desc">list all keybindings</td></tr>
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">:</span></td><td class="desc">command prompt</td></tr>
     </table>
@@ -423,7 +424,7 @@
 </table>
 
 <footer>
-  Built from <code>~/.config/tmux/tmux.conf</code> on 2026-04-29. Refresh after meaningful config changes.
+  Built from <code>~/.config/tmux/tmux.conf</code> on 2026-04-30. Refresh after meaningful config changes.
   <br>
   When in doubt: <span class="k prefix">C-a</span> <span class="k">?</span> for the live keymap list.
 </footer>


### PR DESCRIPTION
## Summary
- Add `terminal-features ",*:hyperlinks"` for `xterm-ghostty` and `xterm-256color` so tmux passes OSC 8 escape sequences through instead of stripping them
- Effect: file-reference links printed by Claude Code (and any other tool emitting OSC 8) become clickable inside tmux — same `shift+cmd+click` modifier as URLs
- No routing config in this repo: `file://` clicks open in whatever the user's existing macOS file-type defaults are set to (Finder → Get Info → "Open with" → "Change All"). Deliberately ships no `duti`, no Ghostty `link` rule, no Claude Code setting override
- README "Quirks" gets a smoke-test snippet, tmux cheatsheet gets a new row, CLAUDE.md gets a Conventions bullet

## Test plan
- [x] `tmux source-file ~/.config/tmux/tmux.conf` reloads cleanly
- [x] `tmux show -g terminal-features` lists `xterm-ghostty:hyperlinks` and `xterm-256color:hyperlinks`
- [x] After detach + reattach, `tmux display-message -p '#{client_termfeatures}'` includes `hyperlinks`
- [x] README smoke-test snippet renders an underlined hyperlink
- [x] `shift+cmd+click` on the rendered link opens `.zshrc` in the default editor for the file type
- [x] Cheatsheet renders correctly; footer date bumped

## Notes
Phase 2 (a `<prefix> o` keyboard picker that opens the file in a session-scoped nvim) is not in this PR. It's planned to ship in a separate worktree off updated main per the dotfiles branching policy.