### PR TITLE
feat(procs): Solarized ps replacement with ps/psh aliases

### DIFF
--- a/.config/procs/procs-heavy.toml
+++ b/.config/procs/procs-heavy.toml
@@ -1,0 +1,105 @@
+# .config/procs/procs-heavy.toml — "what's hot right now" view.
+# Loaded by `psh` (alias in .zshrc) via `--load-config`. Trimmed column set
+# (Pid, User, UsageCpu, UsageMem, VmRss, Command) and default sort by
+# UsageCpu descending so heavy processes float to the top.
+#
+# [style.*] blocks are kept in sync with .config/procs/procs.toml — `procs
+# --load-config` replaces the whole config (no inheritance), so duplication
+# is intentional. When tweaking colors, update both files.
+
+[[columns]]
+kind = "Pid"
+style = "BrightMagenta|Magenta"
+numeric_search = true
+nonnumeric_search = false
+align = "Left"
+
+[[columns]]
+kind = "User"
+style = "BrightBlue|Blue"
+numeric_search = false
+nonnumeric_search = true
+align = "Left"
+
+[[columns]]
+kind = "Separator"
+style = "White|BrightBlack"
+numeric_search = false
+nonnumeric_search = false
+align = "Left"
+
+[[columns]]
+kind = "UsageCpu"
+style = "ByPercentage"
+numeric_search = false
+nonnumeric_search = false
+align = "Right"
+
+[[columns]]
+kind = "UsageMem"
+style = "ByPercentage"
+numeric_search = false
+nonnumeric_search = false
+align = "Right"
+
+[[columns]]
+kind = "VmRss"
+style = "ByUnit"
+numeric_search = false
+nonnumeric_search = false
+align = "Right"
+
+[[columns]]
+kind = "Separator"
+style = "White|BrightBlack"
+numeric_search = false
+nonnumeric_search = false
+align = "Left"
+
+[[columns]]
+kind = "Command"
+style = "BrightWhite|Black"
+numeric_search = false
+nonnumeric_search = true
+align = "Left"
+
+[style]
+header = "BrightWhite|Black"
+unit = "BrightWhite|Black"
+tree = "BrightWhite|Black"
+
+[style.by_percentage]
+color_000 = "BrightBlue|Blue"
+color_025 = "BrightGreen|Green"
+color_050 = "BrightYellow|Yellow"
+color_075 = "BrightRed|Red"
+color_100 = "BrightRed|Red"
+
+[style.by_state]
+color_d = "BrightRed|Red"
+color_r = "BrightGreen|Green"
+color_s = "BrightBlue|Blue"
+color_t = "BrightCyan|Cyan"
+color_z = "BrightMagenta|Magenta"
+color_x = "BrightMagenta|Magenta"
+color_k = "BrightYellow|Yellow"
+color_w = "BrightYellow|Yellow"
+color_p = "BrightYellow|Yellow"
+
+[style.by_unit]
+color_k = "BrightBlue|Blue"
+color_m = "BrightGreen|Green"
+color_g = "BrightYellow|Yellow"
+color_t = "BrightRed|Red"
+color_p = "BrightRed|Red"
+color_x = "BrightBlue|Blue"
+
+[search]
+numeric_search = "Exact"
+nonnumeric_search = "Partial"
+logic = "And"
+case = "Smart"
+
+[sort]
+column = 3
+order = "Descending"

