### PR TITLE
Shrink sesh picker popup to fit entry count

### DIFF
--- a/.config/tmux/bin/tmux-sesh-picker
+++ b/.config/tmux/bin/tmux-sesh-picker
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# tmux-sesh-picker — open the sesh picker popup at a height that fits the
+# entry list. Width stays at 70% (matches the file/URL picker popups).
+#
+# Bound to <prefix> t in .config/tmux/tmux.conf via `run -b`. The forked
+# pattern matches tmux-fzf-url-newest: when a wrapper opens its own popup,
+# tmux's event loop should not block on the wrapper itself.
+#
+# Sources for `sesh list` MUST mirror the `sesh picker` flag set so the
+# count matches what fzf will display.
+set -euo pipefail
+
+readonly BUFFER=4         # popup border (top+bottom = 2) + fzf prompt + fzf info line
+readonly MIN=6            # smallest usable popup
+readonly DEFAULT=15       # fallback when `sesh list` fails (close to old visual size)
+readonly MAX_PCT=80       # cap as percentage of client height
+
+# Count entries; distinguish "0 items" from "command failed" by exit code.
+if list_output=$(sesh list -c -t -T 2>/dev/null); then
+  if [[ -n "$list_output" ]]; then
+    count=$(printf '%s' "$list_output" | grep -c . || true)
+  else
+    count=0
+  fi
+else
+  count=""  # sentinel: failure
+fi
+
+if [[ -z "$count" ]]; then
+  H=$DEFAULT
+else
+  H=$((count + BUFFER))
+  (( H < MIN )) && H=$MIN
+fi
+
+# Cap at MAX_PCT of client height when we can read it.
+client_h=$(tmux display-message -p '#{client_height}' 2>/dev/null | tr -d ' ' || true)
+if [[ "$client_h" =~ ^[0-9]+$ && "$client_h" -gt 0 ]]; then
+  max_h=$(( client_h * MAX_PCT / 100 ))
+  (( max_h < MIN )) && max_h=$MIN
+  (( H > max_h )) && H=$max_h
+fi
+
+exec tmux display-popup -E -w 70% -h "$H" "sesh picker -i -d -H -c -t -T"

--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -66,18 +66,24 @@ bind l select-pane -R
 bind r source-file ~/.config/tmux/tmux.conf \; display "config reloaded"
 
 # ─── sesh popup ─────────────────────────────
-# `sesh picker` connects to the chosen session itself — don't wrap it in
-# $(...). Wrapping captures stdout, which breaks fzf's TUI rendering (the
-# popup opens but the picker shows zero entries).
+# Picker height tracks the entry count (count + small buffer, clamped to a
+# sane min and 80% of client height). Width stays at 70% to match the file
+# and URL picker popups. Implementation: ~/.config/tmux/bin/tmux-sesh-picker.
+# `run -b` (forked) matches the URL picker pattern — when a wrapper opens
+# its own popup, tmux's event loop must not block on the wrapper itself.
+# Don't wrap `sesh picker` in $(...); that captures stdout and breaks
+# fzf's TUI rendering (popup opens, picker shows zero entries).
 # Swap with the default <prefix> t (clock-mode): lowercase t is faster to
 # reach for the picker we use constantly; uppercase T moves the clock.
-bind-key "t" display-popup -E -w 70% -h 70% "sesh picker -i -d -H -c -t -T"
+bind-key "t" run -b "~/.config/tmux/bin/tmux-sesh-picker"
 bind-key "T" clock-mode
 
 # ─── File-link picker ───────────────────────
 # Sibling of <prefix> u (URL picker): scans pane + 2k scrollback for paths,
 # fzf-picks one, jumps the per-session nvim (or new window if none).
