### PR TITLE
fix(tmux): correct sesh-picker popup height (closes #58)

### DIFF
--- a/.config/tmux/bin/tmux-sesh-picker
+++ b/.config/tmux/bin/tmux-sesh-picker
@@ -7,16 +7,25 @@
 # tmux's event loop should not block on the wrapper itself.
 #
 # Sources for `sesh list` MUST mirror the `sesh picker` flag set so the
-# count matches what fzf will display.
+# count matches what the picker will display.
 set -euo pipefail
 
-readonly BUFFER=4         # popup border (top+bottom = 2) + fzf prompt + fzf info line
-readonly MIN=6            # smallest usable popup
+# Vertical overhead the wrapper has to budget for. Two distinct owners:
+#  - SESH_CHROME: rows sesh's bubbletea TUI subtracts in
+#    picker/tui.go visibleCount() (border + title + filter + counter +
+#    help + blanks). If sesh upstream changes this, bump SESH_CHROME.
+#  - POPUP_BORDER: rows tmux draws around its display-popup. If the popup
+#    is ever opened with `-B` (no border), drop POPUP_BORDER to 0.
+readonly SESH_CHROME=9
+readonly POPUP_BORDER=2
+readonly MIN=12           # SESH_CHROME + POPUP_BORDER + 1 visible item
 readonly DEFAULT=15       # fallback when `sesh list` fails (close to old visual size)
 readonly MAX_PCT=80       # cap as percentage of client height
 
 # Count entries; distinguish "0 items" from "command failed" by exit code.
-if list_output=$(sesh list -c -t -T 2>/dev/null); then
+# Flags MUST mirror the picker's non-display flags: -d -H -c -t -T.
+# (Picker also has -i, but icons are display-only and don't change the count.)
+if list_output=$(sesh list -d -H -c -t -T 2>/dev/null); then
   if [[ -n "$list_output" ]]; then
     count=$(printf '%s' "$list_output" | grep -c . || true)
   else
@@ -29,7 +38,7 @@ fi
 if [[ -z "$count" ]]; then
   H=$DEFAULT
 else
-  H=$((count + BUFFER))
+  H=$((count + SESH_CHROME + POPUP_BORDER))
   (( H < MIN )) && H=$MIN
 fi
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,9 +70,10 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
   tmux / tmuxinator). The binding is
   `run -b ~/.config/tmux/bin/tmux-sesh-picker` (not inline
   `display-popup`): the wrapper counts entries via
