### PR TITLE
tmux: open new windows at session root for s-created sessions

### DIFF
--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -55,6 +55,15 @@ bind - split-window -v -c "#{pane_current_path}"
 unbind '"'
 unbind %
 
+# ─── New window: honor @session_root (set by `s`) ──
+# `s` stamps @session_root with the worktree/project root on every invocation
+# (incl. re-attach), so <prefix> c lands at the session root rather than
+# inheriting pane cwd. Format mirrors tmux.conf:50 (the @claude_session_name
+# emptiness test). Splits intentionally keep pane_current_path — house rule.
+# Sessions not started by `s` have no @session_root → falls back to
+# pane_current_path (tmux default behavior, no regression).
+bind c new-window -c "#{?#{!=:#{@session_root},},#{@session_root},#{pane_current_path}}"
+
 # ─── Vim-style pane nav (with prefix) ───────
 # Alt is reserved for Polish diacritics (ą ć ę ł ń ó ś ź ż), so we use prefix.
 bind h select-pane -L

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,6 +209,7 @@ served at `https://martinciu.github.io/dotfiles/` via GitHub Pages
 - Tmux window-label tests: `scripts/test-tmux-window-label.zsh`
 - Claude tmux window-name tests: `scripts/test-claude-tmux-window-name.zsh`
 - URL-picker wrapper tests: `scripts/test-tmux-fzf-url-newest.sh`
+- Session-root binding tests: `scripts/test-s-session-root.sh`
 - Reapply symlinks (idempotent): `$PROJECTS_HOME/dotfiles/bootstrap.sh`
 - Check brew deps without installing: `brew bundle check --file=$PROJECTS_HOME/dotfiles/Brewfile --verbose`
 - nvim plugin smoke test: `scripts/test-nvim.sh`

--- a/bin/s
+++ b/bin/s
@@ -77,10 +77,14 @@ case $# in
     name="$2"
     session="$project/$name"
     project_path=$(resolve_project_path "$project")
+    # Resolve worktree path unconditionally so we can re-stamp @session_root
+    # on every invocation (handles tmux-continuum restores wiping options).
+    # `wt switch --create --no-cd` is idempotent — see ensure_worktree above.
+    target_path=$(ensure_worktree "$project_path" "$name")
     if ! tmux has-session -t "$session" 2>/dev/null; then
-      target_path=$(ensure_worktree "$project_path" "$name")
       tmux new-session -d -s "$session" -c "$target_path"
     fi
+    tmux set-option -t "$session" @session_root "$target_path"
     finish "$session"
     ;;
   1)
@@ -99,10 +103,11 @@ case $# in
         exit 1
       fi
       session="$project/$name"
+      target_path=$(ensure_worktree "$project_path" "$name")
       if ! tmux has-session -t "$session" 2>/dev/null; then
-        target_path=$(ensure_worktree "$project_path" "$name")
         tmux new-session -d -s "$session" -c "$target_path"
       fi
+      tmux set-option -t "$session" @session_root "$target_path"
       finish "$session"
     else
       project="$1"
@@ -110,6 +115,7 @@ case $# in
       if ! tmux has-session -t "$project" 2>/dev/null; then
         tmux new-session -d -s "$project" -c "$project_path"
       fi
+      tmux set-option -t "$project" @session_root "$project_path"
       finish "$project"
     fi
     ;;
@@ -131,6 +137,7 @@ case $# in
       if ! tmux has-session -t "$project" 2>/dev/null; then
         tmux new-session -d -s "$project" -c "$project_path"
       fi
+      tmux set-option -t "$project" @session_root "$project_path"
       finish "$project"
     fi
     ;;

--- a/docs/tmux-cheatsheet.html
+++ b/docs/tmux-cheatsheet.html
@@ -154,7 +154,7 @@
   <div class="card">
     <h3>Manage</h3>
     <table>
-      <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">c</span></td><td class="desc">create window</td></tr>
+      <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">c</span></td><td class="desc">create window — opens at session root (<code>@session_root</code>, set by <code>s</code>) when present, else inherits pane cwd</td></tr>
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">,</span></td><td class="desc">rename window</td></tr>
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">&amp;</span></td><td class="desc">kill window (confirm)</td></tr>
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">w</span></td><td class="desc">window picker (tree)</td></tr>