-# Geometry matches sesh and tmux-fzf-url popups.
+# Width (70%) matches the sesh and tmux-fzf-url popups; height stays at 70%
+# because the file list is dynamic (whatever fzf finds in scrollback) and
+# can be long. Sesh's height is computed dynamically by its wrapper.
 bind-key "o" display-popup -E -w 70% -h 70% \
   "~/.config/tmux/bin/tmux-fzf-file '#{pane_id}' '#{pane_current_path}'"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,8 +28,7 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
   scrollback, reverses it with `tail -r` (BSD; macOS native — no
   coreutils dependency, so don't swap to `tac`) so `xre`'s
   first-appearance dedup keeps the LATEST occurrence of each URL, and
-  pipes through the plugin's helpers unchanged. Popup geometry matches
-  the sesh picker (`-w 70% -h 70%`). `--tac` in `@fzf-url-fzf-options`
+  pipes through the plugin's helpers unchanged. Popup geometry: `-w 70% -h 70%`. Width matches the sesh and file pickers; the sesh picker's height is now dynamic (see the sesh bullet) but width is the shared anchor. `--tac` in `@fzf-url-fzf-options`
   is intentional so the newest URL lands at the cursor — don't drop it.
   The wrapper owns the binding (added after the TPM `run` line in
   `tmux.conf`); don't remove the wrapper either (without it the
@@ -63,7 +62,8 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
   a missing import target. The picker (`<prefix> t`, swapped with the
   default clock-mode binding which moved to `<prefix> T`) is
   `sesh picker -i -d -H -c -t -T` — three sources only (configured /
-  tmux / tmuxinator). Zoxide is intentionally **not** a picker source:
+  tmux / tmuxinator). The binding is `run -b ~/.config/tmux/bin/tmux-sesh-picker` (not inline `display-popup`): the wrapper counts entries via `sesh list -c -t -T`, then opens `display-popup -E -w 70% -h "$H"` where `H = items + 4` clamped to `[6, 80% of client height]` (fallback `15` if `sesh list` fails). Width stays at 70%; height is dynamic. Don't fold the wrapper back inline — recomputing the height per keypress requires a real script.
+  Zoxide is intentionally **not** a picker source:
   the `-c -t -T` flags are inclusive opt-in, so omitting `-z` drops
   zoxide. Don't re-introduce a custom fzf wrapper script. Zoxide is
   still loaded for `z`-cd, and `_ZO_EXCLUDE_DIRS` blocks `~/`,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,8 +28,13 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
   scrollback, reverses it with `tail -r` (BSD; macOS native — no
   coreutils dependency, so don't swap to `tac`) so `xre`'s
   first-appearance dedup keeps the LATEST occurrence of each URL, and
-  pipes through the plugin's helpers unchanged. Popup geometry: `-w 70% -h 70%`. Width matches the sesh and file pickers; the sesh picker's height is now dynamic (see the sesh bullet) but width is the shared anchor. `--tac` in `@fzf-url-fzf-options`
-  is intentional so the newest URL lands at the cursor — don't drop it.
+  pipes through the plugin's helpers unchanged. Popup geometry:
+  `-w 70% -h 70%`. Width (70%) matches the sesh and file pickers — the
+  shared anchor across the three pickers. The sesh picker's height is
+  now dynamic (see the sesh bullet); URL height stays fixed because
+  scrollback URLs aren't a countable list. `--tac` in
+  `@fzf-url-fzf-options` is intentional so the newest URL lands at the
+  cursor — don't drop it.
   The wrapper owns the binding (added after the TPM `run` line in
   `tmux.conf`); don't remove the wrapper either (without it the
   plugin's binding wins and recurring URLs sort to oldest position).
@@ -62,8 +67,16 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
   a missing import target. The picker (`<prefix> t`, swapped with the
   default clock-mode binding which moved to `<prefix> T`) is
   `sesh picker -i -d -H -c -t -T` — three sources only (configured /
-  tmux / tmuxinator). The binding is `run -b ~/.config/tmux/bin/tmux-sesh-picker` (not inline `display-popup`): the wrapper counts entries via `sesh list -c -t -T`, then opens `display-popup -E -w 70% -h "$H"` where `H = items + 4` clamped to `[6, 80% of client height]` (fallback `15` if `sesh list` fails). Width stays at 70%; height is dynamic. Don't fold the wrapper back inline — recomputing the height per keypress requires a real script.
-  Zoxide is intentionally **not** a picker source:
+  tmux / tmuxinator). The binding is
+  `run -b ~/.config/tmux/bin/tmux-sesh-picker` (not inline
+  `display-popup`): the wrapper counts entries via
+  `sesh list -c -t -T`, then opens
+  `display-popup -E -w 70% -h "$H"` where `H = items + 4` clamped
+  to `[6, 80% of client height]` (fallback `15` if `sesh list`
+  fails). Width stays at 70% — shared anchor with the URL and
+  file pickers; height is dynamic. Don't fold the wrapper back
+  inline — recomputing the height per keypress requires a real
+  script. Zoxide is intentionally **not** a picker source:
   the `-c -t -T` flags are inclusive opt-in, so omitting `-z` drops
   zoxide. Don't re-introduce a custom fzf wrapper script. Zoxide is
   still loaded for `z`-cd, and `_ZO_EXCLUDE_DIRS` blocks `~/`,

