### PR TITLE
docs: README setup section + cheatsheet drift fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,10 +157,10 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
 ## Where things live
 
 - Sources: `$PROJECTS_HOME/dotfiles/{.config,.vimrc,.vim/colors,.zshrc,.p10k.zsh,.claude/CLAUDE.md}` (`.config/` includes `nvim/`, `worktrunk/`, `glow/`)
-- Targets: `~/.config/{ghostty,tmux,ccstatusline,nvim,worktrunk,glow}`, `~/.vimrc`, `~/.vim/colors`, `~/.zshrc`, `~/.p10k.zsh`, `~/.claude/CLAUDE.md`
+- Targets: `~/.config/{ghostty,tmux,ccstatusline,nvim,worktrunk,glow}`, `~/.config/sesh/sesh.toml`, `~/.local/bin/<command>`, `~/.vimrc`, `~/.vim/colors`, `~/.zshrc`, `~/.p10k.zsh`, `~/.claude/CLAUDE.md`
 - The repo's `.claude/CLAUDE.md` IS the user-global Claude config (symlinked to `~/.claude/CLAUDE.md`). Edits there apply to every project on this machine, not just dotfiles.
 - Machine-specific overrides: `~/.zshrc.local` (untracked; copy from `.zshrc.local.template`)
-- Helpers: `.config/tmux/bin/{tmux-project-name,tmux-git-status,claude-tmux-window-name}`
+- Helpers: `.config/tmux/bin/{tmux-project-name,tmux-git-status,claude-tmux-window-name,tmux-fzf-file,tmux-open-in-nvim}`
 - Smoke tests for helpers: `scripts/test-helpers.sh`
 
 ## Cheatsheets (`docs/`)
@@ -191,6 +191,7 @@ served at `https://martinciu.github.io/dotfiles/` via GitHub Pages
 ## Verify changes
 
 - Helper smoke tests: `scripts/test-helpers.sh`
+- File-picker path-extraction tests: `scripts/test-fzf-file-extract.sh`
 - Zsh prompt-context tests: `scripts/test-prompt-context.zsh`
 - Tmux window-label tests: `scripts/test-tmux-window-label.zsh`
 - Claude tmux window-name tests: `scripts/test-claude-tmux-window-name.zsh`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,7 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
   `claude[<name>]`. Set/cleared by `~/.config/tmux/bin/claude-tmux-window-name`
   via Claude Code hooks (`SessionStart`, `Stop`, `SessionEnd`) wired in
   `~/.claude/settings.json`. The hook config is per-machine (not symlinked
-  from this repo — see "First-time setup on a new machine"). The script's
+  from this repo — see [`README.md`](README.md) → "Setup (new machine)"). The script's
   test mock and the script itself live separately —
   `scripts/test-claude-tmux-window-name.zsh` exercises the script through a
   temp `$HOME` and a `tmux` PATH shim, so no in-place duplication of logic.
@@ -136,7 +136,7 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
   fzf-tab needs fzf's `^I` binding already in place and must be sourced
   before any plugin that wraps widgets. The first-time `git config`
   recipe wiring delta as git's pager
-  lives in **First-time setup on a new machine** below.
+  lives in [`README.md`](README.md) → "Setup (new machine)".
 - **Interactive `less` is a `bat` wrapper** (defined in `.zshrc` next to the
   `cat` alias). Files get bat's full decoration; piped input uses `--plain` so
   `cmd | less` stays clean. `command less` reaches real `less` for `less +F`,
@@ -201,35 +201,4 @@ served at `https://martinciu.github.io/dotfiles/` via GitHub Pages
 
 ## First-time setup on a new machine
 
-After `brew bundle` and `bootstrap.sh`, run once to wire git → delta:
-
-```bash
-git config --global core.pager delta
-git config --global interactive.diffFilter "delta --color-only"
-git config --global delta.navigate true
-git config --global delta.line-numbers true
-git config --global delta.syntax-theme "Solarized (dark)"
-```
-
-Then add the Claude Code hooks that drive the `claude[<name>]` window title.
-Open `~/.claude/settings.json` and add (or merge into) these top-level
-entries inside the `hooks` object:
-
-```json
-"SessionStart": [
-  { "hooks": [ { "type": "command",
-    "command": "~/.config/tmux/bin/claude-tmux-window-name set" } ] }
-],
-"Stop": [
-  { "hooks": [ { "type": "command",
-    "command": "~/.config/tmux/bin/claude-tmux-window-name set" } ] }
-],
-"SessionEnd": [
-  { "hooks": [ { "type": "command",
-    "command": "~/.config/tmux/bin/claude-tmux-window-name clear" } ] }
-]
-```
-
-`~/.claude/settings.json` is not symlinked from this repo (it accumulates
-machine-local permission state), so this is a one-time manual edit per
-machine.
+See [`README.md`](README.md) → "Setup (new machine)".