--- a/.config/procs/procs.toml
+++ b/.config/procs/procs.toml
@@ -1,0 +1,120 @@
+# .config/procs/procs.toml — Solarized-themed defaults for `procs`.
+# Used by bare `procs` and the `ps` alias. Two-color overrides on Pid (violet)
+# and User (blue) for Solarized accent contrast; everything else mirrors
+# procs's `--gen-config` defaults, which already match Solarized's palette
+# (BrightBlue→BrightGreen→BrightYellow→BrightRed gradient for percentages).
+#
+# Companion file `.config/procs/procs-heavy.toml` is loaded by the `psh`
+# alias; keep the [style.*] blocks in sync between the two files because
+# `procs --load-config` replaces the whole config (no inheritance).
+
+[[columns]]
+kind = "Pid"
+style = "BrightMagenta|Magenta"
+numeric_search = true
+nonnumeric_search = false
+align = "Left"
+
+[[columns]]
+kind = "User"
+style = "BrightBlue|Blue"
+numeric_search = false
+nonnumeric_search = true
+align = "Left"
+
+[[columns]]
+kind = "Separator"
+style = "White|BrightBlack"
+numeric_search = false
+nonnumeric_search = false
+align = "Left"
+
+[[columns]]
+kind = "Tty"
+style = "BrightWhite|Black"
+numeric_search = false
+nonnumeric_search = false
+align = "Left"
+
+[[columns]]
+kind = "UsageCpu"
+style = "ByPercentage"
+numeric_search = false
+nonnumeric_search = false
+align = "Right"
+
+[[columns]]
+kind = "UsageMem"
+style = "ByPercentage"
+numeric_search = false
+nonnumeric_search = false
+align = "Right"
+
+[[columns]]
+kind = "CpuTime"
+style = "BrightCyan|Cyan"
+numeric_search = false
+nonnumeric_search = false
+align = "Left"
+
+[[columns]]
+kind = "MultiSlot"
+style = "ByUnit"
+numeric_search = false
+nonnumeric_search = false
+align = "Right"
+
+[[columns]]
+kind = "Separator"
+style = "White|BrightBlack"
+numeric_search = false
+nonnumeric_search = false
+align = "Left"
+
+[[columns]]
+kind = "Command"
+style = "BrightWhite|Black"
+numeric_search = false
+nonnumeric_search = true
+align = "Left"
+
+[style]
+header = "BrightWhite|Black"
+unit = "BrightWhite|Black"
+tree = "BrightWhite|Black"
+
+[style.by_percentage]
+color_000 = "BrightBlue|Blue"
+color_025 = "BrightGreen|Green"
+color_050 = "BrightYellow|Yellow"
+color_075 = "BrightRed|Red"
+color_100 = "BrightRed|Red"
+
+[style.by_state]
+color_d = "BrightRed|Red"
+color_r = "BrightGreen|Green"
+color_s = "BrightBlue|Blue"
+color_t = "BrightCyan|Cyan"
+color_z = "BrightMagenta|Magenta"
+color_x = "BrightMagenta|Magenta"
+color_k = "BrightYellow|Yellow"
+color_w = "BrightYellow|Yellow"
+color_p = "BrightYellow|Yellow"
+
+[style.by_unit]
+color_k = "BrightBlue|Blue"
+color_m = "BrightGreen|Green"
+color_g = "BrightYellow|Yellow"
+color_t = "BrightRed|Red"
+color_p = "BrightRed|Red"
+color_x = "BrightBlue|Blue"
+
+[search]
+numeric_search = "Exact"
+nonnumeric_search = "Partial"
+logic = "And"
+case = "Smart"
+
+[sort]
+column = 0
+order = "Ascending"

--- a/.zshrc
+++ b/.zshrc
@@ -154,6 +154,10 @@ if command -v glow >/dev/null 2>&1; then
   alias md='glow --style $HOME/.config/glow/glamour.json'
   alias mdp='md -p'
 fi
+if command -v procs >/dev/null 2>&1; then
+  alias ps='procs'
+  alias psh='procs --load-config $HOME/.config/procs/procs-heavy.toml'
+fi
 if command -v nvim >/dev/null 2>&1; then
   alias vim='nvim'
   alias vi='command vim'

--- a/Brewfile
+++ b/Brewfile
@@ -28,6 +28,7 @@ brew "bat"                      # syntax-highlighted cat / man pager backend
 brew "git-delta"                # git diff/log/blame pager
 brew "glow"                     # render markdown to ANSI
 brew "vivid"                    # generates LS_COLORS palettes