--- a/scripts/test-s-session-root.sh
+++ b/scripts/test-s-session-root.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Tests the @session_root format string used by the <prefix> c binding in
+# .config/tmux/tmux.conf. Two arms:
+#   1. @session_root set   -> resolves to its value
+#   2. @session_root unset -> falls back to pane_current_path
+#
+# Plus a presence check that tmux.conf actually wires the binding.
+#
+# Uses an isolated tmux server (-L test-session-root-$$) so no interference
+# with the user's running tmux. Tears down via trap on EXIT.
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+CONF="$REPO/.config/tmux/tmux.conf"
+
+# Must match the format string in tmux.conf's `bind c new-window -c …` line.
+FMT='#{?#{!=:#{@session_root},},#{@session_root},#{pane_current_path}}'
+
+SOCKET="test-session-root-$$"
+T=(tmux -L "$SOCKET")
+
+cleanup() { "${T[@]}" kill-server 2>/dev/null || true; rm -rf "$DIR_A" "$DIR_B"; }
+trap cleanup EXIT
+
+pass=0
+fail=0
+fail_msgs=()
+
+assert_eq() {
+  local got="$1" want="$2" desc="$3"
+  if [ "$got" = "$want" ]; then
+    pass=$((pass+1)); echo "  PASS  $desc"
+  else
+    fail=$((fail+1))
+    fail_msgs+=("FAIL  $desc"$'\n'"        got:  '$got'"$'\n'"        want: '$want'")
+    echo "  FAIL  $desc"
+  fi
+}
+
+assert_contains() {
+  local hay="$1" needle="$2" desc="$3"
+  if printf '%s' "$hay" | grep -q -F -- "$needle"; then
+    pass=$((pass+1)); echo "  PASS  $desc"
+  else
+    fail=$((fail+1))
+    fail_msgs+=("FAIL  $desc"$'\n'"        needle not found: '$needle'")
+    echo "  FAIL  $desc"
+  fi
+}
+
+echo
+echo "tmux @session_root format string"
+echo "────────────────────────────────"
+
+# Use real paths (resolves macOS /var -> /private/var) so display-message
+# returns paths in the form we compare against.
+DIR_A=$(mktemp -d); DIR_A=$(cd "$DIR_A" && pwd -P)
+DIR_B=$(mktemp -d); DIR_B=$(cd "$DIR_B" && pwd -P)
+
+# Bring up an isolated server with one session whose start dir is DIR_A.
+"${T[@]}" new-session -d -s s1 -c "$DIR_A"
+
+# Test 1: @session_root set -> resolves to its value.
+"${T[@]}" set-option -t s1 @session_root "$DIR_B"
+got=$("${T[@]}" display-message -p -t s1 "$FMT")
+assert_eq "$got" "$DIR_B" "@session_root set -> format resolves to its value"
+
+# Test 2: @session_root unset -> falls back to pane_current_path.
+"${T[@]}" set-option -u -t s1 @session_root
+got=$("${T[@]}" display-message -p -t s1 "$FMT")
+assert_eq "$got" "$DIR_A" "@session_root unset -> format falls back to pane_current_path"
+
+# Test 3: tmux.conf actually contains the binding using @session_root.
+conf=$(cat "$CONF")
+assert_contains "$conf" "bind c new-window -c" \
+  "tmux.conf has 'bind c new-window -c' (overrides default <prefix> c)"
+assert_contains "$conf" "@session_root" \
+  "tmux.conf references @session_root (the <prefix> c binding consumes it)"
+
+# Summary
+echo
+echo "─────────────────"
+echo "test-s-session-root.sh passed: $pass"
+echo "test-s-session-root.sh failed: $fail"
+if [ "$fail" -gt 0 ]; then
+  echo
+  printf '%s\n' "${fail_msgs[@]}"
+  exit 1
+fi
+exit 0

--- a/scripts/test-s.sh
+++ b/scripts/test-s.sh
@@ -245,6 +245,8 @@ SHIM
   assert_contains "$log" "new-session -d -s dotfiles -c /tmp/fakerepo" \
     "1-arg-out creates tmux session at project path"
   assert_contains "$log" "attach -t dotfiles" "1-arg-out attaches (TMUX unset)"
+  assert_contains "$log" "set-option -t dotfiles @session_root /tmp/fakerepo" \
+    "1-arg-out stamps @session_root with project root"
   rm -rf "$shimdir"
 
   # ─── 2-arg out: session=<project>/<name>, wt creates worktree ──────
@@ -263,6 +265,8 @@ SHIM
   assert_contains "$log" "new-session -d -s dotfiles/feature-x -c /tmp/fakerepo/.claude/worktrees/feature-x" \
     "2-arg-out creates tmux session named <project>/<name> at worktree path"
   assert_contains "$log" "attach -t dotfiles/feature-x" "2-arg-out attaches (TMUX unset)"
+  assert_contains "$log" "set-option -t dotfiles/feature-x @session_root /tmp/fakerepo/.claude/worktrees/feature-x" \
+    "2-arg-out stamps @session_root on the session"
   rm -rf "$shimdir"
 
   # ─── 2-arg in tmux: switch-client instead of attach ─────────────────
