### PR TITLE
feat(worktrunk): share tmp/ across worktrees via pre-start symlink

### DIFF
--- a/.config/worktrunk/config.toml
+++ b/.config/worktrunk/config.toml
@@ -247,5 +247,22 @@ worktree-path = "{{ repo_path }}/.claude/worktrees/{{ branch | sanitize }}"
 #
 # See `wt hook` (https://worktrunk.dev/hook/) for hook types, execution order, template variables, and examples. User hooks apply to all projects; project hooks (https://worktrunk.dev/config/#project-configuration) apply only to that repository.
 
+# Share `tmp/` across worktrees by symlinking to the primary worktree's tmp/.
+# Why: Superpowers writes specs/plans to tmp/ and `tmp/` is gitignored in
+# repos that follow that convention, so they would otherwise be lost when
+# the worktree is removed. Guarded on `git check-ignore -q tmp/` so this is
+# a no-op in repos where tmp/ is tracked source — never wipes real content.
+# Also adds `tmp` (without slash) to the worktree's .git/info/exclude so the
+# symlink itself doesn't show as untracked (the repo's `tmp/` rule only
+# matches directories, and a symlink isn't a directory to git).
+[pre-start]
+share-tmp = "git check-ignore -q tmp/ && { mkdir -p {{ primary_worktree_path }}/tmp && rm -rf tmp && ln -s {{ primary_worktree_path }}/tmp tmp && excl=$(git rev-parse --git-path info/exclude) && { grep -qxF tmp \"$excl\" || echo tmp >> \"$excl\"; }; } || true"
+
+# Don't let copy-ignored clobber the tmp/ symlink with a real copy.
+# In repos where tmp/ is tracked, copy-ignored ignores tracked paths
+# anyway, so this exclude is a no-op there.
+[step.copy-ignored]
+exclude = ["tmp/"]
+
 [post-start]
 copy = "wt step copy-ignored"


### PR DESCRIPTION
## Summary

- Add `pre-start` user hook that replaces each new worktree's `tmp/` with a symlink to the primary worktree's `tmp/`, so Superpowers specs/plans (under `tmp/specs/`, `tmp/plans/`) survive worktree creation and removal.
- Add `[step.copy-ignored] exclude = ["tmp/"]` so the existing `post-start: copy-ignored` doesn't clobber the symlink with a real copy.
- Guarded on `git check-ignore -q tmp/` — hook is a no-op in repos where `tmp/` is tracked source, never wipes real content.
- Hook also appends `tmp` to the worktree's `.git/info/exclude` so the symlink doesn't show as untracked (the repo's `tmp/` rule only matches directories, and a symlink isn't a directory to git).

## Test plan

- [x] Throwaway worktree: `tmp/` is a symlink → primary's `tmp/`.
- [x] Files written in primary visible from worktree; round-trip writes from worktree appear in primary.
- [x] `git status` clean in a fresh worktree (no untracked symlink entry).
- [x] `wt remove` succeeds without `--force`.
- [x] Primary's `tmp/` survives `wt remove`.
- [x] Tracked-`tmp/` simulation (fresh repo, `tmp/` not gitignored): `git check-ignore -q tmp/` exits 1, hook short-circuits to `|| true`, no-op.