### PR TITLE
tmux <prefix> u: full pane scrollback, latest occurrence wins

### DIFF
--- a/.config/tmux/bin/tmux-fzf-url-newest
+++ b/.config/tmux/bin/tmux-fzf-url-newest
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# tmux-fzf-url-newest — like tmux-fzf-url's <prefix> u, but for recurring
+# URLs the LATEST pane occurrence wins. xre dedups by first appearance,
+# so we reverse the captured pane content with `tail -r` (BSD; macOS
+# native, no coreutils dependency) before extraction.
+# @fzf-url-fzf-options keeps `--tac`, so fzf re-reverses for display and
+# the newest URL still lands at the cursor.
+#
+# Why a wrapper rather than a fully custom script: we delegate ALL regex
+# extraction and URL opening to the plugin (xre + PAT_* + open_url) by
+# sourcing fzf-url.sh past its test guard
+# (`[[ "${__FZF_URL_TESTING:-}" == 1 ]] && return 0`). Plugin pattern
+# updates flow through automatically; we only own the `tail -r` step.
+set -euo pipefail
+
+PLUGIN_DIR="$HOME/.config/tmux/plugins/tmux-fzf-url"
+
+__FZF_URL_TESTING=1 source "$PLUGIN_DIR/fzf-url.sh"
+
+limit="${1:-50000}"
+
+ensure_xre || { tmux display 'tmux-fzf-url: xre install failed'; exit 1; }
+
+content="$(tmux capture-pane -J -p -e -S -"$limit" | tail -r)"
+items="$(printf '%s\n' "$content" | xre_extract | nl -w3 -s '  ')"
+[ -z "$items" ] && { tmux display 'tmux-fzf-url: no URLs found'; exit 0; }
+
+_copy_cmd="$(get_copy_cmd '')"
+fzf_filter <<<"$items" | awk '{print $2}' | while read -r chosen; do
+  open_url "$chosen" &>"/tmp/tmux-$(id -u)-fzf-url.log"
+done

--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -88,17 +88,22 @@ set -g @plugin 'tmux-plugins/tmux-resurrect'
 set -g @plugin 'tmux-plugins/tmux-continuum'
 set -g @continuum-restore 'on'
 
-# tmux-fzf-url — keyboard-driven URL opener bound to <prefix> u.
-# Scope: visible pane + 2000 lines of scrollback (URL printed a few screens
-# ago is reachable; the full 50k history-limit is not regexed every invocation).
-# Popup geometry matches the sesh picker for visual consistency.
-# --tac reverses fzf input so the most recently printed URL lands at the
-# bottom near the cursor (plugin emits oldest→newest in pane order).
+# tmux-fzf-url provides: xre binary (auto-installed regex extractor),
+# the URL/Git/IP/GitHub-shorthand pattern set, fzf-tmux invocation, and
+# the open_url dispatcher. We OWN the <prefix> u binding (override after
+# the TPM run below) because xre dedups by FIRST appearance — for
+# recurring URLs we want the LATEST occurrence to win positioning.
+# See bin/tmux-fzf-url-newest. --tac in @fzf-url-fzf-options is
+# intentional so the newest URL lands at the cursor.
 set -g @plugin 'wfxr/tmux-fzf-url'
-set -g @fzf-url-history-limit '2000'
 set -g @fzf-url-fzf-options '-w 70% -h 70% --multi -0 --no-preview --border --tac'
 
 run '~/.config/tmux/plugins/tpm/tpm'
+
+# Override the plugin's <prefix> u binding (set during the TPM run above)
+# with our wrapper. Must come AFTER `run '...tpm'` so we win the binding.
+bind-key -N "Open URLs (full pane scrollback, newest occurrence wins)" u \
+  run -b "~/.config/tmux/bin/tmux-fzf-url-newest 50000"
 
 # ─── Status line (Solarized base16 + powerline) ──
 # base03=#002b36 base02=#073642 base01=#586e75 base00=#657b83

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,12 +19,23 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
   auto-restores the last saved env on tmux start), `tmux-fzf-url`. Don't
   remove TPM ("we hand-roll everything") without an explicit ask — the
   status bar is hand-rolled, behavior plugins aren't.
