### PR TITLE
fix(tmux): URL picker exits 1 on selection (unbound custom_open)

### DIFF
--- a/.config/tmux/bin/tmux-fzf-url-newest
+++ b/.config/tmux/bin/tmux-fzf-url-newest
@@ -33,6 +33,10 @@ items="$(printf '%s\n' "$content" | xre_extract | nl -w3 -s '  ')"
 [ -z "$items" ] && { tmux display 'tmux-fzf-url: no URLs found'; exit 0; }
 
 _copy_cmd="$(get_copy_cmd '')"
+# open_url checks `[[ -n $custom_open ]]` unconditionally; the plugin's main
+# flow sets it from $2 but we skip that path via the test guard, so define
+# it here or `set -u` makes the lookup an unbound-variable error.
+custom_open=""
 fzf_filter <<<"$items" | awk '{print $2}' | while read -r chosen; do
   open_url "$chosen" &>"/tmp/tmux-$(id -u)-fzf-url.log"
 done

--- a/scripts/test-tmux-fzf-url-newest.sh
+++ b/scripts/test-tmux-fzf-url-newest.sh
@@ -128,6 +128,53 @@ check "wrapper exits 0 when fzf is cancelled with ESC (exit 130)" \
   test_esc_exits_zero
 
 # ---------------------------------------------------------------------------
+# Test 5: wrapper exits 0 when the user picks a URL.
+# Regression for: open_url checks `[[ -n $custom_open ]]` unconditionally;
+# without `custom_open=""` defined, `set -u` makes it an unbound-variable
+# error and the wrapper exits 1 — tmux surfaces it as `'... returned 1'`.
+# Mock tmux + fzf-tmux so fzf-tmux returns a numbered URL line and the
+# wrapper's `open_url` runs through a stub `open` on PATH.
+# ---------------------------------------------------------------------------
+test_selection_exits_zero() {
+  [ -d "$PLUGIN_DIR" ] || { echo "  plugin not installed at $PLUGIN_DIR"; return 1; }
+  [ -x "$PLUGIN_DIR/bin/xre" ] || { echo "  xre binary not present at $PLUGIN_DIR/bin/xre"; return 1; }
+
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  # shellcheck disable=SC2064
+  trap "rm -rf '$tmpdir'" RETURN
+
+  cat > "$tmpdir/tmux" <<'EOF'
+#!/usr/bin/env bash
+case "$1" in
+  capture-pane) printf 'visit https://example.com today\n' ;;
+  show)         printf '%s\n' '-w 70% -h 70% --multi -0 --no-preview --border --tac' ;;
+  display)      ;;
+  *)            ;;
+esac
+EOF
+  chmod +x "$tmpdir/tmux"
+
+  cat > "$tmpdir/fzf-tmux" <<'EOF'
+#!/usr/bin/env bash
+printf '  1  https://example.com\n'
+EOF
+  chmod +x "$tmpdir/fzf-tmux"
+
+  cat > "$tmpdir/open" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+  chmod +x "$tmpdir/open"
+
+  local status=0
+  PATH="$tmpdir:$PATH" "$WRAPPER" 100 >/dev/null 2>&1 || status=$?
+  [ "$status" -eq 0 ] || { echo "  wrapper exited $status, expected 0 (URL selection should succeed)"; return 1; }
+}
+check "wrapper exits 0 when a URL is selected" \
+  test_selection_exits_zero
+
+# ---------------------------------------------------------------------------
 printf '\n%d passed, %d failed\n' "$pass" "$fail"
 if [ "$fail" -gt 0 ]; then
   printf 'Failed:\n'


### PR DESCRIPTION
## Summary

- Selecting a URL in `<prefix> u` failed with `'... tmux-fzf-url-newest 50000' returned 1` and the URL never opened.
- Root cause: the wrapper sources `fzf-url.sh` past its test guard, which skips the plugin's main-flow line that sets `custom_open=$2`. `open_url` then evaluates `[[ -n $custom_open ]]` against an undefined var, and `set -u` turns the lookup into an exit-1 error before `open` is ever called. (Confirmed via `/tmp/tmux-$(id -u)-fzf-url.log`: `custom_open: unbound variable`.)
- Fix: define `custom_open=""` in the wrapper before calling `open_url`. Added a regression test (Test 5 in `scripts/test-tmux-fzf-url-newest.sh`) that mocks `tmux`, `fzf-tmux`, and `open` to drive the selection path end-to-end — fails with `wrapper exited 1` without the fix, passes with it.

## Test plan

- [x] `scripts/test-tmux-fzf-url-newest.sh` — 5/5 passing locally
- [x] Verified test fails without the fix (`exited 1, expected 0`)
- [ ] Manual smoke test: `<prefix> u` in tmux, pick a URL, confirm browser opens and tmux shows no error