### PR TITLE
Add lnav (TUI log navigator)

### DIFF
--- a/.config/lnav/configs/installed/solarized-dark.json
+++ b/.config/lnav/configs/installed/solarized-dark.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://lnav.org/schemas/config-v1.schema.json",
+  "ui": {
+    "theme": "solarized-dark"
+  }
+}

--- a/.config/lnav/formats/installed/inngest.json
+++ b/.config/lnav/formats/installed/inngest.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://lnav.org/schemas/format-v1.schema.json",
+  "inngest_dev": {
+    "title": "Inngest dev-server log",
+    "description": "JSON-per-line log output from `inngest-cli dev` (local development server, v1.x).",
+    "url": "https://www.inngest.com/docs/dev-server",
+    "json": true,
+    "timestamp-field": "time",
+    "level-field": "level",
+    "body-field": "msg",
+    "level": {
+      "fatal":    "FATAL",
+      "critical": "CRIT(ICAL)?",
+      "error":    "ERR(OR)?",
+      "warning":  "WARN(ING)?",
+      "info":     "INFO",
+      "debug":    "DEBUG",
+      "trace":    "TRACE"
+    },
+    "value": {
+      "msg":         { "kind": "string" },
+      "caller":      { "kind": "string", "identifier": true },
+      "service":     { "kind": "string", "identifier": true },
+      "svc":         { "kind": "string", "identifier": true },
+      "queue_shard": { "kind": "string", "identifier": true },
+      "run_id":      { "kind": "string", "identifier": true },
+      "function":    { "kind": "string", "identifier": true },
+      "step":        { "kind": "string", "identifier": true },
+      "event":       { "kind": "string", "identifier": true },
+      "addr":        { "kind": "string" },
+      "backend":     { "kind": "string" },
+      "db":          { "kind": "string" },
+      "mode":        { "kind": "string" },
+      "topic":       { "kind": "string" }
+    },
+    "line-format": [
+      { "field": "__timestamp__" },
+      " ",
+      { "field": "__level__" },
+      " ",
+      { "field": "caller", "default-value": "-", "max-width": 18 },
+      " ",
+      { "field": "msg" }
+    ],
+    "sample": [
+      { "line": "{\"time\":\"2026-05-02T15:23:14.748261Z\",\"level\":\"INFO\",\"msg\":\"initialized database\",\"db\":\"sqlite\",\"mode\":\"memory\"}" },
+      { "line": "{\"time\":\"2026-05-02T15:23:14.758771Z\",\"level\":\"INFO\",\"msg\":\"service starting\",\"caller\":\"executor\",\"service\":\"executor\"}" }
+    ]
+  }
+}

--- a/Brewfile
+++ b/Brewfile
@@ -32,6 +32,7 @@ brew "procs"                    # modern ps replacement (Rust)
 brew "zsh-syntax-highlighting"  # live command-line highlighting
 brew "zsh-autosuggestions"      # ghost-text completion from history
 brew "fzf-tab"                  # fzf-driven Tab completion menu
+brew "lnav"                     # TUI log file navigator
 
 # System monitoring
 brew "btop"                     # modern top replacement (themed Solarized)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,6 +206,26 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
   custom Solarized theme file — `solarized_dark` is built-in. Don't
   pin more keys without a clear reason — small diff = easy upstream
   bumps.
+- **`lnav` is the TUI log navigator** (homebrew `lnav`; raw command, no
+  alias). The entire `.config/lnav/` directory is symlinked by
+  `bootstrap.sh`. Theme is lnav's **built-in** `solarized-dark`,
+  activated by `.config/lnav/configs/installed/solarized-dark.json` —
+  one tiny file that only sets `ui.theme`; no slot-mapping JSON because
+  upstream's built-in already uses the canonical Solarized palette
+  (verified). Don't redefine the theme; if you need a tweak, prefer a
+  separate config file that overrides specific slots rather than
+  forking the whole theme. Custom log-format files live at
+  `.config/lnav/formats/installed/<name>.json`. One tracked format
+  today: `inngest.json` for `inngest-cli dev` stdout — uses lnav's
+  `"json": true` mode (Inngest CLI v1.x emits JSON-per-line) and maps
+  `time`/`level`/`msg` to lnav's `__timestamp__`/`__level__`/body
+  slots. Add new formats by dropping a JSON file in the same directory
+  — re-running `bootstrap.sh` is **not** needed because the parent dir
+  is already symlinked. lnav writes runtime mutations (e.g. via
+  `:config`) to `~/.config/lnav/config.json`, which is **not** in the
+  repo — tracked files in `configs/installed/` and `formats/installed/`
+  won't be clobbered. Don't replace lnav with another log TUI without
+  an ask; don't add a shell alias or wrapper.
 
 ## Where things live
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -48,6 +48,9 @@ link ".config/btop"    "$HOME/.config/btop"
 # --- procs (modern ps; Solarized config + procs-heavy.toml for `psh`)
 link ".config/procs"   "$HOME/.config/procs"
 