-  `sesh list -c -t -T`, then opens
-  `display-popup -E -w 70% -h "$H"` where `H = items + 4` clamped
-  to `[6, 80% of client height]` (fallback `15` if `sesh list`
+  `sesh list -d -H -c -t -T` (mirrors the picker's flag set), then opens
+  `display-popup -E -w 70% -h "$H"` where
+  `H = items + 11` (sesh chrome 9 + tmux popup border 2), clamped
+  to `[12, 80% of client height]` (fallback `15` if `sesh list`
   fails). Width stays at 70% — shared anchor with the URL and
   file pickers; height is dynamic. Don't fold the wrapper back
   inline — recomputing the height per keypress requires a real

--- a/docs/tmux-cheatsheet.html
+++ b/docs/tmux-cheatsheet.html
@@ -129,8 +129,9 @@
     </p>
     <p class="note">
       Popup width is fixed at 70% (shared anchor with the URL and file pickers);
-      height is dynamic — <code>items + 4</code>, clamped to <code>[6, 80% of
-      client height]</code>, falling back to <code>15</code> if
+      height is dynamic — <code>items + 11</code> (sesh chrome 9 + popup border 2),
+      clamped to <code>[12, 80% of client height]</code>, falling back to
+      <code>15</code> if
       <code>sesh list</code> fails. Width gives long
       <code>&lt;project&gt;/&lt;worktree&gt;</code> session names room; sizing
       height to the entry count keeps the popup compact.
@@ -385,7 +386,7 @@
 </table>
 
 <footer>
-  Built from <code>~/.config/tmux/tmux.conf</code> on 2026-05-01. Refresh after meaningful config changes.
+  Built from <code>~/.config/tmux/tmux.conf</code> on 2026-05-02. Refresh after meaningful config changes.
   <br>
   When in doubt: <span class="k prefix">C-a</span> <span class="k">?</span> for the live keymap list.
 </footer>

--- a/scripts/test-tmux-sesh-picker.sh
+++ b/scripts/test-tmux-sesh-picker.sh
@@ -2,7 +2,8 @@
 # Smoke tests for the <prefix> t sesh-picker wrapper.
 #
 # Verifies popup height math:
-#   H = max(MIN, count + BUFFER), clamped above by floor(client_height * MAX_PCT/100).
+#   H = max(MIN, count + SESH_CHROME + POPUP_BORDER),
+#   clamped above by floor(client_height * MAX_PCT/100).
 #   On `sesh list` failure, H = DEFAULT (still clamped above).
 #
 # Strategy: prepend a tempdir with fake `sesh` and `tmux` shims to PATH;
@@ -78,19 +79,23 @@ trap 'rm -rf "$SHIM_DIR"' EXIT
 setup_shims "$SHIM_DIR"
 export CAPTURE_FILE="$SHIM_DIR/captured-h"
 
-# Case 1: 0 items → MIN (6) — count+BUFFER=4, clamped up to MIN
+# Case 1: 0 items → MIN (12) — count+CHROME+BORDER=11, clamped up to MIN
 export FAKE_CLIENT_HEIGHT=30 FAKE_SESH_ITEMS=0; unset FAKE_SESH_FAIL
-run_case "0 items clamps to MIN" 6
+run_case "0 items clamps to MIN" 12
 
-# Case 2: 5 items → 5 + BUFFER (4) = 9
+# Case 2: 1 item → 1+9+2=12, equals MIN (boundary case proves the clamp engages)
+export FAKE_SESH_ITEMS=1
+run_case "1 item at MIN boundary" 12
+
+# Case 3: 5 items → 5 + SESH_CHROME (9) + POPUP_BORDER (2) = 16
 export FAKE_SESH_ITEMS=5
-run_case "5 items → count+BUFFER" 9
+run_case "5 items → count + SESH_CHROME + POPUP_BORDER" 16
 
-# Case 3: 100 items in 30-row terminal → cap at floor(30*0.8) = 24
+# Case 4: 100 items in 30-row terminal → cap at floor(30*0.8) = 24
 export FAKE_SESH_ITEMS=100
 run_case "100 items capped to 80% of client height" 24
 
-# Case 4: sesh fails → DEFAULT (15), still under 30-row cap of 24
+# Case 5: sesh fails → DEFAULT (15), still under 30-row cap of 24
 export FAKE_SESH_FAIL=1
 run_case "sesh failure falls back to DEFAULT" 15
 


### PR DESCRIPTION
## Summary

- Fixes #58: `<prefix> t` popup wastes most of its height — only ~2 items render below the filter prompt.
- Two compounding bugs in `.config/tmux/bin/tmux-sesh-picker`: count flags didn't mirror the picker (`-c -t -T` vs `-i -d -H -c -t -T`), and `BUFFER=4` was wrong because sesh's bubbletea TUI subtracts a chrome of **9** rows in `picker/tui.go:visibleCount()` plus tmux's 2-row popup border = 11.
- Replaced single `BUFFER` with two named constants: `SESH_CHROME=9` (sesh-owned) and `POPUP_BORDER=2` (tmux-owned). Aligned count flags to `-d -H -c -t -T`. Raised `MIN` from 6 to 12 (chrome + border + 1 visible item).
- Updated tests, project CLAUDE.md formula description, and the tmux cheatsheet to match.

## Test plan

- [x] `scripts/test-tmux-sesh-picker.sh` — 5/5 pass (cases bracket the floor with 0- and 1-item, plus 5-item, 100-item cap, and sesh-failure DEFAULT).
- [ ] Manual: hit `<prefix> t` with the configured sessions; popup sizes to the visible list, no large empty space below.
- [ ] Manual: cheatsheet renders (`open docs/tmux-cheatsheet.html`) — "Sesh picker" card shows the new `items + 11` formula.

## Out of scope

- Filing an upstream issue at `joshmedeski/sesh` re: the 9-row chrome and 15-item visible cap. Not load-bearing for this user (≤6 sessions).
- Replacing `sesh picker` with a custom fzf wrapper. Source inspection confirmed sesh handles `tea.WindowSizeMsg` correctly; the wrapper bug is ours, not upstream's. CLAUDE.md's "Don't re-introduce a custom fzf wrapper" rule stays intact.