### PR TITLE
fix(tmux): silence URL picker ESC cancellation (exit 130)

### DIFF
--- a/.config/tmux/bin/tmux-fzf-url-newest
+++ b/.config/tmux/bin/tmux-fzf-url-newest
@@ -11,7 +11,14 @@
 # sourcing fzf-url.sh past its test guard
 # (`[[ "${__FZF_URL_TESTING:-}" == 1 ]] && return 0`). Plugin pattern
 # updates flow through automatically; we only own the `tail -r` step.
-set -euo pipefail
+#
+# No `pipefail`: matches the upstream plugin script. fzf returns 130 on
+# ESC; with pipefail, that propagates through `fzf_filter | awk | while`
+# as the wrapper's own exit code, and tmux's `run -b` then surfaces it
+# as `'... tmux-fzf-url-newest 50000' returned 130`. Without pipefail
+# the pipeline takes the `while read` loop's status (0 on no input),
+# so cancelling the picker is silent.
+set -eu
 
 PLUGIN_DIR="$HOME/.config/tmux/plugins/tmux-fzf-url"
 

--- a/scripts/test-tmux-fzf-url-newest.sh
+++ b/scripts/test-tmux-fzf-url-newest.sh
@@ -88,6 +88,46 @@ check "wrapper $WRAPPER exists and is executable" \
   test_wrapper_executable
 
 # ---------------------------------------------------------------------------
+# Test 4: wrapper exits 0 when the fzf picker is cancelled with ESC.
+# fzf returns 130 on ESC; with `set -euo pipefail` that propagates as the
+# wrapper's own exit code, and tmux's `run -b` then surfaces it as
+# `'... tmux-fzf-url-newest 50000' returned 130`. Mock tmux + fzf-tmux to
+# simulate ESC and assert the wrapper finishes silently.
+# ---------------------------------------------------------------------------
+test_esc_exits_zero() {
+  [ -d "$PLUGIN_DIR" ] || { echo "  plugin not installed at $PLUGIN_DIR"; return 1; }
+  [ -x "$PLUGIN_DIR/bin/xre" ] || { echo "  xre binary not present at $PLUGIN_DIR/bin/xre"; return 1; }
+
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  # shellcheck disable=SC2064
+  trap "rm -rf '$tmpdir'" RETURN
+
+  cat > "$tmpdir/tmux" <<'EOF'
+#!/usr/bin/env bash
+case "$1" in
+  capture-pane) printf 'visit https://example.com today\n' ;;
+  show)         printf '%s\n' '-w 70% -h 70% --multi -0 --no-preview --border --tac' ;;
+  display)      ;;
+  *)            ;;
+esac
+EOF
+  chmod +x "$tmpdir/tmux"
+
+  cat > "$tmpdir/fzf-tmux" <<'EOF'
+#!/usr/bin/env bash
+exit 130
+EOF
+  chmod +x "$tmpdir/fzf-tmux"
+
+  local status=0
+  PATH="$tmpdir:$PATH" "$WRAPPER" 100 >/dev/null 2>&1 || status=$?
+  [ "$status" -eq 0 ] || { echo "  wrapper exited $status, expected 0 (ESC cancellation should be silent)"; return 1; }
+}
+check "wrapper exits 0 when fzf is cancelled with ESC (exit 130)" \
+  test_esc_exits_zero
+
+# ---------------------------------------------------------------------------
 printf '\n%d passed, %d failed\n' "$pass" "$fail"
 if [ "$fail" -gt 0 ]; then
   printf 'Failed:\n'


### PR DESCRIPTION
## Summary

- After PR #35, hitting ESC on the `<prefix> u` URL picker surfaced `'/Users/.../tmux-fzf-url-newest 50000' returned 130` in tmux.
- Root cause: the wrapper used `set -euo pipefail`; fzf returns 130 on ESC, and `pipefail` propagated that through `fzf_filter | awk | while read` as the wrapper's own exit code. tmux's `run -b` then surfaced any non-zero exit as a popup error.
- Fix: drop `pipefail` (`set -eu`) — matches the upstream `fzf-url.sh` script, where the pipeline takes the `while read` loop's status (0 on no input) and cancellation is silent.
- Adds a contract test (`test_esc_exits_zero`) that mocks `tmux` + `fzf-tmux` to simulate ESC and asserts the wrapper exits 0.

## Test plan

- [x] `bash scripts/test-tmux-fzf-url-newest.sh` — 4/4 pass
- [x] `bash scripts/test-helpers.sh` — 30/30 pass
- [ ] Manually: open URL picker (`<prefix> u`), press ESC, confirm no error popup
- [ ] Manually: open URL picker, pick a URL, confirm it still opens

## Session stats

| | |
|---|---|
| Elapsed | 7m 27s |
| Working | 5m 23s (72% of elapsed) |
| Idle | 1m 27s |

| Model | Msgs | Input | Output | CacheR | CW-5m | CW-1h | Cost USD |
|---|---:|---:|---:|---:|---:|---:|---:|
| opus-4-7 | 47 | 111 | 48,679 | 2,272,509 | 0 | 373,184 | $18.2569 |
| **TOTAL** | **47** | **111** | **48,679** | **2,272,509** | **0** | **373,184** | **$18.2569** |

Total billed tokens: 2,694,483 — effective rate $203.77/hr (cost ÷ working time, public Anthropic API rates; plan billing differs).