@@ -288,16 +292,22 @@ SHIM
     pass=$((pass+1))
     echo "  PASS  in-tmux does not use 'attach -t'"
   fi
+  assert_contains "$log" "set-option -t dotfiles/feature-x @session_root /tmp/fakerepo/.claude/worktrees/feature-x" \
+    "2-arg-in stamps @session_root on the session"
   rm -rf "$shimdir"
 
-  # ─── has-session short-circuit: no wt call, no new-session ─────────
+  # ─── has-session short-circuit: no new-session, but wt + stamp still run ──
+  # When the session already exists, we skip new-session creation but STILL
+  # call wt (idempotent per bin/s:25) and re-stamp @session_root — the latter
+  # is how we self-heal after tmux-continuum restores wipe session options.
   shimdir=$(make_shimdir)
   write_sesh_shim "$shimdir" '[{"Name":"dotfiles","Path":"/tmp/fakerepo"}]'
   write_tmux_shim "$shimdir"
   echo 0 >"$shimdir/tmux.has_session_exit"   # session "exists"
   cat >"$shimdir/wt" <<SHIM
 #!/usr/bin/env bash
-echo "wt should not be called when session already exists" >&2; exit 99
+echo "\$@" >>"$shimdir/wt.log"
+printf '{"action":"existing","branch":"feature-x","path":"/tmp/fakerepo/.claude/worktrees/feature-x"}\n'
 SHIM
   chmod +x "$shimdir/wt"
   out=$(env -u TMUX PATH="$shimdir:$PATH" "$S" dotfiles feature-x 2>&1); rc=$?
@@ -311,6 +321,8 @@ SHIM
     pass=$((pass+1))
     echo "  PASS  has-session=0 skips new-session"
   fi
+  assert_contains "$log" "set-option -t dotfiles/feature-x @session_root /tmp/fakerepo/.claude/worktrees/feature-x" \
+    "has-session=0 still stamps @session_root (handles post-restore wipe)"
   assert_contains "$log" "attach -t dotfiles/feature-x" "has-session=0 still attaches"
   rm -rf "$shimdir"
 
@@ -333,6 +345,8 @@ SHIM
   log=$(cat "$shimdir/tmux.log")
   assert_contains "$log" "new-session -d -s dotfiles -c $fixture_real" \
     "picker creates session at picked project path"
+  assert_contains "$log" "set-option -t dotfiles @session_root $fixture_real" \
+    "picker stamps @session_root with picked project path"
   rm -rf "$shimdir" "$fixture"
 
   # ─── 1-arg in tmux: session=<project>/<name>, wt creates worktree ──
@@ -356,6 +370,8 @@ SHIM
     "1-arg in-tmux creates session named <inferred-project>/<name> at worktree"
   assert_contains "$log" "switch-client -t fixproject/feature-y" \
     "1-arg in-tmux uses switch-client"
+  assert_contains "$log" "set-option -t fixproject/feature-y @session_root $fixture_real/.claude/worktrees/feature-y" \
+    "1-arg-in stamps @session_root with worktree path"
   rm -rf "$shimdir" "$fixture"
 fi
 


### PR DESCRIPTION
## Summary

- `<prefix> c` (new window) in `s`-created sessions now opens at the session root (worktree path or project root) rather than inheriting the current pane's cwd. Splits are unchanged — house rule keeps them at `pane_current_path`.
- Producer/consumer split via a session-scoped tmux user option `@session_root`: `bin/s` stamps it on every invocation; `tmux.conf` reads it from the new-window binding with a `pane_current_path` fallback.
- Re-stamping on every `s` invocation is the persistence story across `tmux-continuum` restores — no plugin or file persistence needed.

## Mechanism

`bin/s` sets `@session_root` to the worktree path (worktree dispatch cases) or project root (non-worktree dispatch cases) before `finish`. `tmux.conf` overrides `bind c` with:

```tmux
bind c new-window -c "#{?#{!=:#{@session_root},},#{@session_root},#{pane_current_path}}"
```

Format mirrors the existing `@claude_session_name` emptiness test in `tmux.conf`. Sessions not started by `s` have no `@session_root` → fallback to `pane_current_path` (tmux default behavior, no regression).

## Test plan

- [x] `bash scripts/test-s.sh` — 43/43 pass (existing shim-based tests + 6 new `assert_contains` checks for `set-option @session_root` across all dispatch cases)
- [x] `bash scripts/test-s-session-root.sh` — 4/4 pass (new integration test: isolated tmux server, `display-message -p` to evaluate the binding's format-string for both arms; plus grep assertions on `tmux.conf`)
- [x] Worktree clean, three focused commits