-- **tmux URL picker is `<prefix> u` via `tmux-fzf-url`** (`wfxr/tmux-fzf-url`,
-  loaded by TPM). Scope is visible pane + 2000-line scrollback (not the full
-  50k history). Popup geometry matches the sesh picker (`-w 70% -h 70%`).
-  `--tac` is intentional so the newest URL lands at the cursor — don't drop
-  it. Don't replace with a custom shell script; the plugin already does
-  regex extraction efficiently.
+- **tmux URL picker is `<prefix> u` via a thin wrapper over `tmux-fzf-url`**
+  (`.config/tmux/bin/tmux-fzf-url-newest`). The plugin
+  (`wfxr/tmux-fzf-url`, loaded by TPM) supplies the `xre` regex binary,
+  pattern set, `fzf_filter`, and `open_url` helpers; the wrapper sources
+  `fzf-url.sh` with its test guard tripped (`__FZF_URL_TESTING=1`) to
+  import those, then captures the current pane's full 50000-line
+  scrollback, reverses it with `tail -r` (BSD; macOS native — no
+  coreutils dependency, so don't swap to `tac`) so `xre`'s
+  first-appearance dedup keeps the LATEST occurrence of each URL, and
+  pipes through the plugin's helpers unchanged. Popup geometry matches
+  the sesh picker (`-w 70% -h 70%`). `--tac` in `@fzf-url-fzf-options`
+  is intentional so the newest URL lands at the cursor — don't drop it.
+  The wrapper owns the binding (added after the TPM `run` line in
+  `tmux.conf`); don't remove the wrapper either (without it the
+  plugin's binding wins and recurring URLs sort to oldest position).
+  Don't replace the wrapper with a fully custom shell script; regex
+  extraction still goes through the plugin's `xre`.
 - **`<prefix> o` is the file-picker binding** (sibling of `<prefix> u` URL
   picker). Implemented by `.config/tmux/bin/tmux-fzf-file` (picker) +
   `tmux-open-in-nvim` (dispatcher). nvim auto-listens on
@@ -195,6 +206,7 @@ served at `https://martinciu.github.io/dotfiles/` via GitHub Pages
 - Zsh prompt-context tests: `scripts/test-prompt-context.zsh`
 - Tmux window-label tests: `scripts/test-tmux-window-label.zsh`
 - Claude tmux window-name tests: `scripts/test-claude-tmux-window-name.zsh`
+- URL-picker wrapper tests: `scripts/test-tmux-fzf-url-newest.sh`
 - Reapply symlinks (idempotent): `$PROJECTS_HOME/dotfiles/bootstrap.sh`
 - Check brew deps without installing: `brew bundle check --file=$PROJECTS_HOME/dotfiles/Brewfile --verbose`
 - nvim plugin smoke test: `scripts/test-nvim.sh`

--- a/docs/tmux-cheatsheet.html
+++ b/docs/tmux-cheatsheet.html
@@ -68,7 +68,7 @@
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">t</span></td><td class="desc">sesh picker popup (configured / tmux / zoxide / tmuxinator)</td></tr>
       <tr><td class="key"><code>s [&lt;project&gt;] [&lt;name&gt;]</code></td><td class="desc">create-or-attach worktree+session — inside tmux 1 arg = worktree name in current project, outside tmux 1 arg = project, 0 args = fzf picker</td></tr>
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">T</span></td><td class="desc">clock-mode <span class="muted">(swapped from default <code>t</code>)</span></td></tr>
-      <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">u</span></td><td class="desc">URL picker (fzf, current pane + 2000 lines scrollback) — opens in default browser</td></tr>
+      <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">u</span></td><td class="desc">URL picker (fzf, current pane full 50k scrollback, latest occurrence of duplicates wins) — opens in default browser</td></tr>
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">o</span></td><td class="desc">file picker (fzf, current pane + 2000 lines scrollback) — opens in per-session nvim, falls back to new window</td></tr>
       <tr><td class="key"><span class="k">⇧⌘ click</span></td><td class="desc">Claude Code file links → routes via macOS file-type defaults (OSC 8 passthrough enabled in <code>tmux.conf</code> via <code>terminal-features hyperlinks</code>)</td></tr>
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">?</span></td><td class="desc">list all keybindings</td></tr>
@@ -376,7 +376,7 @@
 </table>
 
 <footer>
-  Built from <code>~/.config/tmux/tmux.conf</code> on 2026-04-30. Refresh after meaningful config changes.
+  Built from <code>~/.config/tmux/tmux.conf</code> on 2026-05-01. Refresh after meaningful config changes.
   <br>
   When in doubt: <span class="k prefix">C-a</span> <span class="k">?</span> for the live keymap list.
 </footer>

--- a/scripts/test-tmux-fzf-url-newest.sh
+++ b/scripts/test-tmux-fzf-url-newest.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Smoke tests for the <prefix> u URL picker wrapper.
+#
+# Two contract checks against the wfxr/tmux-fzf-url plugin we depend on:
+#   1. Sourcing fzf-url.sh with __FZF_URL_TESTING=1 imports the helpers
+#      we need (xre_extract, fzf_filter, open_url, get_copy_cmd,
+#      ensure_xre, PAT_URL) WITHOUT running the plugin's main flow.
+#   2. `tail -r` | xre_extract emits the LATEST occurrence of a duplicated
+#      URL ahead of an inline unique URL — the property the wrapper relies
+#      on. (`tail -r` is BSD/macOS; we don't depend on GNU coreutils' `tac`.)
+#
+# Plus one wrapper-presence check (the wrapper itself).
+set -euo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PLUGIN_DIR="$HOME/.config/tmux/plugins/tmux-fzf-url"
+WRAPPER="$REPO/.config/tmux/bin/tmux-fzf-url-newest"
+
+pass=0
+fail=0
+fail_msgs=()
+
+check() {
+  local name="$1"; shift
+  if "$@"; then
+    printf 'PASS  %s\n' "$name"
+    pass=$((pass + 1))
+  else
+    printf 'FAIL  %s\n' "$name"
+    fail=$((fail + 1))
+    fail_msgs+=("$name")
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: plugin source guard imports the helpers we need
+# ---------------------------------------------------------------------------
+test_source_guard() {
+  [ -d "$PLUGIN_DIR" ] || { echo "  plugin not installed at $PLUGIN_DIR"; return 1; }
+
+  bash -c '
+    set -e
+    __FZF_URL_TESTING=1 source "'"$PLUGIN_DIR"'/fzf-url.sh"
+    for fn in xre_extract fzf_filter open_url get_copy_cmd ensure_xre; do
+      declare -F "$fn" >/dev/null || { echo "  missing function: $fn" >&2; exit 1; }
+    done
+    [ -n "${PAT_URL:-}" ] || { echo "  PAT_URL not set" >&2; exit 1; }
+  '
+}
+check "source guard imports xre_extract/fzf_filter/open_url/get_copy_cmd/ensure_xre/PAT_URL" \
+  test_source_guard
+
+# ---------------------------------------------------------------------------
+# Test 2: `tail -r` | xre_extract puts late occurrence of a duplicated URL
+# before a unique URL that appeared between its early and late occurrences.
+# ---------------------------------------------------------------------------
+test_latest_occurrence_wins() {
+  [ -d "$PLUGIN_DIR" ] || { echo "  plugin not installed at $PLUGIN_DIR"; return 1; }
+  [ -x "$PLUGIN_DIR/bin/xre" ] || { echo "  xre binary not present at $PLUGIN_DIR/bin/xre"; return 1; }
+
+  local out
+  out="$(bash -c '
+    set -e
+    __FZF_URL_TESTING=1 source "'"$PLUGIN_DIR"'/fzf-url.sh"
+    printf "%s\n" \
+      "early line https://example.com/duped" \
+      "middle    https://example.com/unique" \
+      "late line https://example.com/duped" \
+      | tail -r | xre_extract
+  ')"
+
+  local first_line second_line
+  first_line="$(printf '%s\n' "$out" | sed -n '1p')"
+  second_line="$(printf '%s\n' "$out" | sed -n '2p')"
+  [ "$first_line" = "https://example.com/duped" ] || { echo "  line 1 was '$first_line', expected 'https://example.com/duped'"; return 1; }
+  [ "$second_line" = "https://example.com/unique" ] || { echo "  line 2 was '$second_line', expected 'https://example.com/unique'"; return 1; }
+}
+check "tail -r | xre_extract emits late-duplicate before mid-unique" \
+  test_latest_occurrence_wins
+
+# ---------------------------------------------------------------------------
+# Test 3: wrapper exists and is executable
+# ---------------------------------------------------------------------------
+test_wrapper_executable() {
+  [ -x "$WRAPPER" ] || { echo "  $WRAPPER is not executable (or missing)"; return 1; }
+}
+check "wrapper $WRAPPER exists and is executable" \
+  test_wrapper_executable
+
+# ---------------------------------------------------------------------------
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+if [ "$fail" -gt 0 ]; then
+  printf 'Failed:\n'
+  for msg in "${fail_msgs[@]}"; do printf '  - %s\n' "$msg"; done
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Replaces `tmux-fzf-url`'s default `<prefix> u` binding with a thin wrapper (`.config/tmux/bin/tmux-fzf-url-newest`) that scans the current pane's full 50000-line scrollback (was 2000) and surfaces the *latest* occurrence of each URL. xre dedupes by first appearance, so the wrapper reverses captured pane content with `tail -r` (BSD; no coreutils dependency) before extraction.
- Wrapper sources the plugin's `fzf-url.sh` with its test guard tripped (`__FZF_URL_TESTING=1`), so xre, `PAT_*`, `open_url`, `fzf_filter`, and `get_copy_cmd` are delegated to the plugin — no fork, no duplicated patterns. The new binding is registered in `tmux.conf` *after* the TPM `run` line so it overrides the plugin's default.
- Adds `scripts/test-tmux-fzf-url-newest.sh` (3 contract checks: source-guard imports the helpers, `tail -r | xre_extract` puts late-duplicate before mid-unique, wrapper is executable) and updates the CLAUDE.md house rule + tmux cheatsheet row.

## Test plan
- [x] `scripts/test-tmux-fzf-url-newest.sh` — 3 passed, 0 failed
- [x] `scripts/test-fzf-file-extract.sh` — 10/10 pass (no regression in sibling picker)
- [x] `zsh scripts/test-tmux-window-label.zsh` — 11/11 pass
- [x] `zsh scripts/test-claude-tmux-window-name.zsh` — 11/11 pass
- [x] `tmux -f tmux.conf -L cfgcheck start-server \; kill-server` — config parses
- [x] `tmux list-keys -T prefix u` shows `run-shell -b "~/.config/tmux/bin/tmux-fzf-url-newest 50000"` after sourcing the new config
- [ ] Reload tmux config in a live session (`<prefix> r`); confirm `<prefix> u` popup opens with the sesh-picker geometry
- [ ] In a pane with >2000 lines of scrollback containing URLs older than the prior 2000-line window, confirm those older URLs appear in the picker
- [ ] In a pane where the same URL appears multiple times, confirm only one entry is shown and that the latest occurrence drives sort order (last printed lands at the cursor with `--tac`)

## Session stats

| Metric | Value |
|---|---|
| Elapsed | 25.2 min (1,514s) |
| Working | 17.0 min (1,021s, 67% of elapsed) |
| Idle (wait-for-user) | 6.5 min (389s) |
| Messages | 150 |
| Input tokens | 378 |
| Output tokens | 154,536 |
| Cache reads | 12,539,995 |
| Cache writes (1h) | 1,077,717 |
| Total billed tokens | 13,772,626 |
| Cost (public rates, USD) | $62.74 |
| Effective rate | $221.16/hr |

Model: `opus-4-7` (single model, no subagents). Cost is computed against published Anthropic API rates and is a relative guide, not an invoice — Claude Max/Pro/Team/Enterprise plan billing differs.