### PR TITLE
feat(bootstrap): symlink only lnav installed/ subdirs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,10 +221,19 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
   pin more keys without a clear reason — small diff = easy upstream
   bumps.
 - **`lnav` is the TUI log navigator** (homebrew `lnav`; raw command, no
-  alias). The entire `.config/lnav/` directory is symlinked by
-  `bootstrap.sh`. Theme is lnav's **built-in** `solarized-dark`,
-  activated by `.config/lnav/configs/installed/solarized-dark.json` —
-  one tiny file that only sets `ui.theme`; no slot-mapping JSON because
+  alias). Only the two `installed/` subdirs are symlinked from the
+  repo: `bootstrap.sh` creates `~/.config/lnav/` as a real dir, then
+  links `~/.config/lnav/configs/installed` and
+  `~/.config/lnav/formats/installed` (dir-level) into the repo. lnav
+  owns the rest of the tree — built-in samples (`configs/default`,
+  `formats/default`), `crash/`, `staging/`, `log_metadata.db`,
+  per-PID `view-info-*.json`, and `:config`-written `config.json`
+  all live in the real `~/.config/lnav/` outside the repo. Don't
+  re-introduce the whole-dir symlink — the runtime artifacts polluted
+  `git status` (issue #64). Theme is lnav's **built-in**
+  `solarized-dark`, activated by
+  `.config/lnav/configs/installed/solarized-dark.json` — one tiny
+  file that only sets `ui.theme`; no slot-mapping JSON because
   upstream's built-in already uses the canonical Solarized palette
   (verified). Don't redefine the theme; if you need a tweak, prefer a
   separate config file that overrides specific slots rather than
@@ -233,13 +242,13 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
   today: `inngest.json` for `inngest-cli dev` stdout — uses lnav's
   `"json": true` mode (Inngest CLI v1.x emits JSON-per-line) and maps
   `time`/`level`/`msg` to lnav's `__timestamp__`/`__level__`/body
-  slots. Add new formats by dropping a JSON file in the same directory
-  — re-running `bootstrap.sh` is **not** needed because the parent dir
-  is already symlinked. lnav writes runtime mutations (e.g. via
-  `:config`) to `~/.config/lnav/config.json`, which is **not** in the
-  repo — tracked files in `configs/installed/` and `formats/installed/`
-  won't be clobbered. Don't replace lnav with another log TUI without
-  an ask; don't add a shell alias or wrapper.
+  slots. Add new formats by dropping a JSON file in `installed/` — no
+  `bootstrap.sh` re-run needed because `installed/` itself is the
+  (dir-level) symlink. `lnav -i <path>` also writes into `installed/`
+  and therefore into the repo — that's intended (installed configs
+  become tracked dotfiles), but worth knowing. Don't replace lnav
+  with another log TUI without an ask; don't add a shell alias or
+  wrapper.
 - **`diff` is a zsh alias to `difft`** (defined in `.zshrc`, guarded on
   `command -v difft`). Difftastic is a syntactic, language-aware diff for
   ad-hoc, non-git file comparisons. Git diffs are unaffected — git's pager

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -51,8 +51,32 @@ link ".config/btop"    "$HOME/.config/btop"
 # --- procs (modern ps; Solarized config + procs-heavy.toml for `psh`)
 link ".config/procs"   "$HOME/.config/procs"
 