--- a/docs/tmux-cheatsheet.html
+++ b/docs/tmux-cheatsheet.html
@@ -65,7 +65,7 @@
       <tr><td class="key"><code>tmux ls</code></td><td class="desc">list sessions</td></tr>
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">d</span></td><td class="desc">detach (session keeps running)</td></tr>
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">r</span></td><td class="desc">reload <code>~/.config/tmux/tmux.conf</code></td></tr>
-      <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">t</span></td><td class="desc">sesh picker popup (configured / tmux / tmuxinator)</td></tr>
+      <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">t</span></td><td class="desc">sesh picker popup (configured / tmux / tmuxinator) — height sized to entry count</td></tr>
       <tr><td class="key"><code>s [&lt;project&gt;] [&lt;name&gt;]</code></td><td class="desc">create-or-attach worktree+session — inside tmux 1 arg = worktree name in current project, outside tmux 1 arg = project, 0 args = fzf picker</td></tr>
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">T</span></td><td class="desc">clock-mode <span class="muted">(swapped from default <code>t</code>)</span></td></tr>
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">u</span></td><td class="desc">URL picker (fzf, current pane full 50k scrollback, latest occurrence of duplicates wins) — opens in default browser</td></tr>
@@ -119,12 +119,21 @@
   <div class="card">
     <h3>Sesh picker <span class="pill">prefix t</span></h3>
     <p>
-      <span class="k prefix">C-a</span><span class="k">t</span> opens a popup running
+      <span class="k prefix">C-a</span><span class="k">t</span> runs
+      <code>~/.config/tmux/bin/tmux-sesh-picker</code>, which opens a popup over
       <code>sesh picker -i -d -H -c -t -T</code> — three sources (configured / tmux /
       tmuxinator). Zoxide is intentionally not a picker source. The shared config
       lives at <code>.config/sesh/sesh.toml</code> with an <code>import</code> directive
       pulling machine-local sessions from <code>~/.config/sesh/sesh.local.toml</code>
       (untracked, copied from a template by <code>bootstrap.sh</code>).