+brew "procs"                    # modern ps replacement (Rust)
 brew "zsh-syntax-highlighting"  # live command-line highlighting
 brew "zsh-autosuggestions"      # ghost-text completion from history
 brew "fzf-tab"                  # fzf-driven Tab completion menu

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,10 +149,13 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
   an explicit ask.
 - **Shell colors are Solarized Dark, end-to-end.** Tools: `eza` (ls),
   `bat` (cat + `MANPAGER`), `git-delta` (git pager), `glow` (`md` markdown
-  renderer), `vivid` (`LS_COLORS`), `zsh-syntax-highlighting`,
-  `zsh-autosuggestions`, `fzf-tab` (Tab completion picker). Palette pins:
+  renderer), `vivid` (`LS_COLORS`), `procs` (`ps` replacement),
+  `zsh-syntax-highlighting`, `zsh-autosuggestions`, `fzf-tab` (Tab completion
+  picker). Palette pins:
   `vivid generate solarized-dark`, `bat --theme="Solarized (dark)"`,
-  `delta.syntax-theme = "Solarized (dark)"`,
+  `delta.syntax-theme = "Solarized (dark)"`, `procs` reads
+  `.config/procs/procs.toml` (Pid=violet, User=blue, percentage gradient
+  blue→green→yellow→red),
   `md` alias passes `--style .config/glow/glamour.json` (chroma
   `solarized-dark` for fenced code blocks). Don't swap themes or
   introduce alternatives (`exa`, `lsd`, `diff-so-fancy`, `mdcat`, etc.)
@@ -163,6 +166,20 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
   before any plugin that wraps widgets. The first-time `git config`
   recipe wiring delta as git's pager
   lives in [`README.md`](README.md) → "Setup (new machine)".
+- **`ps` is aliased to `procs`** (modern ps replacement; Rust). Two
+  Solarized-themed configs live in `.config/procs/`: `procs.toml` (default,
+  PID asc, ps-like columns) is read by bare `procs` / `ps`;
+  `procs-heavy.toml` (UsageCpu desc, trimmed columns
+  `Pid User UsageCpu UsageMem VmRss Command`) is loaded by the `psh` alias
+  via `--load-config`. The two TOMLs duplicate their `[style.*]` blocks on
+  purpose — `procs --load-config` replaces the entire config (no
+  inheritance), so style edits must touch both files. Aliases are guarded
+  on `command -v procs`. Escape hatches: `command ps`, `\ps`, `/bin/ps`
+  reach legacy `ps`; non-interactive shells (scripts) never see the alias.
+  macOS caveat: `procs` only shows the current user's processes even with
+  no filter (Apple gates cross-user visibility behind elevated privileges);
+  for "show all system daemons" use `\ps -ax`. Don't add a `psx` alias for
+  the all-users view — legacy `ps` already serves it without a sudo prompt.
 - **Interactive `less` is a `bat` wrapper** (defined in `.zshrc` next to the
   `cat` alias). Files get bat's full decoration; piped input uses `--plain` so
   `cmd | less` stays clean. `command less` reaches real `less` for `less +F`,

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -42,6 +42,9 @@ link ".config/worktrunk" "$HOME/.config/worktrunk"
 # --- glow
 link ".config/glow"    "$HOME/.config/glow"
 
+# --- procs (modern ps; Solarized config + procs-heavy.toml for `psh`)
+link ".config/procs"   "$HOME/.config/procs"
+
 # --- sesh: shared config is symlinked; machine-local sessions in sesh.local.toml
 link ".config/sesh/sesh.toml" "$HOME/.config/sesh/sesh.toml"
 if [ ! -f "$HOME/.config/sesh/sesh.local.toml" ]; then

--- a/docs/shell-colors-cheatsheet.html
+++ b/docs/shell-colors-cheatsheet.html
@@ -16,7 +16,7 @@
 <header>
   <h1>Shell Colors — Getting Started &amp; Cheatsheet</h1>
   <div class="sub">
-    Solarized Dark, end-to-end &middot; eza · bat · git-delta · glow · vivid · fzf · fzf-tab · zsh-autosuggestions · zsh-syntax-highlighting
+    Solarized Dark, end-to-end &middot; eza · bat · git-delta · glow · vivid · procs · fzf · fzf-tab · zsh-autosuggestions · zsh-syntax-highlighting
   </div>
 </header>
 
