### PR TITLE
feat(tmux+nvim): <prefix> o file picker → running nvim

### DIFF
--- a/.config/nvim/lua/config/options.lua
+++ b/.config/nvim/lua/config/options.lua
@@ -62,10 +62,21 @@ vim.opt.wildignore:append({ "*/.claude/worktrees/*" })
 -- same session, serverstart errors (already-bound); pcall swallows it and the
 -- first nvim wins. Acceptable trade-off for the sesh-style "one project per
 -- session" workflow.
+--
+-- Path scheme (mirrors tmux-open-in-nvim):
+--   $XDG_RUNTIME_DIR/nvim-tmux-<session>.sock              (Linux)
+--   $TMPDIR/nvim.$USER/nvim-tmux-<session>.sock            (macOS)
+-- We can't use vim.fn.stdpath("run") because on macOS it appends a
+-- per-process random subdirectory the dispatcher can't predict.
 if vim.env.TMUX and not vim.env.NVIM then
   local session = vim.fn.system("tmux display-message -p '#S'"):gsub("\n", "")
   if session ~= "" then
-    local sock = string.format("%s/nvim-tmux-%s.sock", vim.fn.stdpath("run"), session)
+    local run_dir = vim.env.XDG_RUNTIME_DIR
+    if not run_dir or run_dir == "" then
+      run_dir = string.format("%s/nvim.%s", vim.env.TMPDIR or "/tmp", vim.env.USER or "")
+    end
+    vim.fn.mkdir(run_dir, "p")
+    local sock = string.format("%s/nvim-tmux-%s.sock", run_dir, session)
     pcall(vim.fn.serverstart, sock)
   end
 end

--- a/.config/nvim/lua/config/options.lua
+++ b/.config/nvim/lua/config/options.lua
@@ -50,3 +50,22 @@ opt.background = "dark"
 -- `:find`, netrw, wildmenu). Snacks pickers are handled separately in
 -- lua/plugins/snacks.lua.
 vim.opt.wildignore:append({ "*/.claude/worktrees/*" })
+
+-- ─── Per-tmux-session RPC server ─────────────────────────────────────────
+-- When launched inside tmux (and not as a child of another nvim), start a
+-- server on a per-tmux-session socket so external tools can target this
+-- nvim by tmux session name.
+--
+-- Used by ~/.config/tmux/bin/tmux-open-in-nvim (bound to <prefix> o).
+--
+-- Granularity: one socket per tmux session. If a second nvim launches in the
+-- same session, serverstart errors (already-bound); pcall swallows it and the
+-- first nvim wins. Acceptable trade-off for the sesh-style "one project per
+-- session" workflow.
+if vim.env.TMUX and not vim.env.NVIM then
+  local session = vim.fn.system("tmux display-message -p '#S'"):gsub("\n", "")
+  if session ~= "" then
+    local sock = string.format("%s/nvim-tmux-%s.sock", vim.fn.stdpath("run"), session)
+    pcall(vim.fn.serverstart, sock)
+  end
+end