+# --- lnav (TUI log navigator; theme activation + custom format files)
+link ".config/lnav"    "$HOME/.config/lnav"
+
 # --- sesh: shared config is symlinked; machine-local sessions in sesh.local.toml
 link ".config/sesh/sesh.toml" "$HOME/.config/sesh/sesh.toml"
 if [ ! -f "$HOME/.config/sesh/sesh.local.toml" ]; then

--- a/docs/shell-colors-cheatsheet.html
+++ b/docs/shell-colors-cheatsheet.html
@@ -16,7 +16,7 @@
 <header>
   <h1>Shell Colors — Getting Started &amp; Cheatsheet</h1>
   <div class="sub">
-    Solarized Dark, end-to-end &middot; eza · bat · git-delta · glow · vivid · procs · fzf · fzf-tab · zsh-autosuggestions · zsh-syntax-highlighting
+    Solarized Dark, end-to-end &middot; eza · bat · git-delta · glow · vivid · procs · lnav · fzf · fzf-tab · zsh-autosuggestions · zsh-syntax-highlighting
   </div>
 </header>
 
@@ -25,6 +25,7 @@
   <a href="#start">Getting started</a>
   <a href="#eza">eza</a>
   <a href="#procs">procs</a>
+  <a href="#lnav">lnav</a>
   <a href="#bat">bat</a>
   <a href="#less">less wrapper</a>
   <a href="#delta">git-delta</a>
@@ -156,6 +157,46 @@
       <code>\ps&nbsp;-ax</code> or <code>command&nbsp;ps&nbsp;-ax</code>.
     </p>
     <p class="note">Pipes strip color (<code>color_mode = "Auto"</code>). Prefer <code>procs &lt;pat&gt;</code> over <code>ps&nbsp;|&nbsp;grep&nbsp;&lt;pat&gt;</code> — same result, colors preserved.</p>
+  </div>
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════════════════ -->
+<h2 id="lnav">lnav <span class="tool-tag">TUI log navigator</span></h2>
+
+<div class="grid">
+  <div class="card">
+    <h3>Most-used invocations</h3>
+    <table>
+      <tr><td class="key"><code>lnav file.log</code></td><td class="desc">open one file (auto-tails new lines)</td></tr>
+      <tr><td class="key"><code>lnav dir/</code></td><td class="desc">open every log file in a directory; merged by timestamp</td></tr>
+      <tr><td class="key"><code>cmd | lnav</code></td><td class="desc">read from stdin (no positional arg)</td></tr>
+      <tr><td class="key"><code>lnav -n file.log</code></td><td class="desc">headless / no UI (useful for format debugging)</td></tr>
+    </table>
+  </div>
+
+  <div class="card">
+    <h3>Files we ship</h3>
+    <table>
+      <tr><td class="key"><code>~/.config/lnav/configs/installed/solarized-dark.json</code></td><td class="desc">activates lnav's built-in Solarized Dark theme</td></tr>
+      <tr><td class="key"><code>~/.config/lnav/formats/installed/inngest.json</code></td><td class="desc">JSON format for <code>inngest-cli dev</code> stdout</td></tr>
+      <tr><td class="key"><code>~/.config/lnav/config.json</code></td><td class="desc">lnav's runtime mutable config (not in repo)</td></tr>
+    </table>
+    <p class="note">Add new formats by dropping a JSON file in <code>formats/installed/</code> — the parent dir is already symlinked, no <code>bootstrap.sh</code> re-run needed. Theme is lnav's built-in (palette matches <code>bat</code> / <code>delta</code> / <code>procs</code> / <code>btop</code>); we don't redefine slots.</p>
+  </div>
+
+  <div class="card">
+    <h3>Inside the TUI</h3>
+    <table>
+      <tr><td class="key"><span class="k">q</span></td><td class="desc">quit</td></tr>
+      <tr><td class="key"><span class="k">e</span> / <span class="k">E</span></td><td class="desc">next / prev error</td></tr>
+      <tr><td class="key"><span class="k">w</span> / <span class="k">W</span></td><td class="desc">next / prev warning</td></tr>
+      <tr><td class="key"><span class="k">/</span><i>pat</i> / <span class="k">n</span></td><td class="desc">search / next match</td></tr>
+      <tr><td class="key"><span class="k">:</span></td><td class="desc">command prompt (e.g. <code>:filter-in</code>, <code>:goto</code>)</td></tr>
+      <tr><td class="key"><span class="k">;</span></td><td class="desc">SQL prompt — query log lines as a table (e.g. <code>SELECT * FROM inngest_dev WHERE level = 'error'</code>)</td></tr>
+      <tr><td class="key"><span class="k">t</span> / <span class="k">i</span></td><td class="desc">time histogram / global histogram view</td></tr>
+      <tr><td class="key"><span class="k">TAB</span></td><td class="desc">switch between log view and bottom prompt</td></tr>
+    </table>
+    <p class="note">Bottom status bar shows the matched format name (e.g. <code>inngest_dev</code>) when an installed format matches the file.</p>
   </div>
 </div>
 