+    </p>
+    <p class="note">
+      Popup width is fixed at 70% (shared anchor with the URL and file pickers);
+      height is dynamic — <code>items + 4</code>, clamped to <code>[6, 80% of
+      client height]</code>, falling back to <code>15</code> if
+      <code>sesh list</code> fails. Width gives long
+      <code>&lt;project&gt;/&lt;worktree&gt;</code> session names room; sizing
+      height to the entry count keeps the popup compact.
     </p>
     <p class="note">
       <code>_ZO_EXCLUDE_DIRS</code> blocks <code>~/</code>, <code>~/Downloads/*</code>,

--- a/scripts/test-tmux-sesh-picker.sh
+++ b/scripts/test-tmux-sesh-picker.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Smoke tests for the <prefix> t sesh-picker wrapper.
+#
+# Verifies popup height math:
+#   H = max(MIN, count + BUFFER), clamped above by floor(client_height * MAX_PCT/100).
+#   On `sesh list` failure, H = DEFAULT (still clamped above).
+#
+# Strategy: prepend a tempdir with fake `sesh` and `tmux` shims to PATH;
+# run the wrapper; the fake `tmux display-popup` writes its `-h` arg to a
+# capture file; assert against expected values.
+set -euo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WRAPPER="$REPO/.config/tmux/bin/tmux-sesh-picker"
+
+pass=0
+fail=0
+fail_msgs=()
+
+setup_shims() {
+  local tmpdir="$1"
+
+  cat > "$tmpdir/sesh" <<'EOF'
+#!/usr/bin/env bash
+# Fake sesh: emit $FAKE_SESH_ITEMS lines, or exit non-zero if FAKE_SESH_FAIL=1.
+[[ "${FAKE_SESH_FAIL:-0}" = "1" ]] && exit 1
+n=${FAKE_SESH_ITEMS:-0}
+for ((i=1; i<=n; i++)); do echo "session-$i"; done
+EOF
+  chmod +x "$tmpdir/sesh"
+
+  cat > "$tmpdir/tmux" <<'EOF'
+#!/usr/bin/env bash
+# Fake tmux:
+#   - display-message -p '#{client_height}'  -> echo $FAKE_CLIENT_HEIGHT
+#   - display-popup ... -h N ...             -> write N to $CAPTURE_FILE
+case "$1" in
+  display-message)
+    echo "${FAKE_CLIENT_HEIGHT:-30}"
+    ;;
+  display-popup)
+    shift
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        -h) echo "$2" > "$CAPTURE_FILE"; shift 2 ;;
+        *)  shift ;;
+      esac
+    done
+    ;;
+  *)
+    echo "fake tmux: unhandled $1" >&2
+    exit 1
+    ;;
+esac
+EOF
+  chmod +x "$tmpdir/tmux"
+}
+
+run_case() {
+  local label="$1" expected="$2"
+  rm -f "$CAPTURE_FILE"
+  PATH="$SHIM_DIR:$PATH" "$WRAPPER" >/dev/null 2>&1 || true
+  local got
+  got="$(cat "$CAPTURE_FILE" 2>/dev/null || echo '(none)')"
+  if [[ "$got" == "$expected" ]]; then
+    printf 'PASS  %s (h=%s)\n' "$label" "$got"
+    pass=$((pass + 1))
+  else
+    printf 'FAIL  %s — expected h=%s, got h=%s\n' "$label" "$expected" "$got"
+    fail=$((fail + 1))
+    fail_msgs+=("$label")
+  fi
+}
+
+# ---------------------------------------------------------------------------
+SHIM_DIR="$(mktemp -d)"
+trap 'rm -rf "$SHIM_DIR"' EXIT
+setup_shims "$SHIM_DIR"
+export CAPTURE_FILE="$SHIM_DIR/captured-h"
+
+# Case 1: 0 items → MIN (6) — count+BUFFER=4, clamped up to MIN
+export FAKE_CLIENT_HEIGHT=30 FAKE_SESH_ITEMS=0; unset FAKE_SESH_FAIL
+run_case "0 items clamps to MIN" 6
+
+# Case 2: 5 items → 5 + BUFFER (4) = 9
+export FAKE_SESH_ITEMS=5
+run_case "5 items → count+BUFFER" 9
+
+# Case 3: 100 items in 30-row terminal → cap at floor(30*0.8) = 24
+export FAKE_SESH_ITEMS=100
+run_case "100 items capped to 80% of client height" 24
+
+# Case 4: sesh fails → DEFAULT (15), still under 30-row cap of 24
+export FAKE_SESH_FAIL=1
+run_case "sesh failure falls back to DEFAULT" 15
+
+# ---------------------------------------------------------------------------
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+if [ "$fail" -gt 0 ]; then
+  printf 'Failed:\n'
+  for msg in "${fail_msgs[@]}"; do printf '  - %s\n' "$msg"; done
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- New wrapper `~/.config/tmux/bin/tmux-sesh-picker` sizes the `<prefix> t` popup to `items + 4`, clamped to `[6, 80% of client height]` (fallback `15` if `sesh list` fails). Width stays at 70% — shared anchor with the URL and file pickers.
- `<prefix> t` binding swapped from inline `display-popup` to `run -b` the wrapper (mirrors the URL picker's pattern).
- Smoke test (`scripts/test-tmux-sesh-picker.sh`) covers MIN clamp, normal range, MAX_PCT clamp, and `sesh list` failure via PATH-shimmed `sesh`/`tmux`.
- Docs updated: `CLAUDE.md` (sesh + URL bullets, reciprocal width-anchor clause) and `docs/tmux-cheatsheet.html`.

## Test plan

- [ ] `scripts/test-tmux-sesh-picker.sh` passes (4/4)
- [ ] Reload tmux config (`<prefix> r`); `<prefix> t` opens a popup whose height matches the current session count, not 70% of screen
- [ ] Open a fresh shell, kill all sessions except one, reload, hit `<prefix> t` — popup should be MIN-clamped (6 rows)
- [ ] Confirm width still matches the URL picker (`<prefix> u`) and file picker (`<prefix> o`)