### PR TITLE
Modernize: diff (non-git) → difftastic

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -166,6 +166,9 @@ fi
 if command -v btop >/dev/null 2>&1; then
   alias top='btop'
 fi
+if command -v difft >/dev/null 2>&1; then
+  alias diff='difft'
+fi
 
 # ─── Plugins (order matters) ─────────────────────────────────────
 # Required order:

--- a/Brewfile
+++ b/Brewfile
@@ -26,6 +26,7 @@ brew "tree-sitter-cli" # nvim-treesitter parser builds
 brew "eza"                      # ls replacement with icons + git status
 brew "bat"                      # syntax-highlighted cat / man pager backend
 brew "git-delta"                # git diff/log/blame pager
+brew "difftastic"               # syntactic diff for ad-hoc compares (non-git)
 brew "glow"                     # render markdown to ANSI
 brew "vivid"                    # generates LS_COLORS palettes
 brew "procs"                    # modern ps replacement (Rust)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,6 +206,17 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
   custom Solarized theme file — `solarized_dark` is built-in. Don't
   pin more keys without a clear reason — small diff = easy upstream
   bumps.
+- **`diff` is a zsh alias to `difft`** (defined in `.zshrc`, guarded on
+  `command -v difft`). Difftastic is a syntactic, language-aware diff for
+  ad-hoc, non-git file comparisons. Git diffs are unaffected — git's pager
+  is still `delta`, and that wiring is intentional. `vimdiff` is also
+  unaffected — it's a separate alias (`vim -d`, which resolves via the
+  `vim`→`nvim` alias). Escape hatches: `command diff`, `\diff`,
+  `/usr/bin/diff` reach legacy `diff`. Non-interactive shells (scripts,
+  Make, CI) never see the alias. Don't pin flags on the alias —
+  difftastic's defaults (`--background dark`, side-by-side, color auto)
+  already match the Solarized Dark setup; the terminal palette supplies
+  the colors.
 
 ## Where things live
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Solarized-themed quick references — also browseable at
 
 - [Neovim](https://martinciu.github.io/dotfiles/nvim-cheatsheet.html) — LazyVim leader map, picker, LSP, neotest, Mason/Lazy
 - [tmux](https://martinciu.github.io/dotfiles/tmux-cheatsheet.html) — prefix `C-a` map, sessions/windows/panes, sesh picker, status bar, copy mode
-- [Shell colors](https://martinciu.github.io/dotfiles/shell-colors-cheatsheet.html) — eza, bat, less wrapper, git-delta, glow, vivid, fzf, zsh plugins
+- [Shell colors](https://martinciu.github.io/dotfiles/shell-colors-cheatsheet.html) — eza, bat, less wrapper, git-delta, difftastic, glow, vivid, fzf, zsh plugins
 
 ## Setup (new machine)
 

--- a/docs/shell-colors-cheatsheet.html
+++ b/docs/shell-colors-cheatsheet.html
@@ -16,7 +16,7 @@
 <header>
   <h1>Shell Colors — Getting Started &amp; Cheatsheet</h1>
   <div class="sub">
-    Solarized Dark, end-to-end &middot; eza · bat · git-delta · glow · vivid · procs · fzf · fzf-tab · zsh-autosuggestions · zsh-syntax-highlighting
+    Solarized Dark, end-to-end &middot; eza · bat · git-delta · difftastic · glow · vivid · procs · fzf · fzf-tab · zsh-autosuggestions · zsh-syntax-highlighting
   </div>
 </header>
 
@@ -28,6 +28,7 @@
   <a href="#bat">bat</a>
   <a href="#less">less wrapper</a>
   <a href="#delta">git-delta</a>
+  <a href="#difftastic">difftastic</a>
   <a href="#glow">glow / md</a>
   <a href="#vivid">vivid / LS_COLORS</a>
   <a href="#fzf">fzf</a>
@@ -48,6 +49,7 @@
       <tr><td class="key"><code>eza</code></td><td class="desc">ls replacement with icons + git status</td></tr>
       <tr><td class="key"><code>bat</code></td><td class="desc">syntax-highlighted cat / man pager backend</td></tr>
       <tr><td class="key"><code>git-delta</code></td><td class="desc">git diff/log/blame pager</td></tr>
+      <tr><td class="key"><code>difftastic</code></td><td class="desc">syntactic diff for ad-hoc compares (non-git)</td></tr>
       <tr><td class="key"><code>glow</code></td><td class="desc">render markdown to ANSI (powers <code>md</code> alias)</td></tr>
       <tr><td class="key"><code>vivid</code></td><td class="desc">generates LS_COLORS palettes</td></tr>
       <tr><td class="key"><code>procs</code></td><td class="desc">modern ps replacement (Rust)</td></tr>
@@ -61,7 +63,7 @@
   <div class="card">
     <h3>House rules (per CLAUDE.md)</h3>
     <ul class="compact">
-      <li><strong>Solarized Dark, end-to-end.</strong> Don't swap themes or introduce alternatives (<code>exa</code>, <code>lsd</code>, <code>diff-so-fancy</code>, …) without asking.</li>
+      <li><strong>Solarized Dark, end-to-end.</strong> Don't swap themes or introduce alternatives (<code>exa</code>, <code>lsd</code>, <code>diff-so-fancy</code>, <code>delta</code> for non-git, …) without asking.</li>
       <li><strong>Plugin source order in <code>.zshrc</code> is fixed:</strong> fzf → <code>bindkey -r '^[c'</code> (Alt-C unbind) → zoxide → fzf-tab → zsh-autosuggestions → zsh-syntax-highlighting (must be last).</li>
       <li><strong>Palette pins:</strong> <code>vivid generate solarized-dark</code>, <code>bat --theme="Solarized (dark)"</code>, <code>delta.syntax-theme = "Solarized (dark)"</code>.</li>
       <li><strong>JetBrainsMono Nerd Font.</strong> Required for <code>eza --icons</code>.</li>
@@ -266,6 +268,37 @@
       <tr><td class="key"><code>delta --no-gitconfig --diff-highlight</code></td><td class="desc">minimal preview</td></tr>
       <tr><td class="key"><code>git -c core.pager=cat diff</code></td><td class="desc">bypass delta one-shot</td></tr>
     </table>
+  </div>
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════════════════ -->
+<h2 id="difftastic">difftastic <span class="tool-tag">non-git diff</span></h2>
+
+<div class="grid">
+  <div class="card">
+    <h3>Where it kicks in</h3>
+    <p>Aliased over <code>diff</code> for ad-hoc file compares outside git. Git diffs still flow through <code>delta</code> (see above) — the two cover different surfaces.</p>
+    <table>
+      <tr><td class="key"><code>diff a b</code></td><td class="desc">syntactic, language-aware diff between two files</td></tr>
+      <tr><td class="key"><code>diff a/ b/</code></td><td class="desc">recursive directory diff</td></tr>
+      <tr><td class="key"><code>diff old.json new.json</code></td><td class="desc">tree-sitter parses each side; structural moves are recognized</td></tr>
+    </table>
+  </div>
+
+  <div class="card">
+    <h3>Bypass to legacy <code>diff</code></h3>
+    <table>
+      <tr><td class="key"><code>command diff a b</code></td><td class="desc">skip the alias (zsh built-in)</td></tr>
+      <tr><td class="key"><code>\diff a b</code></td><td class="desc">same; backslash quotes the alias name</td></tr>
+      <tr><td class="key"><code>/usr/bin/diff a b</code></td><td class="desc">absolute path bypasses <code>$PATH</code></td></tr>
+    </table>
+    <p class="note">Non-interactive shells (scripts, Make, CI) never see the alias — zsh aliases don't propagate without <code>-i</code>.</p>
+  </div>
+
+  <div class="card">
+    <h3>Why no theme pin</h3>
+    <p>Difftastic uses ANSI 16-color directly; Ghostty's terminal palette is already Solarized Dark, so it inherits on-palette colors with no extra config. The default <code>--background dark</code> matches; nothing to wire.</p>
+    <p class="note">Don't introduce <code>delta</code>, <code>diff-so-fancy</code>, or another diff renderer for non-git — they're line-based, not syntactic, and would duplicate what delta already does for git.</p>
   </div>
 </div>
 


### PR DESCRIPTION
## Summary

- Add `difftastic` to `Brewfile` (report-only, as per repo convention).
- Alias `diff` → `difft` in `.zshrc`, guarded on `command -v difft`. Escape hatches: `command diff`, `\diff`, `/usr/bin/diff`. Interactive only.
- Document the convention in `CLAUDE.md`, the shell-colors cheatsheet, and the README.

Git diffs continue to flow through `delta` — that wiring is unchanged. `vimdiff` (alias to `vim -d` → `nvim`) is also unchanged.

Closes #49.

## Test plan

- [ ] `brew bundle check --file=Brewfile --verbose` reports `difftastic` as missing on a fresh box (report-only).
- [ ] `brew install difftastic && exec zsh` then `type diff` → `diff is an alias for difft`.
- [ ] `command diff a b`, `\diff a b`, `/usr/bin/diff a b` all reach legacy `diff`.
- [ ] `zsh -c 'type diff'` (non-interactive) → `diff is /usr/bin/diff` — alias does not leak to scripts.
- [ ] Open `docs/shell-colors-cheatsheet.html` in a browser; new `difftastic` section renders, ToC link works, header strip and "Don't swap" line updated, footer date is `2026-05-02`.
- [ ] `README.md` line 12 lists `difftastic` between `git-delta` and `glow`.