### PR TITLE
feat: adopt tailspin (tspin) for live-log highlighting

### DIFF
--- a/.config/tailspin/theme.toml
+++ b/.config/tailspin/theme.toml
@@ -1,0 +1,57 @@
+# theme.toml — Solarized-aligned overrides for tailspin (tspin).
+#
+# tspin accepts ANSI color names only (red, blue, bright_red, …); Ghostty's
+# Solarized Dark theme resolves them per the canonical Solarized terminal
+# mapping (bright_red -> orange #cb4b16, bright_magenta -> violet #6c71c4,
+# bright_green -> base01 #586e75, bright_cyan -> base1 #93a1a1).
+#
+# Schema reference:
+#   https://github.com/bensadeh/tailspin/blob/main/src/theme/mod.rs
+#
+# Minimal pin: only override groups whose tspin defaults clash with Solarized.
+# Unspecified groups (uuids, pointers, processes, emails, json, jvm_stack_traces,
+# regexps) inherit upstream defaults.
+
+# --- Severity keywords (defined here; tspin has no built-in error/warn/info).
+
+[[keywords]]
+words = ["ERROR", "Error", "error", "FATAL", "Fatal", "fatal", "FAIL", "Fail", "fail"]
+style = { fg = "red", bold = true }
+
+[[keywords]]
+words = ["WARN", "Warn", "warn", "WARNING", "Warning", "warning"]
+style = { fg = "bright_red" }                    # Solarized orange
+
+[[keywords]]
+words = ["INFO", "Info", "info"]
+style = { fg = "blue" }
+
+[[keywords]]
+words = ["DEBUG", "Debug", "debug", "TRACE", "Trace", "trace"]
+style = { fg = "bright_green" }                  # Solarized base01 (muted)
+
+# --- Built-in groups.
+
+[dates]
+date = { fg = "cyan" }
+time = { fg = "cyan" }
+
+[numbers]
+number = { fg = "magenta" }
+
+[urls]
+http  = { fg = "blue", underline = true }
+https = { fg = "blue", underline = true }
+host  = { fg = "bright_cyan" }                   # Solarized base1
+
+[paths]
+segment = { fg = "cyan" }
+
+[quotes]
+style = { fg = "green" }
+
+[key_value_pairs]
+key = { fg = "bright_cyan" }                     # Solarized base1
+
+[ip_addresses]
+number = { fg = "bright_magenta" }               # Solarized violet

--- a/Brewfile
+++ b/Brewfile
@@ -27,6 +27,7 @@ brew "eza"                      # ls replacement with icons + git status
 brew "bat"                      # syntax-highlighted cat / man pager backend
 brew "git-delta"                # git diff/log/blame pager
 brew "glow"                     # render markdown to ANSI
+brew "tailspin"                 # syntax-highlighted log viewer (tspin)
 brew "vivid"                    # generates LS_COLORS palettes
 brew "procs"                    # modern ps replacement (Rust)
 brew "zsh-syntax-highlighting"  # live command-line highlighting

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,6 +151,7 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
 - **Shell colors are Solarized Dark, end-to-end.** Tools: `eza` (ls),
   `bat` (cat + `MANPAGER`), `git-delta` (git pager), `glow` (`md` markdown
   renderer), `vivid` (`LS_COLORS`), `procs` (`ps` replacement),
+  `tailspin` (`tspin`, live-log highlighter),
   `zsh-syntax-highlighting`, `zsh-autosuggestions`, `fzf-tab` (Tab completion
   picker). Palette pins:
   `vivid generate solarized-dark`, `bat --theme="Solarized (dark)"`,