@@ -24,6 +24,7 @@
   <strong style="color:var(--base2)">Jump:</strong>
   <a href="#start">Getting started</a>
   <a href="#eza">eza</a>
+  <a href="#procs">procs</a>
   <a href="#bat">bat</a>
   <a href="#less">less wrapper</a>
   <a href="#delta">git-delta</a>
@@ -49,6 +50,7 @@
       <tr><td class="key"><code>git-delta</code></td><td class="desc">git diff/log/blame pager</td></tr>
       <tr><td class="key"><code>glow</code></td><td class="desc">render markdown to ANSI (powers <code>md</code> alias)</td></tr>
       <tr><td class="key"><code>vivid</code></td><td class="desc">generates LS_COLORS palettes</td></tr>
+      <tr><td class="key"><code>procs</code></td><td class="desc">modern ps replacement (Rust)</td></tr>
       <tr><td class="key"><code>zsh-autosuggestions</code></td><td class="desc">ghost-text completion from history</td></tr>
       <tr><td class="key"><code>zsh-syntax-highlighting</code></td><td class="desc">live command-line highlighting</td></tr>
       <tr><td class="key"><code>fzf</code></td><td class="desc">fuzzy finder + Ctrl-R / Ctrl-T bindings</td></tr>
@@ -78,8 +80,10 @@
       <tr><td class="key"><code>la</code></td><td class="desc">→ <code>ll -a</code></td></tr>
       <tr><td class="key"><code>vim</code> / <code>vimdiff</code></td><td class="desc">→ <code>nvim</code> (guarded on <code>command -v nvim</code>)</td></tr>
       <tr><td class="key"><code>vi</code></td><td class="desc">→ <code>command vim</code> (legacy minimal vim, suppresses recursive alias)</td></tr>
+      <tr><td class="key"><code>ps</code></td><td class="desc">→ <code>procs</code> (Solarized; PID asc; ps-like columns)</td></tr>
+      <tr><td class="key"><code>psh</code></td><td class="desc">→ <code>procs --load-config ~/.config/procs/procs-heavy.toml</code> (CPU desc, trimmed)</td></tr>
     </table>
-    <p class="note">BSD <code>\ls</code> still works (escape skips alias) and uses OMZ's default LSCOLORS. Use <code>command less</code> to reach real <code>less</code> for <code>less +F</code>, <code>-R</code>, etc.</p>
+    <p class="note">BSD <code>\ls</code> still works (escape skips alias) and uses OMZ's default LSCOLORS. Use <code>command less</code> to reach real <code>less</code> for <code>less +F</code>, <code>-R</code>, etc. <code>command ps</code> / <code>\ps</code> / <code>/bin/ps</code> reach legacy <code>ps</code>.</p>
   </div>
 
 </div>
@@ -112,6 +116,45 @@
       <tr><td class="key"><code>eza -l --time-style=long-iso</code></td><td class="desc">ISO timestamps</td></tr>
     </table>
     <p class="note">Colors come from <code>LS_COLORS</code> (set by <code>vivid</code>). Icons need a Nerd Font in your terminal.</p>
