### PR TITLE
feat: install btop as modern Solarized top replacement

### DIFF
--- a/.config/btop/btop.conf
+++ b/.config/btop/btop.conf
@@ -1,0 +1,16 @@
+# btop config — only the deltas from default.
+# Everything not listed here rides btop's defaults so upstream
+# improvements land without us having to touch this file.
+
+# Match the rest of the terminal stack (eza, bat, delta, glow, nvim,
+# tmux, ghostty all on Solarized Dark). solarized_dark is built into
+# btop — no theme file to vendor.
+color_theme = "solarized_dark"
+
+# Don't paint over the terminal background. Same logic as why ghostty
+# and tmux defer to the terminal palette: avoids double-tinting and
+# keeps the border between btop and surrounding panes clean.
+theme_background = False
+
+# h/j/k/l navigation. Matches nvim and tmux pane nav (prefix h/j/k/l).
+vim_keys = True

--- a/.zshrc
+++ b/.zshrc
@@ -159,6 +159,9 @@ if command -v nvim >/dev/null 2>&1; then
   alias vi='command vim'
   alias vimdiff='vim -d'
 fi
+if command -v btop >/dev/null 2>&1; then
+  alias top='btop'
+fi
 
 # ─── Plugins (order matters) ─────────────────────────────────────
 # Required order:

--- a/Brewfile
+++ b/Brewfile
@@ -31,3 +31,6 @@ brew "vivid"                    # generates LS_COLORS palettes
 brew "zsh-syntax-highlighting"  # live command-line highlighting
 brew "zsh-autosuggestions"      # ghost-text completion from history
 brew "fzf-tab"                  # fzf-driven Tab completion menu
+
+# System monitoring
+brew "btop"                     # modern top replacement (themed Solarized)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,6 +179,15 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
   `~/Library/Preferences/glow/`, not `~/.config/glow/`. Don't swap to `mdcat`,
   `frogmouth`, or another renderer without an explicit ask. (`mdcat` was
   considered and ruled out: archived upstream as of 2025-01-10.)
+- **`top` is a zsh alias to `btop`** (defined in `.zshrc`, guarded on
+  `command -v btop`). Theme is pinned `solarized_dark` via
+  `.config/btop/btop.conf` (only `color_theme`,
+  `theme_background = False`, and `vim_keys = True` are pinned —
+  everything else rides btop defaults). macOS `top` is reachable via
+  `command top` or `\top`. Don't replace btop with htop or vendor a
+  custom Solarized theme file — `solarized_dark` is built-in. Don't
+  pin more keys without a clear reason — small diff = easy upstream
+  bumps.
 
 ## Where things live
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -42,6 +42,9 @@ link ".config/worktrunk" "$HOME/.config/worktrunk"
 # --- glow
 link ".config/glow"    "$HOME/.config/glow"
 
+# --- btop
+link ".config/btop"    "$HOME/.config/btop"
+
 # --- sesh: shared config is symlinked; machine-local sessions in sesh.local.toml
 link ".config/sesh/sesh.toml" "$HOME/.config/sesh/sesh.toml"
 if [ ! -f "$HOME/.config/sesh/sesh.local.toml" ]; then

--- a/docs/shell-colors-cheatsheet.html
+++ b/docs/shell-colors-cheatsheet.html
@@ -78,6 +78,7 @@
       <tr><td class="key"><code>la</code></td><td class="desc">→ <code>ll -a</code></td></tr>
       <tr><td class="key"><code>vim</code> / <code>vimdiff</code></td><td class="desc">→ <code>nvim</code> (guarded on <code>command -v nvim</code>)</td></tr>
       <tr><td class="key"><code>vi</code></td><td class="desc">→ <code>command vim</code> (legacy minimal vim, suppresses recursive alias)</td></tr>
+      <tr><td class="key"><code>top</code></td><td class="desc">→ <code>btop</code> (modern colorful TUI, Solarized; <code>command top</code> for BSD top)</td></tr>
     </table>
     <p class="note">BSD <code>\ls</code> still works (escape skips alias) and uses OMZ's default LSCOLORS. Use <code>command less</code> to reach real <code>less</code> for <code>less +F</code>, <code>-R</code>, etc.</p>
   </div>
@@ -459,7 +460,7 @@
 </ol>
 
 <footer>
-  Built from <code>~/.zshrc</code>, <code>Brewfile</code>, and project CLAUDE.md on 2026-04-30.
+  Built from <code>~/.zshrc</code>, <code>Brewfile</code>, and project CLAUDE.md on 2026-05-02.
   Refresh after meaningful color-tooling changes.
 </footer>
 


### PR DESCRIPTION
## Summary

- Add `btop` (modern, colorful TUI process monitor) to the `Brewfile` in a new "System monitoring" section.
- Pin a 3-line `~/.config/btop/btop.conf` symlinked from the repo: `solarized_dark` theme, transparent background, vim keys. All other btop settings ride defaults so upstream improvements land cleanly.
- Symlink `.config/btop` via `bootstrap.sh` (mirrors the ghostty/tmux/glow pattern).
- Alias `top` → `btop` in `.zshrc` (guarded on `command -v btop`); `command top` and `\top` still reach macOS BSD top for one-shot batch output.
- Document the convention in root `CLAUDE.md`; add a row to `docs/shell-colors-cheatsheet.html` and refresh its footer date.

Built-in `solarized_dark` theme (ships with btop) — no theme file vendored.

## Test plan

- [x] `brew bundle check --file=Brewfile` reports satisfied (btop installed via `brew install btop`).
- [x] `BTOP_CONFIG_DIR=$PWD/.config/btop btop --version` runs cleanly (config parses without errors).
- [x] `zsh -c "source .zshrc; type top"` returns `top is an alias for btop`.
- [x] `/usr/bin/top -l 1 -n 1` still produces BSD-`top` output (escape hatch unaffected).
- [x] `solarized_dark.theme` ships with btop at `$(brew --prefix btop)/share/btop/themes/`.
- [ ] After merge: re-run `bootstrap.sh` from the main checkout — expect `linked: ~/.config/btop -> .../dotfiles/.config/btop` first run, `ok:` on re-run.
- [ ] After merge: open a fresh terminal, run `top` — expect btop's TUI with Solarized Dark gradient bars; terminal background visible behind it (no double-tint); `j`/`k` navigate processes.