@@ -158,9 +159,19 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
   `.config/procs/procs.toml` (Pid=violet, User=blue, percentage gradient
   blue→green→yellow→red),
   `md` alias passes `--style .config/glow/glamour.json` (chroma
-  `solarized-dark` for fenced code blocks). Don't swap themes or
-  introduce alternatives (`exa`, `lsd`, `diff-so-fancy`, `mdcat`, etc.)
-  without asking. Plugin source order in `.zshrc` is fixed: fzf →
+  `solarized-dark` for fenced code blocks),
+  `tspin` reads `.config/tailspin/theme.toml` — minimal pin via ANSI
+  color names (Ghostty's Solarized palette resolves them to hex; e.g.
+  `bright_red` → orange `#cb4b16`, `bright_magenta` → violet `#6c71c4`,
+  `bright_green` → base01). Severity keywords
+  (`error`/`warn`/`info`/`debug`) are shipped as `[[keywords]]` blocks
+  since tspin has no built-in groups for them. Invocation stays explicit
+  — `tspin file.log` / `tspin -f file.log` / `cmd | tspin -p`. No `tail`
+  alias, no `t` shortcut (keeps `tail` vanilla, limits surface area, and
+  avoids breaking `tail -n` since tspin's CLI isn't a `tail` superset).
+  Don't swap themes or introduce alternatives
+  (`exa`, `lsd`, `diff-so-fancy`, `mdcat`, `lnav`, etc.) without asking.
+  Plugin source order in `.zshrc` is fixed: fzf →
   `bindkey -r '^[c'` (Alt-C unbind) → zoxide → fzf-tab →
   zsh-autosuggestions → zsh-syntax-highlighting (must be last).
   fzf-tab needs fzf's `^I` binding already in place and must be sourced

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ These drive the `claude[<name>]` window title (tmux's
 | sesh         | `.config/sesh/sesh.toml`             | `~/.config/sesh/sesh.toml` |
 | worktrunk    | `.config/worktrunk/`                 | `~/.config/worktrunk` |
 | glow         | `.config/glow/`                      | `~/.config/glow` |
+| tailspin     | `.config/tailspin/`                  | `~/.config/tailspin` |
 | ccstatusline | `.config/ccstatusline/`              | `~/.config/ccstatusline` |
 | Claude       | `.claude/CLAUDE.md`                  | `~/.claude/CLAUDE.md` |
 | user bin     | `bin/*` (e.g. `s`)                   | `~/.local/bin/*`    |

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -42,6 +42,9 @@ link ".config/worktrunk" "$HOME/.config/worktrunk"
 # --- glow
 link ".config/glow"    "$HOME/.config/glow"
 
+# --- tailspin (tspin) — Solarized theme.toml
+link ".config/tailspin" "$HOME/.config/tailspin"
+
 # --- btop
 link ".config/btop"    "$HOME/.config/btop"
 

--- a/docs/shell-colors-cheatsheet.html
+++ b/docs/shell-colors-cheatsheet.html
@@ -29,6 +29,7 @@
   <a href="#less">less wrapper</a>
   <a href="#delta">git-delta</a>
   <a href="#glow">glow / md</a>
+  <a href="#tspin">tspin</a>
   <a href="#vivid">vivid / LS_COLORS</a>
   <a href="#fzf">fzf</a>
   <a href="#fzf-tab">fzf-tab</a>
@@ -51,6 +52,7 @@
       <tr><td class="key"><code>glow</code></td><td class="desc">render markdown to ANSI (powers <code>md</code> alias)</td></tr>
       <tr><td class="key"><code>vivid</code></td><td class="desc">generates LS_COLORS palettes</td></tr>
       <tr><td class="key"><code>procs</code></td><td class="desc">modern ps replacement (Rust)</td></tr>
+      <tr><td class="key"><code>tailspin</code></td><td class="desc">live-log highlighter (<code>tspin</code>); Solarized via <code>~/.config/tailspin/theme.toml</code></td></tr>
       <tr><td class="key"><code>zsh-autosuggestions</code></td><td class="desc">ghost-text completion from history</td></tr>
       <tr><td class="key"><code>zsh-syntax-highlighting</code></td><td class="desc">live command-line highlighting</td></tr>
       <tr><td class="key"><code>fzf</code></td><td class="desc">fuzzy finder + Ctrl-R / Ctrl-T bindings</td></tr>
@@ -311,6 +313,50 @@
       <tr><td class="key"><code>command glow ...</code></td><td class="desc">bypass alias (no <code>--style</code>)</td></tr>
     </table>
     <p class="note">Don't swap to <code>mdcat</code> / <code>frogmouth</code> without an explicit ask — <code>mdcat</code> was archived upstream 2025-01-10.</p>
+  </div>
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════════════════ -->
+<h2 id="tspin">tailspin / tspin <span class="tool-tag">live-log highlighter</span></h2>
+
+<div class="grid">
+  <div class="card">
+    <h3>Daily use</h3>
+    <table>
+      <tr><td class="key"><code>tspin file.log</code></td><td class="desc">open file (paged via <code>less</code>)</td></tr>
+      <tr><td class="key"><code>tspin -f file.log</code></td><td class="desc">follow (live tail with highlights)</td></tr>
+      <tr><td class="key"><code>cmd | tspin -p</code></td><td class="desc">pipe stdin, print to stdout (no pager)</td></tr>
+      <tr><td class="key"><code>tspin -e 'kubectl logs -f pod'</code></td><td class="desc">run command, view paged output</td></tr>
+    </table>
+    <p class="note">No <code>tail</code> alias and no <code>t</code> shortcut — <code>tail</code> / <code>tail -n</code> stay vanilla. tspin's CLI isn't a <code>tail</code> superset (no <code>-n</code>), so wrapping <code>tail</code> would break common uses.</p>
+  </div>
+
+  <div class="card">
+    <h3>Theme — Solarized via <code>theme.toml</code></h3>
+    <p>
+      tspin reads <code>~/.config/tailspin/theme.toml</code>. It accepts ANSI color
+      <em>names</em> only (<code>red</code>, <code>blue</code>, <code>bright_red</code>, …);
+      Ghostty's Solarized Dark palette resolves them to hex via the canonical
+      Solarized terminal mapping:
+    </p>
+    <table>
+      <tr><td class="key"><code>red</code></td><td class="desc">red <code>#dc322f</code></td></tr>
+      <tr><td class="key"><code>bright_red</code></td><td class="desc">orange <code>#cb4b16</code></td></tr>
+      <tr><td class="key"><code>bright_magenta</code></td><td class="desc">violet <code>#6c71c4</code></td></tr>
+      <tr><td class="key"><code>bright_green</code></td><td class="desc">base01 <code>#586e75</code></td></tr>
+      <tr><td class="key"><code>bright_cyan</code></td><td class="desc">base1 <code>#93a1a1</code></td></tr>
+    </table>
+    <p class="note">Severity (<code>error</code> / <code>warn</code> / <code>info</code> / <code>debug</code>) is shipped as <code>[[keywords]]</code> blocks — tspin has no built-in groups for them.</p>
+  </div>
+
+  <div class="card">
+    <h3>What gets highlighted</h3>
+    <ul class="compact">
+      <li><strong>Severities</strong> — error/fatal/fail (red, bold), warn (orange), info (blue), debug/trace (base01).</li>
+      <li><strong>Built-ins</strong> — dates / times (cyan), numbers (magenta), URLs (blue + underline), paths (cyan), quotes (green), IPs (violet), kv-pair keys (base1).</li>
+      <li><strong>Inherited from upstream</strong> — UUIDs, pointers, processes, emails, JSON, JVM stack traces.</li>
+    </ul>
+    <p class="note">Schema: <code>github.com/bensadeh/tailspin/blob/main/src/theme/mod.rs</code>. Override anything with extra <code>[[keywords]]</code> or block-level entries.</p>
   </div>
 </div>
 


### PR DESCRIPTION
## Summary
- Adds `tailspin` (`tspin`) to the Brewfile for syntax-highlighted live-log viewing.
- Ships a minimal Solarized-aligned `theme.toml` (ANSI color names; Ghostty's palette resolves them to Solarized hex per the canonical Solarized terminal mapping).
- Plain `tail` / `tail -n` stay vanilla — no shell aliases, no `t` shortcut. tspin's CLI isn't a `tail` superset (no `-n`), so wrapping `tail` would have broken common uses.
- Severity highlighting (`error` / `warn` / `info` / `debug`) is shipped as `[[keywords]]` blocks since tspin has no built-in groups for them.
- Updates CLAUDE.md, README.md "What's where", and the shell-colors cheatsheet (new tspin card + nav entry + Brew-packages row).

Closes #56.

## Test plan
- [x] `brew bundle check --file=Brewfile --verbose` passes
- [x] `tspin --version` reports 6.0.0 post-install
- [x] `tspin /var/log/system.log` highlights dates / numbers / processes / IPs in Solarized hues
- [x] `echo "ERROR: ... at 192.168.1.1, see https://example.com, /var/log/foo line 42 INFO" | tspin -p` shows ERROR red, IP violet, URL blue+underline, host base1, path cyan, number magenta, INFO blue
- [x] `type tail` returns `tail is /usr/bin/tail` (no alias); `tail -n 3 /etc/hosts` works unchanged
- [x] `bash scripts/test-helpers.sh` still passes (30/30 + 43/43)
- [x] All five touched files (CLAUDE.md, README.md, Brewfile, bootstrap.sh, cheatsheet) reference tspin