+  </div>
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════════════════ -->
+<h2 id="procs">procs <span class="tool-tag">modern ps</span></h2>
+
+<div class="grid">
+  <div class="card">
+    <h3>Most-used flags</h3>
+    <table>
+      <tr><td class="key"><code>procs</code></td><td class="desc">all your processes, Solarized columns, sort by PID</td></tr>
+      <tr><td class="key"><code>procs zsh</code></td><td class="desc">regex search across PID/User/Command (replaces <code>ps | grep</code>)</td></tr>
+      <tr><td class="key"><code>procs --tree</code></td><td class="desc">parent/child tree view</td></tr>
+      <tr><td class="key"><code>procs --watch</code></td><td class="desc">refresh every 1s; <code>--watch-interval N</code> for custom</td></tr>
+      <tr><td class="key"><code>procs --sortd UsageCpu</code></td><td class="desc">sort by CPU descending (asc = <code>--sorta</code>)</td></tr>
+      <tr><td class="key"><code>procs --insert VmRss</code></td><td class="desc">add a column on the fly (kinds: <code>procs --list</code>)</td></tr>
+    </table>
+  </div>
+
+  <div class="card">
+    <h3>Aliases &amp; configs</h3>
+    <table>
+      <tr><td class="key"><code>ps</code></td><td class="desc">→ <code>procs</code> (default Solarized view)</td></tr>
+      <tr><td class="key"><code>psh</code></td><td class="desc">→ <code>procs --load-config ~/.config/procs/procs-heavy.toml</code> (CPU desc, trimmed)</td></tr>
+      <tr><td class="key"><code>~/.config/procs/procs.toml</code></td><td class="desc">default config (in-repo, symlinked)</td></tr>
+      <tr><td class="key"><code>~/.config/procs/procs-heavy.toml</code></td><td class="desc">trimmed columns + CPU-desc; loaded by <code>psh</code></td></tr>
+    </table>
+    <p class="note">Both TOMLs duplicate their <code>[style.*]</code> blocks; <code>procs --load-config</code> replaces the whole config (no inheritance). Edit both when tweaking colors.</p>
+  </div>
+
+  <div class="card">
+    <h3>macOS caveat</h3>
+    <p>
+      <code>procs</code> on macOS only shows <strong>your own</strong> processes — Apple gates
+      cross-user visibility behind elevated privileges. To see system daemons (the
+      <code>_appstore</code>, <code>_audiomxd</code>, etc. that <code>ps&nbsp;-ax</code> shows), fall through to legacy:
+      <code>\ps&nbsp;-ax</code> or <code>command&nbsp;ps&nbsp;-ax</code>.
+    </p>
+    <p class="note">Pipes strip color (<code>color_mode = "Auto"</code>). Prefer <code>procs &lt;pat&gt;</code> over <code>ps&nbsp;|&nbsp;grep&nbsp;&lt;pat&gt;</code> — same result, colors preserved.</p>
   </div>
 </div>
 
@@ -459,7 +502,7 @@
 </ol>
 
 <footer>
-  Built from <code>~/.zshrc</code>, <code>Brewfile</code>, and project CLAUDE.md on 2026-04-30.
+  Built from <code>~/.zshrc</code>, <code>Brewfile</code>, and project CLAUDE.md on 2026-05-02.
   Refresh after meaningful color-tooling changes.
 </footer>
 


### PR DESCRIPTION
## Summary

- Adds `dalance/procs` as a Solarized-themed `ps` replacement.
- Two interactive aliases:
  - `ps` → `procs` (default columns, PID asc).
  - `psh` → `procs --load-config ~/.config/procs/procs-heavy.toml` (trimmed columns: Pid User UsageCpu UsageMem VmRss Command, sort by CPU desc).
- Configs live at `.config/procs/{procs,procs-heavy}.toml` and are symlinked into `~/.config/procs/` by `bootstrap.sh`.
- Brewfile entry, project CLAUDE.md convention bullet + palette pin, shell-colors cheatsheet section (TOC, brew table row, alias rows, dedicated procs section, footer date).

## Test plan

- [x] `brew bundle check --file=Brewfile --verbose` is satisfied.
- [x] `./bootstrap.sh` is idempotent; `~/.config/procs/{procs,procs-heavy}.toml` resolve.
- [x] `procs --load-config .config/procs/procs.toml | head` renders Solarized output with `PID:▲` sort indicator.
- [x] `procs --load-config .config/procs/procs-heavy.toml | head` renders trimmed columns with `CPU:▼` sort indicator.
- [x] `./scripts/test-helpers.sh` passes (regression check).
- [ ] Cheatsheet at `docs/shell-colors-cheatsheet.html` renders with the new `procs` section, updated TOC, and new alias rows (visual check).

## Notes

- macOS caveat (documented): `procs` only shows the current user's processes; legacy `ps -ax` (via `\ps`, `command ps`, or `/bin/ps`) still reaches all-users view. No `psx` alias.
- Style blocks duplicated across the two TOMLs because `procs --load-config` replaces the whole config — no inheritance.