-# --- lnav (TUI log navigator; theme activation + custom format files)
-link ".config/lnav"    "$HOME/.config/lnav"
+# --- lnav (TUI log navigator; only installed/ subdirs are symlinked from repo)
+# lnav writes its built-in samples (configs/default, formats/default), crash
+# dumps, staging area, log_metadata.db, view-info-*.json, and :config-written
+# config.json into the real ~/.config/lnav/ — outside the repo. We only own
+# the two installed/ subdirs.
+LNAV_HOME="$HOME/.config/lnav"
+LNAV_REPO=".config/lnav"
+# 1. Old whole-dir symlink → tear down so we can rebuild as a real dir
+if [ -L "$LNAV_HOME" ]; then
+  rm "$LNAV_HOME"
+  echo "removed: $LNAV_HOME (legacy whole-dir symlink)"
+fi
+# 2. Stale runtime artifacts inside the repo (from pre-migration lnav runs).
+#    Only the known set lnav itself emits — never touch installed/.
+rm -rf  "$DOTFILES/$LNAV_REPO/configs/default" \
+        "$DOTFILES/$LNAV_REPO/formats/default" \
+        "$DOTFILES/$LNAV_REPO/crash" \
+        "$DOTFILES/$LNAV_REPO/staging"
+rm -f   "$DOTFILES/$LNAV_REPO/log_metadata.db" \
+        "$DOTFILES/$LNAV_REPO/config.json"
+rm -f   "$DOTFILES/$LNAV_REPO"/view-info-*.json
+# 3. New shape: real parent dirs + dir-level symlinks for installed/
+mkdir -p "$LNAV_HOME/configs" "$LNAV_HOME/formats"
+link "$LNAV_REPO/configs/installed" "$LNAV_HOME/configs/installed"
+link "$LNAV_REPO/formats/installed" "$LNAV_HOME/formats/installed"
+unset LNAV_HOME LNAV_REPO
 
 # --- sesh: shared config is symlinked; machine-local sessions in sesh.local.toml
 link ".config/sesh/sesh.toml" "$HOME/.config/sesh/sesh.toml"

--- a/docs/shell-colors-cheatsheet.html
+++ b/docs/shell-colors-cheatsheet.html
@@ -185,7 +185,7 @@
       <tr><td class="key"><code>~/.config/lnav/formats/installed/inngest.json</code></td><td class="desc">JSON format for <code>inngest-cli dev</code> stdout</td></tr>
       <tr><td class="key"><code>~/.config/lnav/config.json</code></td><td class="desc">lnav's runtime mutable config (not in repo)</td></tr>
     </table>
-    <p class="note">Add new formats by dropping a JSON file in <code>formats/installed/</code> — the parent dir is already symlinked, no <code>bootstrap.sh</code> re-run needed. Theme is lnav's built-in (palette matches <code>bat</code> / <code>delta</code> / <code>procs</code> / <code>btop</code>); we don't redefine slots.</p>
+    <p class="note">Add new formats by dropping a JSON file in <code>formats/installed/</code> — the <code>installed/</code> dir is symlinked from the repo, so no <code>bootstrap.sh</code> re-run is needed. (lnav owns the rest of <code>~/.config/lnav/</code>.) Theme is lnav's built-in (palette matches <code>bat</code> / <code>delta</code> / <code>procs</code> / <code>btop</code>); we don't redefine slots.</p>
   </div>
 
   <div class="card">


### PR DESCRIPTION
## Summary

- Stop symlinking the whole `.config/lnav/` dir; only `configs/installed` and `formats/installed` (dir-level) are linked into the repo. lnav's runtime tree (`default/`, `crash/`, `staging/`, `log_metadata.db`, `view-info-*.json`, `config.json`) lives in a real `~/.config/lnav/` outside the repo.
- `bootstrap.sh` is self-migrating: tears down the legacy whole-dir symlink, deletes stale runtime artifacts that materialized inside the repo, then creates the new shape. Idempotent on fresh and re-run.
- Updates `CLAUDE.md` lnav bullet (with a note that `lnav -i <path>` writes into `installed/` and lands in the repo intentionally) and tightens the cheatsheet wording.

Closes #64.

## Test Plan

- [x] `bash bootstrap.sh` on a machine with the legacy whole-dir symlink — migration fires, prints `removed: ~/.config/lnav (legacy whole-dir symlink)` + two `linked:` lines.
- [x] `bash bootstrap.sh` re-run — prints two `ok:` lines, no `removed:` (idempotent).
- [x] `~/.config/lnav/` is a real dir; `configs/installed` and `formats/installed` are symlinks pointing into the repo; `configs/default` / `formats/default` / `crash/` / `staging/` exist under the real dir, not the repo.
- [x] `lnav -V` followed by `git status -- .config/lnav/` — clean working tree in both the worktree and the main checkout.
- [x] `bash scripts/test-helpers.sh` — all 73 helper smoke tests pass.

## Why

Issue #64 reported that running `lnav` materialized built-in samples and per-session state inside the repo working tree, polluting `git status`. lnav has no CLI flag to suppress materialization (`-h` confirms — only `-I dir` adds an extra config dir). Solution: don't expose the parent dir to lnav; only own the two `installed/` subdirs we actually populate by hand. The "drop a JSON in `installed/`, no bootstrap re-run" convention is preserved because `installed/` itself is a dir-level symlink.