### PR TITLE
Drop zoxide from sesh picker sources

### DIFF
--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -71,7 +71,7 @@ bind r source-file ~/.config/tmux/tmux.conf \; display "config reloaded"
 # popup opens but the picker shows zero entries).
 # Swap with the default <prefix> t (clock-mode): lowercase t is faster to
 # reach for the picker we use constantly; uppercase T moves the clock.
-bind-key "t" display-popup -E -w 70% -h 70% "sesh picker -i -d -H"
+bind-key "t" display-popup -E -w 70% -h 70% "sesh picker -i -d -H -c -t -T"
 bind-key "T" clock-mode
 
 # ─── File-link picker ───────────────────────

--- a/.zshrc
+++ b/.zshrc
@@ -180,10 +180,11 @@ bindkey -M emacs -r '^[c' 2>/dev/null
 bindkey -M viins -r '^[c' 2>/dev/null
 bindkey -M vicmd -r '^[c' 2>/dev/null
 
-# zoxide — frecency-ranked `cd` (`z foo`) and source for sesh picker.
-# _ZO_EXCLUDE_DIRS is colon-separated globs (per `man zoxide`); we block
-# the home root + three noise sources so the sesh picker stays focused on
-# real projects under $PROJECTS_HOME.
+# zoxide — frecency-ranked `cd` (`z foo`). The sesh picker no longer
+# reads zoxide (see tmux.conf: `sesh picker ... -c -t -T`), so these
+# excludes exist purely for `z` discipline: `z lib` should not jump
+# into ~/Library, `z config` should not jump into ~/.config, etc.
+# _ZO_EXCLUDE_DIRS is colon-separated globs (per `man zoxide`).
 if command -v zoxide >/dev/null 2>&1; then
   export _ZO_EXCLUDE_DIRS="$HOME:$HOME/Downloads/*:$HOME/.config/*:$HOME/Library/*"
   eval "$(zoxide init zsh)"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,11 +62,13 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
   the shared file; don't drop the `import` line — sesh hard-errors on
   a missing import target. The picker (`<prefix> t`, swapped with the
   default clock-mode binding which moved to `<prefix> T`) is
-  `sesh picker -i -d -H` — full vanilla, all sources (configured /
-  tmux / zoxide / tmuxinator). Don't re-introduce a custom fzf wrapper
-  script. Zoxide is on but `_ZO_EXCLUDE_DIRS` blocks `~/`,
+  `sesh picker -i -d -H -c -t -T` — three sources only (configured /
+  tmux / tmuxinator). Zoxide is intentionally **not** a picker source:
+  the `-c -t -T` flags are inclusive opt-in, so omitting `-z` drops
+  zoxide. Don't re-introduce a custom fzf wrapper script. Zoxide is
+  still loaded for `z`-cd, and `_ZO_EXCLUDE_DIRS` blocks `~/`,
   `~/Downloads/*`, `~/.config/*`, `~/Library/*` from being indexed —
-  keeps the picker focused on real projects under `$PROJECTS_HOME`.
+  keeps `z lib`/`z config`/etc. from jumping into noise dirs.
 - **`s` is the worktree+session command** (`bin/s`, symlinked to
   `~/.local/bin/s` by `bootstrap.sh`). Surface:
   `s [<project>] [<name>]`. Inside tmux a single arg is the worktree

--- a/docs/tmux-cheatsheet.html
+++ b/docs/tmux-cheatsheet.html
@@ -65,7 +65,7 @@
       <tr><td class="key"><code>tmux ls</code></td><td class="desc">list sessions</td></tr>
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">d</span></td><td class="desc">detach (session keeps running)</td></tr>
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">r</span></td><td class="desc">reload <code>~/.config/tmux/tmux.conf</code></td></tr>
-      <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">t</span></td><td class="desc">sesh picker popup (configured / tmux / zoxide / tmuxinator)</td></tr>
+      <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">t</span></td><td class="desc">sesh picker popup (configured / tmux / tmuxinator)</td></tr>
       <tr><td class="key"><code>s [&lt;project&gt;] [&lt;name&gt;]</code></td><td class="desc">create-or-attach worktree+session — inside tmux 1 arg = worktree name in current project, outside tmux 1 arg = project, 0 args = fzf picker</td></tr>
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">T</span></td><td class="desc">clock-mode <span class="muted">(swapped from default <code>t</code>)</span></td></tr>
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">u</span></td><td class="desc">URL picker (fzf, current pane full 50k scrollback, latest occurrence of duplicates wins) — opens in default browser</td></tr>
@@ -120,17 +120,17 @@
     <h3>Sesh picker <span class="pill">prefix t</span></h3>
     <p>
       <span class="k prefix">C-a</span><span class="k">t</span> opens a popup running
-      <code>sesh picker -i -d -H</code> — full vanilla, all sources (configured / tmux /
-      zoxide / tmuxinator). The shared config lives at
-      <code>.config/sesh/sesh.toml</code> with an <code>import</code> directive pulling
-      machine-local sessions from <code>~/.config/sesh/sesh.local.toml</code> (untracked,
-      copied from a template by <code>bootstrap.sh</code>).
+      <code>sesh picker -i -d -H -c -t -T</code> — three sources (configured / tmux /
+      tmuxinator). Zoxide is intentionally not a picker source. The shared config
+      lives at <code>.config/sesh/sesh.toml</code> with an <code>import</code> directive
+      pulling machine-local sessions from <code>~/.config/sesh/sesh.local.toml</code>
+      (untracked, copied from a template by <code>bootstrap.sh</code>).
     </p>
     <p class="note">
       <code>_ZO_EXCLUDE_DIRS</code> blocks <code>~/</code>, <code>~/Downloads/*</code>,
-      <code>~/.config/*</code>, <code>~/Library/*</code> from zoxide indexing — keeps the
-      picker focused on real projects under <code>$PROJECTS_HOME</code>. Don't re-introduce
-      a custom fzf wrapper script.
+      <code>~/.config/*</code>, <code>~/Library/*</code> from zoxide indexing — these
+      excludes now exist for <code>z</code>-cd hygiene only (the picker no longer
+      reads zoxide). Don't re-introduce a custom fzf wrapper script.
     </p>
   </div>
 


### PR DESCRIPTION
## Summary

- Switch `<prefix> t` from `sesh picker -i -d -H` to `sesh picker -i -d -H -c -t -T` so the picker shows only configured sessions, live tmux sessions, and tmuxinator configs — no more zoxide-frecency directories cluttering the list (`~/.claude/skills`, `~/.agent-browser`, `~/code/*/.claude/worktrees/*`, `/tmp`, etc.).
- Sesh's `-c -t -T` flags are inclusive opt-in; omitting `-z` drops zoxide. `z` (cd) is unaffected — zoxide is still loaded.
- Re-justify `_ZO_EXCLUDE_DIRS` in `.zshrc`, `CLAUDE.md`, and `docs/tmux-cheatsheet.html`: it now exists for `z`-cd hygiene (so `z lib` doesn't jump into `~/Library`), not picker focus.

## Test plan

- [ ] Reload tmux config on main after merge (`<prefix> r`).
- [ ] Open the picker (`<prefix> t`) and confirm only configured / tmux / tmuxinator entries appear (no zoxide directories).
- [ ] Run `z dotfiles` (or any frecency-ranked prefix) — confirm `z`-cd still works.
- [ ] Open `docs/tmux-cheatsheet.html` in a browser — keymap row and Sesh picker card render correctly with the new wording.