### PR TITLE
Prep for public release: MIT LICENSE + README cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,7 +224,3 @@ entries inside the `hooks` object:
 `~/.claude/settings.json` is not symlinked from this repo (it accumulates
 machine-local permission state), so this is a one-time manual edit per
 machine.
-
-## Out of scope (future work, separate spec)
-
-- Lifting API tokens out of `~/.zshrc` into `~/.secrets`

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Marcin Ciunelis
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,3 @@ Personal config for Ghostty + zsh + tmux + vim, all in Solarized + JetBrainsMono
   lines for paths that exist on disk (OSC 8 hyperlinks + plain `path:line`
   regex), fzf-picks one, jumps the per-session nvim. Falls back to a fresh
   nvim in a new tmux window if no live nvim socket exists for the session.
-
-## Future work
-
-- Lift API tokens out of `~/.zshrc` into a gitignored `~/.secrets`


### PR DESCRIPTION
## Summary

- Add MIT LICENSE (`Copyright 2026 Marcin Ciunelis`).
- Drop the stale "Future work — Lift API tokens out of `~/.zshrc` into `~/.secrets`" bullet from `README.md` and `CLAUDE.md`. The line predates the `[[ -f ~/.secrets ]] && source ~/.secrets` already present in `.zshrc` — the work it described is done.

## Audit summary (full notes in `tmp/specs/2026-04-30-public-release-design.md`)

- Current files: no API keys, tokens, passwords, SSH keys, or hardcoded `/Users/martinciu/...` paths.
- Git history (215 commits): scanned for `ghp_`, `sk-*`, `xoxb-`, AWS keys, private-key blocks, SSH key files, `token=`/`api_key=`/`secret=` assignments — no matches.
- Reverted atuin config (PR #19) contained no sync key — UI/behaviour only.
- Residual: 38 `/Users/martinciu/...` references inside deleted Superpowers planning docs reachable via history. They're shell-session captures, not credentials, and `martinciu` is the public GitHub handle anyway. **Decision: accept; do not rewrite history.**
- Author email `marcin.ciunelis@gmail.com` is in commit metadata across all 215 commits. **Decision: accept.**

Pre-public polish that's still pending (not in this PR):
- GitHub repo description update + topics (`dotfiles`, `tmux`, `neovim`, `ghostty`, `solarized`).
- The actual `gh repo edit --visibility public` flip — one-way door, deliberate separate step.

## Test plan

- [ ] `git log --oneline -5` shows MIT LICENSE + README cleanup at `ipo` tip.
- [ ] `cat LICENSE` renders proper MIT text with 2026 / Marcin Ciunelis.
- [ ] `grep -n 'Lift API tokens' README.md CLAUDE.md` returns nothing.
- [ ] `bootstrap.sh` still runs idempotently.