### PR TITLE
tmux: switch to another session on destroy instead of detaching

### DIFF
--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -24,6 +24,11 @@ set -g escape-time 10
 set -g focus-events on
 set -g history-limit 50000
 
+# When the last pane in a session exits (Ctrl-D, `exit`, kill-session),
+# switch to the most-recently-used other session instead of detaching.
+# Falls back to detach if no other session exists.
+set -g detach-on-destroy off
+
 # No bells anywhere — Ghostty/zsh/vim are also silenced; this kills tmux's
 # own bell flag (#F) on the window status line.
 set -g bell-action none

--- a/docs/tmux-cheatsheet.html
+++ b/docs/tmux-cheatsheet.html
@@ -159,6 +159,7 @@
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">(</span> / <span class="k">)</span></td><td class="desc">prev / next session</td></tr>
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">L</span></td><td class="desc">switch to last session</td></tr>
     </table>
+    <p class="note">Closing the last pane of a session (<code>exit</code>, <code>Ctrl-D</code>) switches to the most-recently-used other session via <code>detach-on-destroy off</code>. Detaches only when no other session exists.</p>
   </div>
 
   <div class="card">


### PR DESCRIPTION
## Summary

- Sets `detach-on-destroy off` in `.config/tmux/tmux.conf` so closing the last pane of a session lands on the most-recently-used other session instead of detaching. Falls back to detach when no other session exists, preserving the existing "I'm done with tmux" exit path.
- Adds a matching note to the Sessions / "From inside tmux" card in `docs/tmux-cheatsheet.html` to keep the cheatsheet in sync with the config (per the repo house rule).

## Test plan

- [ ] Pull this branch into the main checkout (`~/.config/tmux` symlinks there, not the worktree, so live tmux only picks up the change post-merge).
- [ ] `<prefix> r` to reload tmux config; status line shows `config reloaded` (no parse errors).
- [ ] `tmux show -g detach-on-destroy` reports `off`.
- [ ] **Multi-session:** with at least two sessions open, `exit` / `Ctrl-D` out of the last pane of one — should switch to the other session, not detach.
- [ ] **Single-session fallback:** kill all but one session, then `exit` the last pane — should detach as today.
- [ ] **Regression:** `<prefix> d` still detaches explicitly (does not switch).
- [ ] Render `docs/tmux-cheatsheet.html` (`open` it) and verify the new note paragraph appears under the "From inside tmux" card with the same Solarized-muted style as the sibling card's `tmux-resurrect` note.

## Session stats

Authored via Claude Code with Superpowers (brainstorm → spec → plan → subagent-driven implementation → spec & code-quality reviews → PR).

- **Duration:** 39.4 min (controller + subagents)
- **Total billed tokens:** 6,285,196
- **Estimated cost (public Anthropic API rates):** $40.65

| Model | Msgs | Input | Output | Cache read | CW-5m | CW-1h | Cost USD |
|---|---:|---:|---:|---:|---:|---:|---:|
| opus-4-7 (controller) | 87 | 277 | 105,354 | 4,737,577 | 115,361 | 763,219 | $40.07 |
| sonnet-4-6 (subagents) | 29 | 41 | 3,982 | 458,821 | 100,564 | 0 | $0.57 |
| **TOTAL** | **116** | **318** | **109,336** | **5,196,398** | **215,925** | **763,219** | **$40.65** |

Cost is a public-rate estimate; Claude Max/Pro/Team plans bundle usage so actual incremental cost may differ. Cache reads dominate (≈83% of billed tokens) — that's normal for a session that re-uses the system prompt across turns.