### PR DESCRIPTION
## Summary

Adopts [`lnav`](https://github.com/tstack/lnav) (v0.14.0) as the dotfiles' TUI for navigating and analyzing log files. Additive — does not replace `tail`, `less`, or `tspin`.

- **Brewfile:** `brew "lnav"` in the "Shell colors & appearance" group.
- **`bootstrap.sh`:** symlinks the entire `.config/lnav/` directory.
- **`.config/lnav/configs/installed/solarized-dark.json`:** activates lnav's **built-in** Solarized Dark theme (4-line file). Verified palette in `src/themes/solarized-dark.json` upstream matches the project's Solarized pin exactly — no slot-mapping JSON needed.
- **`.config/lnav/formats/installed/inngest.json`:** custom format for `inngest-cli dev` stdout.
  - **Plan deviation noted:** the design assumed Inngest emitted regex-friendly `key=value` lines. In practice, `inngest-cli dev` (v1.x) emits **JSON-per-line**, so the format file uses lnav's `"json": true` mode instead. Strict simplification — same field set (`time`, `level`, `msg` core; `caller`/`service`/`run_id`/`function`/`step`/etc. as identifier-grade context fields), no regex to maintain.
- **`CLAUDE.md`:** lnav convention bullet under "Conventions — don't drift from these".
- **`docs/shell-colors-cheatsheet.html`:** lnav card alongside the existing shell-color tools (header subtitle + TOC + new section with three cards: invocations, files we ship, inside the TUI).

Closes #57.

## Test plan

- [x] `python3 -m json.tool < .config/lnav/configs/installed/solarized-dark.json` — valid JSON
- [x] `python3 -m json.tool < .config/lnav/formats/installed/inngest.json` — valid JSON
- [x] `bash -n bootstrap.sh` — syntax OK
- [x] `brew bundle list --file=Brewfile | grep -c lnav` — `1`
- [x] `brew bundle --file=Brewfile` — installed `lnav 0.14.0` cleanly
- [x] HTML well-formedness + tag balance check on cheatsheet (49 div / 25 table / 134 tr / 268 td / 14 h2 / 36 h3 — all balanced)
- [x] Smoke test: captured 16 lines of `inngest-cli dev` stdout from `~/code/strava-timeline`, ran `lnav -n -c ';SELECT log_format, COUNT(*) FROM inngest_dev' tmp/inngest-sample.log` → returns `inngest_dev | 16`. Format matched at quality 3001.5–3002.5 with 0 strikes per lnav debug log.

## Post-merge action

After merging, on each machine: `cd $PROJECTS_HOME/dotfiles && ./bootstrap.sh` to create the `~/.config/lnav` symlink (bootstrap will back up any existing `~/.config/lnav` directory to `~/.config/lnav.bak.<timestamp>` first).

## Out of scope

- Production Inngest Cloud / Vercel-log-drain format parsing (separate file, separate trigger).
- Next.js dev-server log format (rejected during brainstorm — multi-line ANSI noise, low payoff).
- Shell alias or wrapper script — raw `lnav` is fine.
- Trial-evaluation tracking infrastructure (this is integrated as a permanent tool).