--- a/README.md
+++ b/README.md
@@ -75,16 +75,19 @@ These drive the `claude[<name>]` window title (tmux's
 
 ## What's where
 
-| Tool      | Source path                          | Target              |
-| --------- | ------------------------------------ | ------------------- |
-| Ghostty   | `.config/ghostty/`                   | `~/.config/ghostty` |
-| tmux      | `.config/tmux/`                      | `~/.config/tmux`    |
-| nvim      | `.config/nvim/`                      | `~/.config/nvim`    |
-| vim       | `.vimrc`, `.vim/colors/`             | `~/.vimrc`, `~/.vim/colors` |
-| zsh       | `.zshrc`, `.p10k.zsh`                | `~/.zshrc`, `~/.p10k.zsh` |
-| sesh      | `.config/sesh/sesh.toml`             | `~/.config/sesh/sesh.toml` |
-| worktrunk | `.config/worktrunk/config.toml`      | `~/.config/worktrunk/config.toml` |
-| glow      | `.config/glow/glamour.json`          | `~/.config/glow/glamour.json` |
+| Tool         | Source path                          | Target              |
+| ------------ | ------------------------------------ | ------------------- |
+| Ghostty      | `.config/ghostty/`                   | `~/.config/ghostty` |
+| tmux         | `.config/tmux/`                      | `~/.config/tmux`    |
+| nvim         | `.config/nvim/`                      | `~/.config/nvim`    |
+| vim          | `.vimrc`, `.vim/colors/`             | `~/.vimrc`, `~/.vim/colors` |
+| zsh          | `.zshrc`, `.p10k.zsh`                | `~/.zshrc`, `~/.p10k.zsh` |
+| sesh         | `.config/sesh/sesh.toml`             | `~/.config/sesh/sesh.toml` |
+| worktrunk    | `.config/worktrunk/`                 | `~/.config/worktrunk` |
+| glow         | `.config/glow/`                      | `~/.config/glow` |
+| ccstatusline | `.config/ccstatusline/`              | `~/.config/ccstatusline` |
+| Claude       | `.claude/CLAUDE.md`                  | `~/.claude/CLAUDE.md` |
+| user bin     | `bin/*` (e.g. `s`)                   | `~/.local/bin/*`    |
 
 ## Keymaps quick-ref
 

--- a/docs/shell-colors-cheatsheet.html
+++ b/docs/shell-colors-cheatsheet.html
@@ -428,6 +428,8 @@
 <!-- ═══════════════════════════════════════════════════════════════════════ -->
 <h2 id="bootstrap">Bootstrap a new machine</h2>
 
+<p class="note">Full new-machine setup is in <a href="../README.md"><code>README.md</code></a> &rarr; "Setup (new machine)". The steps below are the shell-colors-relevant subset.</p>
+
 <pre><span class="c"># 1) Brew packages</span>
 <span class="cmd">brew bundle</span> --file=<span class="arg">$PROJECTS_HOME/dotfiles/Brewfile</span>
 
@@ -448,9 +450,11 @@
 
 <h3>Plugin source order in <code>.zshrc</code> (do not reorder)</h3>
 <ol class="compact">
-  <li><code>zsh-autosuggestions.zsh</code></li>
-  <li>fzf <code>completion.zsh</code> + <code>key-bindings.zsh</code></li>
+  <li>fzf <code>completion.zsh</code> + <code>key-bindings.zsh</code> &mdash; binds <code>^I</code></li>
   <li><code>bindkey -r '^[c'</code> &mdash; remove fzf's Alt-C binding (Polish diacritics)</li>
+  <li><code>zoxide init zsh</code></li>
+  <li><code>fzf-tab.zsh</code> &mdash; needs fzf's <code>^I</code> already bound; must be before any plugin that wraps widgets</li>
+  <li><code>zsh-autosuggestions.zsh</code></li>
   <li><code>zsh-syntax-highlighting.zsh</code> &mdash; <strong>must be last</strong></li>
 </ol>
 

--- a/docs/tmux-cheatsheet.html
+++ b/docs/tmux-cheatsheet.html
@@ -298,6 +298,9 @@
     <table>
       <tr><td class="key"><code>~/.config/tmux/bin/tmux-project-name</code></td><td class="desc">prints the project label for the right side</td></tr>
       <tr><td class="key"><code>~/.config/tmux/bin/tmux-git-status</code></td><td class="desc">git/worktree status segment, colors as args</td></tr>
+      <tr><td class="key"><code>~/.config/tmux/bin/claude-tmux-window-name</code></td><td class="desc">sets/clears <code>@claude_session_name</code> from Claude Code hooks (drives <code>claude[&lt;name&gt;]</code> window title)</td></tr>
+      <tr><td class="key"><code>~/.config/tmux/bin/tmux-fzf-file</code></td><td class="desc">scans pane + scrollback for paths, fzf picker — backs <span class="k prefix">C-a</span> <span class="k">o</span></td></tr>
+      <tr><td class="key"><code>~/.config/tmux/bin/tmux-open-in-nvim</code></td><td class="desc">remote-sends <code>:edit</code> to the per-session nvim socket; falls back to a fresh nvim in a new window</td></tr>
       <tr><td class="key"><code>scripts/test-helpers.sh</code></td><td class="desc">smoke-tests for the helpers</td></tr>
     </table>
     <p class="note">Worktree detection uses <code>git rev-parse --git-dir</code> vs <code>--git-common-dir</code> so it works for <code>.claude/worktrees/*</code>, worktrunk paths, and sibling worktrees alike.</p>
@@ -367,6 +370,7 @@
   <tr><td class="key"><span class="k prefix">C-a</span><span class="k">r</span></td><td class="desc">reload config inside running tmux</td></tr>
   <tr><td class="key"><code>scripts/test-helpers.sh</code></td><td class="desc">smoke-tests for status helpers</td></tr>
   <tr><td class="key"><code>scripts/test-tmux-window-label.zsh</code></td><td class="desc">window-label extraction tests (mirror of <code>_tmux_window_label</code> in <code>.zshrc</code>)</td></tr>
+  <tr><td class="key"><code>scripts/test-fzf-file-extract.sh</code></td><td class="desc">file-picker path-extraction tests (regex + OSC 8)</td></tr>
   <tr><td class="key"><code>scripts/test-claude-tmux-window-name.zsh</code></td><td class="desc">tests for the <code>claude[&lt;name&gt;]</code> window-title helper</td></tr>
 </table>
 


### PR DESCRIPTION
## Summary

- Add a "Setup (new machine)" section to README with the full clone-to-working ordered list and the four manual extras `bootstrap.sh` cannot automate.
- Audit the README's "What's where" table — add rows for `ccstatusline`, `.claude/CLAUDE.md`, and `bin/*`; correct `worktrunk` and `glow` rows to reflect directory-level symlinks.
- Replace CLAUDE.md's "First-time setup on a new machine" section with a one-line pointer to README; update the two in-line cross-references.
- Fix `docs/tmux-cheatsheet.html` — Status helpers card now lists all five helpers (`tmux-project-name`, `tmux-git-status`, `claude-tmux-window-name`, `tmux-fzf-file`, `tmux-open-in-nvim`); verify table includes `test-fzf-file-extract.sh`.
- Fix `docs/shell-colors-cheatsheet.html` — plugin source order list now matches `.zshrc` (6 items, correct order); Bootstrap section links to README for the full setup.
- `docs/nvim-cheatsheet.html` audited; no drift found.

## Test plan

- [ ] `glow README.md` — Setup section reads cleanly, manual extras have intact code blocks.
- [ ] `bash bootstrap.sh` from a clean home — confirm the README's ordered list matches what bootstrap actually does.
- [ ] `open docs/tmux-cheatsheet.html` — Status helpers shows 5 rows, verify table shows all 5 test scripts.
- [ ] `open docs/shell-colors-cheatsheet.html` — plugin source order list has 6 items in `.zshrc` order; Bootstrap section has README link.
- [ ] `grep -n "First-time setup" CLAUDE.md` — only the heading remains; no "below" or "see" pointers using that phrase.