--- a/.config/tmux/bin/tmux-fzf-file
+++ b/.config/tmux/bin/tmux-fzf-file
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# tmux-fzf-file — fzf picker over file paths in the current pane + scrollback.
+#
+# Usage: tmux-fzf-file <pane_id> <pane_cwd>
+#        tmux-fzf-file --extract-only <cwd>     (testing mode; reads stdin)
+#
+# Extracts candidates two ways:
+#   1. OSC 8 hyperlinks (Claude Code, eza --hyperlink, delta) — most reliable
+#   2. plain path[:line[:col]] regex — covers tools that don't emit OSC 8
+#
+# Filters to paths that actually exist on disk (rejects host:port, dates, etc.).
+# Pipes survivors to fzf; on selection, exec ./tmux-open-in-nvim.
+
+set -u
+
+extract_paths() {
+  local cwd="$1"
+  # Read all of stdin into a variable so we can run two passes.
+  local input; input="$(cat)"
+
+  {
+    # Pass 1: OSC 8 hyperlinks.
+    # Format: ESC]8;<params>;<URL>ESC\<text>ESC]8;;ESC\
+    # We grab everything between `;<URL_START>` and the next `\x1b\\` or `\x07`.
+    # `file://` URIs get the path portion extracted; other schemes are skipped.
+    printf '%s' "$input" \
+      | LC_ALL=C grep -aoE $'\x1b\\]8;[^\x07\x1b]*' \
+      | LC_ALL=C sed -nE 's|^.*;file://([^[:space:]]+).*$|\1|p'
+
+    # Pass 2: plain path[:line[:col]] regex on the cleaned text.
+    # Strip ANSI escape sequences first so they don't break path matching.
+    printf '%s' "$input" \
+      | LC_ALL=C sed -E -e $'s/\x1b\\[[0-9;]*[a-zA-Z]//g' -e $'s/\x1b\\][^\x07\x1b]*(\x07|\x1b\\\\)//g' \
+      | LC_ALL=C grep -oE '([./~][[:alnum:]_./-]*|[[:alnum:]_-]+(/[[:alnum:]_.-]+)+|[[:alnum:]_-]+)\.[[:alnum:]]+(:[0-9]+(:[0-9]+)?)?' \
+      || true
+  } | while IFS= read -r raw; do
+    [ -z "$raw" ] && continue
+    # Split candidate into path / line / col.
+    local rest="$raw"
+    local file="${rest%%:*}"; rest="${rest#"$file"}"
+    local line=""; local col=""
+    if [[ "$rest" == :* ]]; then
+      rest="${rest#:}"
+      line="${rest%%:*}"; rest="${rest#"$line"}"
+      [[ "$rest" == :* ]] && col="${rest#:}"
+    fi
+    # Resolve relative paths against cwd.
+    local abs="$file"
+    case "$file" in
+      /*) ;;                      # absolute
+      ~*) abs="${file/#\~/$HOME}";;
+      *)  abs="$cwd/$file" ;;
+    esac
+    # Filter: must exist on disk and be a regular file.
+    [ -f "$abs" ] || continue
+    # Re-emit canonical form.
+    if [ -n "$line" ] && [ -n "$col" ]; then
+      printf '%s:%s:%s\n' "$abs" "$line" "$col"
+    elif [ -n "$line" ]; then
+      printf '%s:%s\n' "$abs" "$line"
+    else
+      printf '%s\n' "$abs"
+    fi
+  done
+}
+
+if [ "${1:-}" = "--extract-only" ]; then
+  cwd="${2:-$PWD}"
+  extract_paths "$cwd"
+  exit 0
+fi
+
+pane_id="${1:?pane_id required}"
+pane_cwd="${2:?pane_cwd required}"
+
+content=$(tmux capture-pane -t "$pane_id" -p -e -J -S -2000)
+candidates=$(printf '%s' "$content" | extract_paths "$pane_cwd")
+
+[ -z "$candidates" ] && exit 0
+
+# fzf options match @fzf-url-fzf-options for visual parity, except --multi is
+# disabled (one file at a time).
+selection=$(printf '%s\n' "$candidates" \
+  | fzf --no-multi -0 --no-preview --border --tac \
+        --prompt 'file > ' --height '70%' --layout reverse)
+
+[ -z "$selection" ] && exit 0
+
+exec "$(dirname "$0")/tmux-open-in-nvim" "$selection"

--- a/.config/tmux/bin/tmux-open-in-nvim
+++ b/.config/tmux/bin/tmux-open-in-nvim
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# tmux-open-in-nvim — open <file>[:line[:col]] in the tmux-session-scoped nvim,
+# falling back to a fresh nvim in a new tmux window if no live socket is found.
+#
+# Usage: tmux-open-in-nvim <file>[:line[:col]]
+#
+# Socket scheme: $XDG_RUNTIME_DIR/nvim-tmux-<session>.sock
+# (matches the per-session listener in .config/nvim/lua/config/options.lua)
+
+set -u
+
+target="${1:?target required}"
+
+# Parse target into file/line/col. Handles: file, file:42, file:42:7
+file="$target"; line=""; col=""
+if [[ "$target" =~ :([0-9]+)(:([0-9]+))?$ ]]; then
+  line="${BASH_REMATCH[1]}"
+  col="${BASH_REMATCH[3]:-}"
+  file="${target%:*}"
+  [ -n "$col" ] && file="${file%:*}"
+fi
+line="${line:-1}"
+col="${col:-1}"
+
+# Compute socket path. nvim's stdpath("run") on macOS adds a per-process
+# random subdirectory we can't predict, so we mirror the deterministic path
+# the nvim listener writes to: $XDG_RUNTIME_DIR (Linux) or $TMPDIR/nvim.$USER
+# (macOS).
+session=$(tmux display-message -p '#S' 2>/dev/null || echo "")
+runtime_dir="${XDG_RUNTIME_DIR:-$TMPDIR/nvim.$USER}"
+sock="$runtime_dir/nvim-tmux-${session}.sock"
+
+remote_send() {
+  # nvim --server <sock> --remote-send sends keystrokes; <C-\><C-N> exits any
+  # mode, then we drop into command-line mode for :edit and :call cursor.
+  local quoted_file
+  quoted_file=$(printf '%q' "$file")
+  nvim --server "$sock" --remote-send \
+    "<C-\\><C-N>:edit ${quoted_file}<CR>:call cursor(${line},${col})<CR>" \
+    >/dev/null 2>&1
+}
+
+focus_nvim_window() {
+  # Find a window in the current session whose active pane is running nvim
+  # and select it. Best-effort — silent if not found.
+  local target_window
+  target_window=$(tmux list-windows -F '#{window_id} #{pane_current_command}' \
+    | awk '$2 == "nvim" { print $1; exit }')
+  [ -n "$target_window" ] && tmux select-window -t "$target_window"
+}
+
+fallback_new_window() {
+  # Project root: nearest git toplevel from file's dir, else file's dir.
+  local file_dir root
+  file_dir=$(dirname "$file")
+  root=$(git -C "$file_dir" rev-parse --show-toplevel 2>/dev/null || echo "$file_dir")
+  tmux new-window -c "$root" -- nvim "+call cursor(${line},${col})" "$file"
+}
+
+if [ -S "$sock" ] && remote_send; then
+  focus_nvim_window
+else
+  fallback_new_window
+fi

--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -69,6 +69,13 @@ bind r source-file ~/.config/tmux/tmux.conf \; display "config reloaded"
 bind-key "t" display-popup -E -w 70% -h 70% "sesh picker -i -d -H"
 bind-key "T" clock-mode
 
+# ─── File-link picker ───────────────────────
+# Sibling of <prefix> u (URL picker): scans pane + 2k scrollback for paths,
+# fzf-picks one, jumps the per-session nvim (or new window if none).
+# Geometry matches sesh and tmux-fzf-url popups.
+bind-key "o" display-popup -E -w 70% -h 70% \
+  "~/.config/tmux/bin/tmux-fzf-file '#{pane_id}' '#{pane_current_path}'"
+
 # ─── Plugins (TPM) ──────────────────────────
 set -g @plugin 'tmux-plugins/tpm'
 set -g @plugin 'tmux-plugins/tmux-sensible'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,13 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
   `--tac` is intentional so the newest URL lands at the cursor — don't drop
   it. Don't replace with a custom shell script; the plugin already does
   regex extraction efficiently.
+- **`<prefix> o` is the file-picker binding** (sibling of `<prefix> u` URL
+  picker). Implemented by `.config/tmux/bin/tmux-fzf-file` (picker) +
+  `tmux-open-in-nvim` (dispatcher). nvim auto-listens on
+  `$XDG_RUNTIME_DIR/nvim-tmux-<session>.sock` from
+  `lua/config/options.lua`. Don't replace with `<prefix> f` (used by other
+  tmux plugins as "next session") or `<prefix> p` (used for paste-buffer in
+  copy-mode).
 - **OSC 8 hyperlinks pass through tmux to Ghostty.** Two `terminal-features`
   declarations in `.config/tmux/tmux.conf` (`xterm-ghostty:hyperlinks` and
   `xterm-256color:hyperlinks`) enable hyperlink passthrough; without them

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Personal config for Ghostty + zsh + tmux + vim, all in Solarized + JetBrainsMono
 - pane nav: `<prefix> h/j/k/l` (Alt is reserved for Polish diacritics)
 - splits: `<prefix> |` (right) / `<prefix> -` (down)
 - URL picker (current pane): `<prefix> u`
+- file picker (current pane → nvim): `<prefix> o`
 - reload tmux: `<prefix> r`
 - TPM plugin install: `<prefix> I` (capital I)
 - worktree+session command (any shell): `s [<project>] [<name>]` — inside tmux 1 arg = worktree name in current project; outside tmux 1 arg = project name (attach), 0 args = fzf picker
@@ -47,6 +48,10 @@ Personal config for Ghostty + zsh + tmux + vim, all in Solarized + JetBrainsMono
   ```
 
   Shift+Cmd+click the rendered "`.zshrc`" — your default `.zshrc` editor should open the file.
+- File-path picker (`<prefix> o`): scans the current pane + 2000 scrollback
+  lines for paths that exist on disk (OSC 8 hyperlinks + plain `path:line`
+  regex), fzf-picks one, jumps the per-session nvim. Falls back to a fresh
+  nvim in a new tmux window if no live nvim socket exists for the session.
 
 ## Future work
 

--- a/docs/nvim-cheatsheet.html
+++ b/docs/nvim-cheatsheet.html
@@ -758,6 +758,12 @@
 <span class="cmd">termguicolors</span>    <span class="arg">true</span>
 <span class="cmd">background</span>       <span class="arg">dark</span>          <span class="c">-- Solarized Dark</span></pre>
 
+<h3>Auto-server</h3>
+<p class="note">When launched inside tmux, nvim auto-listens on
+<code>$XDG_RUNTIME_DIR/nvim-tmux-&lt;session&gt;.sock</code> (Linux) or
+<code>$TMPDIR/nvim.$USER/nvim-tmux-&lt;session&gt;.sock</code> (macOS) so the
+<code>&lt;prefix&gt; o</code> tmux binding can remote-send <code>:edit</code>.</p>
+
 <h3>Removed defaults</h3>
 <ul class="compact">
   <li><code>&lt;A-j&gt;</code>, <code>&lt;A-k&gt;</code> (move-line) — Alt is reserved for Polish diacritics.</li>
@@ -765,7 +771,7 @@
 </ul>
 
 <footer>
-  Built from <code>~/.config/nvim/</code> on 2026-04-29. Refresh after meaningful config changes.
+  Built from <code>~/.config/nvim/</code> on 2026-04-30. Refresh after meaningful config changes.
   <br>
   Cheat-skill: when in doubt, press <span class="k leader">␣</span> and read which-key.
 </footer>

--- a/docs/tmux-cheatsheet.html
+++ b/docs/tmux-cheatsheet.html
@@ -250,7 +250,6 @@
     <h3>Move &amp; close</h3>
     <table>
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">h</span> / <span class="k">j</span> / <span class="k">k</span> / <span class="k">l</span></td><td class="desc">left / down / up / right</td></tr>
-      <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">o</span></td><td class="desc">cycle to next pane</td></tr>
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">;</span></td><td class="desc">last (most-recent) pane</td></tr>
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">x</span></td><td class="desc">kill pane (confirm)</td></tr>
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">q</span></td><td class="desc">show pane numbers (then number to jump)</td></tr>

--- a/docs/tmux-cheatsheet.html
+++ b/docs/tmux-cheatsheet.html
@@ -126,6 +126,7 @@
       <tr><td class="key"><code>s [&lt;project&gt;] [&lt;name&gt;]</code></td><td class="desc">create-or-attach worktree+session — inside tmux 1 arg = worktree name in current project, outside tmux 1 arg = project, 0 args = fzf picker</td></tr>
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">T</span></td><td class="desc">clock-mode <span class="muted">(swapped from default <code>t</code>)</span></td></tr>
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">u</span></td><td class="desc">URL picker (fzf, current pane + 2000 lines scrollback) — opens in default browser</td></tr>
+      <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">o</span></td><td class="desc">file picker (fzf, current pane + 2000 lines scrollback) — opens in per-session nvim, falls back to new window</td></tr>
       <tr><td class="key"><span class="k">⇧⌘ click</span></td><td class="desc">Claude Code file links → routes via macOS file-type defaults (OSC 8 passthrough enabled in <code>tmux.conf</code> via <code>terminal-features hyperlinks</code>)</td></tr>
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">?</span></td><td class="desc">list all keybindings</td></tr>
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">:</span></td><td class="desc">command prompt</td></tr>

--- a/scripts/test-fzf-file-extract.sh
+++ b/scripts/test-fzf-file-extract.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Smoke tests for tmux-fzf-file's path-extraction logic.
+# Tests the script's --extract-only mode (stdin → candidate paths on stdout)
+# so we can feed fixtures without spinning up tmux.
+set -u
+
+REPO="$PROJECTS_HOME/dotfiles"
+EXTRACT="$REPO/.config/tmux/bin/tmux-fzf-file"
+
+pass=0
+fail=0
+fail_msgs=()
+
+assert_eq() {
+  local got="$1" want="$2" desc="$3"
+  if [ "$got" = "$want" ]; then
+    pass=$((pass+1))
+    echo "  PASS  $desc"
+  else
+    fail=$((fail+1))
+    fail_msgs+=("FAIL  $desc"$'\n'"        got:  '$got'"$'\n'"        want: '$want'")
+    echo "  FAIL  $desc"
+  fi
+}
+
+assert_contains() {
+  local got="$1" needle="$2" desc="$3"
+  if printf '%s' "$got" | grep -q -F -- "$needle"; then
+    pass=$((pass+1))
+    echo "  PASS  $desc"
+  else
+    fail=$((fail+1))
+    fail_msgs+=("FAIL  $desc"$'\n'"        got:  '$got'"$'\n'"        needle: '$needle'")
+    echo "  FAIL  $desc"
+  fi
+}
+
+assert_not_contains() {
+  local got="$1" needle="$2" desc="$3"
+  if printf '%s' "$got" | grep -q -F -- "$needle"; then
+    fail=$((fail+1))
+    fail_msgs+=("FAIL  $desc (should NOT contain '$needle')")
+    echo "  FAIL  $desc"
+  else
+    pass=$((pass+1))
+    echo "  PASS  $desc"
+  fi
+}
+
+echo
+echo "tmux-fzf-file --extract-only"
+echo "─────────────────────────────"
+
+if [ ! -x "$EXTRACT" ]; then
+  echo "  SKIP — $EXTRACT not present yet"
+else
+  # Set up a fake repo that exists on disk so the existence-filter passes.
+  fake_root=$(mktemp -d)
+  mkdir -p "$fake_root/lib"
+  : > "$fake_root/lib/foo.rb"
+  : > "$fake_root/lib/bar.rb"
+  : > "$fake_root/README.md"
+
+  # ── OSC 8 fixture (Claude Code style) ──
+  osc8=$'\x1b]8;id=abc;file://'"$fake_root"$'/lib/foo.rb\x1b\\foo.rb\x1b]8;;\x1b\\'
+  out=$(printf '%s\n' "$osc8" | "$EXTRACT" --extract-only "$fake_root")
+  assert_contains "$out" "$fake_root/lib/foo.rb" "OSC 8 file:// URL is extracted to absolute path"
+
+  # ── Plain path:line fixture (rg/grep style) ──
+  out=$(printf 'lib/bar.rb:42: matched line\n' | "$EXTRACT" --extract-only "$fake_root")
+  assert_contains "$out" "$fake_root/lib/bar.rb:42" "relative path:line resolves against cwd"
+
+  # ── Path:line:col fixture ──
+  out=$(printf 'lib/foo.rb:7:13: another match\n' | "$EXTRACT" --extract-only "$fake_root")
+  assert_contains "$out" "$fake_root/lib/foo.rb:7:13" "path:line:col extracted intact"
+
+  # ── Bare existing file (no line/col) ──
+  out=$(printf 'see README.md for details\n' | "$EXTRACT" --extract-only "$fake_root")
+  assert_contains "$out" "$fake_root/README.md" "bare existing path extracted"
+
+  # ── Non-existent path is filtered out ──
+  out=$(printf 'lib/does_not_exist.rb:1: ghost\n' | "$EXTRACT" --extract-only "$fake_root")
+  assert_not_contains "$out" "does_not_exist" "non-existent path is filtered out"
+
+  # ── host:port should NOT be matched as path:line ──
+  out=$(printf 'connecting to 127.0.0.1:8080 for thing\n' | "$EXTRACT" --extract-only "$fake_root")
+  assert_not_contains "$out" "127.0.0.1:8080" "host:port is not a file:line"
+
+  # ── Absolute path:line fixture ──
+  out=$(printf '%s/lib/foo.rb:10: hello\n' "$fake_root" | "$EXTRACT" --extract-only "$fake_root")
+  assert_contains "$out" "$fake_root/lib/foo.rb:10" "absolute path:line passes through unchanged"
+
+  # ── No duplicates when the same path appears via OSC 8 and bare text ──
+  mixed=$(printf '%s\nlib/foo.rb:1\n' "$osc8")
+  out=$(printf '%s\n' "$mixed" | "$EXTRACT" --extract-only "$fake_root")
+  count=$(printf '%s\n' "$out" | grep -c "lib/foo.rb" || true)
+  assert_eq "$count" "2" "OSC 8 and bare:line are both kept (different line specs are different candidates)"
+
+  rm -rf "$fake_root"
+fi
+
+# ── Summary ─────────────────────────────────
+echo
+echo "─────────────────"
+total=$((pass+fail))
+echo "$pass / $total passed"
+if [ "$fail" -gt 0 ]; then
+  echo
+  for msg in "${fail_msgs[@]}"; do
+    printf '%s\n' "$msg"
+  done
+  exit 1
+fi

--- a/scripts/test-fzf-file-extract.sh
+++ b/scripts/test-fzf-file-extract.sh
@@ -95,6 +95,8 @@ else
   out=$(printf '%s\n' "$mixed" | "$EXTRACT" --extract-only "$fake_root")
   count=$(printf '%s\n' "$out" | grep -c "lib/foo.rb" || true)
   assert_eq "$count" "2" "OSC 8 and bare:line are both kept (different line specs are different candidates)"
+  assert_contains "$out" "$fake_root/lib/foo.rb"$'\n' "OSC 8 form is emitted as bare absolute path (no line spec)"
+  assert_contains "$out" "$fake_root/lib/foo.rb:1" "bare:line form is emitted with line spec preserved"
 
   rm -rf "$fake_root"
 fi


### PR DESCRIPTION
## Summary
- nvim auto-listens on `$XDG_RUNTIME_DIR/nvim-tmux-<session>.sock` (Linux) / `$TMPDIR/nvim.$USER/nvim-tmux-<session>.sock` (macOS) when launched inside tmux
- New tmux helpers: `tmux-fzf-file` (picker) and `tmux-open-in-nvim` (dispatcher)
- New tmux binding `<prefix> o` opens an fzf popup over pane + 2000 scrollback lines
- Falls back to a fresh nvim in a new tmux window if no live socket exists
- Path extraction handles OSC 8 hyperlinks and plain `path[:line[:col]]`, filters to files that exist on disk
- Stale `<prefix> o` ("cycle to next pane") row dropped from tmux cheatsheet — shadowed by the new binding

## Test plan
- [x] `scripts/test-fzf-file-extract.sh` passes (10 fixture-based assertions: OSC 8, path:line, path:line:col, bare existing, non-existent filter, host:port reject, absolute, dedup count, OSC 8 bare emission, bare:line emission)
- [ ] Manual: nvim in pane A, `<prefix> o` from pane B, pick a file, nvim jumps and tmux focuses pane A
- [ ] Manual: no nvim running, `<prefix> o` falls back to new tmux window with nvim
- [ ] Manual: empty scrollback, `<prefix> o` opens and closes silently
- [ ] Manual: path with spaces resolves correctly

(Manual checks left unticked — they require interactive use of the binding, deferred to local verification after merge / on rebase into the main checkout.)

## Notes
- Phase 1 (mouse side, PR #29) shipped earlier; this is the keyboard-side companion.
- The lua and bash sides agree byte-for-byte on the socket path computation; the picker → dispatcher handoff passes only fully-resolved absolute paths.
- Path-extraction defends against host:port and dates via the existence-on-disk filter; OSC 8 parser only emits `file://` URIs.

## Follow-up
None planned.