### PR TITLE
feat(xh): introduce HTTP client alongside curl

### DIFF
--- a/.config/xh/config.json
+++ b/.config/xh/config.json
@@ -1,0 +1,1 @@
+{"default_options": ["--style=solarized"]}

--- a/Brewfile
+++ b/Brewfile
@@ -31,6 +31,7 @@ brew "glow"                     # render markdown to ANSI
 brew "tailspin"                 # syntax-highlighted log viewer (tspin)
 brew "vivid"                    # generates LS_COLORS palettes
 brew "procs"                    # modern ps replacement (Rust)
+brew "xh"                       # modern HTTP client (HTTPie-compatible CLI, Solarized-aware)
 brew "zsh-syntax-highlighting"  # live command-line highlighting
 brew "zsh-autosuggestions"      # ghost-text completion from history
 brew "fzf-tab"                  # fzf-driven Tab completion menu

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,6 +165,7 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
   `bat` (cat + `MANPAGER`), `git-delta` (git pager), `glow` (`md` markdown
   renderer), `vivid` (`LS_COLORS`), `procs` (`ps` replacement),
   `tailspin` (`tspin`, live-log highlighter),
+  `xh` (modern HTTP client; HTTPie-compatible CLI),
   `zsh-syntax-highlighting`, `zsh-autosuggestions`, `fzf-tab` (Tab completion
   picker). Palette pins:
   `vivid generate solarized-dark`, `bat --theme="Solarized (dark)"`,
@@ -270,6 +271,16 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
   difftastic's defaults (`--background dark`, side-by-side, color auto)
   already match the Solarized Dark setup; the terminal palette supplies
   the colors.
+- **`xh` is the interactive HTTP client** (Rust, HTTPie-compatible CLI).
+  Ships as `xh` (HTTP-default) and `xhs` (HTTPS-default) — used under
+  their own names. Theme pinned via `.config/xh/config.json`:
+  `{"default_options": ["--style=solarized"]}`; xh's `--style` accepts
+  `auto`/`solarized`/`monokai`/`fruity` and is rendered through `syntect`
+  (same library family as `bat`). Per-invocation overrides
+  (`xh --style=monokai …`) still work. **Don't alias `curl` to `xh`** —
+  `curl` stays available verbatim for scripts and CI. **Don't add an
+  `http`/`https` alias** either; the rule is "no synonyms, just the
+  binary's name". No `.zshrc` change for this tool.
 
 ## Where things live
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Solarized-themed quick references — also browseable at
 
 - [Neovim](https://martinciu.github.io/dotfiles/nvim-cheatsheet.html) — LazyVim leader map, picker, LSP, neotest, Mason/Lazy
 - [tmux](https://martinciu.github.io/dotfiles/tmux-cheatsheet.html) — prefix `C-a` map, sessions/windows/panes, tmux-sessionx picker, status bar, copy mode
-- [Terminal](https://martinciu.github.io/dotfiles/terminal-cheatsheet.html) — eza, bat, less wrapper, git-delta, difftastic, glow, vivid, fzf, zsh plugins
+- [Terminal](https://martinciu.github.io/dotfiles/terminal-cheatsheet.html) — eza, bat, less wrapper, git-delta, difftastic, glow, vivid, xh, fzf, zsh plugins
 
 ## Setup (new machine)
 
@@ -89,6 +89,7 @@ These drive the `claude[<name>]` window title (tmux's
 | [lnav](https://lnav.org/) | `.config/lnav/{configs,formats}/installed/` | `~/.config/lnav/{configs,formats}/installed` |
 | [btop](https://github.com/aristocratos/btop) | `.config/btop/` | `~/.config/btop`    |
 | [procs](https://github.com/dalance/procs) | `.config/procs/` | `~/.config/procs`   |
+| [xh](https://github.com/ducaale/xh) | `.config/xh/` | `~/.config/xh` |
 | [ccstatusline](https://github.com/sirmalloc/ccstatusline) | `.config/ccstatusline/` | `~/.config/ccstatusline` |
 | [Claude](https://claude.com/claude-code) | `.claude/CLAUDE.md` | `~/.claude/CLAUDE.md` |
 | user bin     | `bin/*` (e.g. `s`)                   | `~/.local/bin/*`    |

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -51,6 +51,9 @@ link ".config/btop"    "$HOME/.config/btop"
 # --- procs (modern ps; Solarized config + procs-heavy.toml for `psh`)
 link ".config/procs"   "$HOME/.config/procs"
 
+# --- xh (modern HTTP client; Solarized via default_options)
+link ".config/xh"      "$HOME/.config/xh"
+
 # --- lnav (TUI log navigator; only installed/ subdirs are symlinked from repo)
 # lnav writes its built-in samples (configs/default, formats/default), crash
 # dumps, staging area, log_metadata.db, view-info-*.json, and :config-written

--- a/docs/terminal-cheatsheet.html
+++ b/docs/terminal-cheatsheet.html
@@ -16,7 +16,7 @@
 <header>
   <h1>Terminal — Getting Started &amp; Cheatsheet</h1>
   <div class="sub">
-    Solarized Dark, end-to-end &middot; eza · bat · git-delta · difftastic · glow · vivid · procs · lnav · fzf · fzf-tab · zsh-autosuggestions · zsh-syntax-highlighting
+    Solarized Dark, end-to-end &middot; eza · bat · git-delta · difftastic · glow · vivid · procs · lnav · xh · fzf · fzf-tab · zsh-autosuggestions · zsh-syntax-highlighting
   </div>
 </header>
 
@@ -32,6 +32,7 @@
   <a href="#difftastic">difftastic</a>
   <a href="#glow">glow / md</a>
   <a href="#tspin">tspin</a>
+  <a href="#xh">xh</a>
   <a href="#vivid">vivid / LS_COLORS</a>
   <a href="#fzf">fzf</a>
   <a href="#fzf-tab">fzf-tab</a>
@@ -58,6 +59,7 @@
       <tr><td class="key"><a href="https://github.com/bensadeh/tailspin"><code>tailspin</code></a></td><td class="desc">live-log highlighter (<code>tspin</code>); Solarized via <code>~/.config/tailspin/theme.toml</code></td></tr>
       <tr><td class="key"><a href="https://lnav.org/"><code>lnav</code></a></td><td class="desc">TUI log navigator; Solarized via built-in theme (see lnav section)</td></tr>
       <tr><td class="key"><a href="https://github.com/aristocratos/btop"><code>btop</code></a></td><td class="desc">modern <code>top</code> replacement; Solarized via <code>~/.config/btop/btop.conf</code></td></tr>
+      <tr><td class="key"><a href="https://github.com/ducaale/xh"><code>xh</code></a></td><td class="desc">modern HTTP client (HTTPie-compatible CLI); Solarized via <code>~/.config/xh/config.json</code></td></tr>
       <tr><td class="key"><a href="https://github.com/zsh-users/zsh-autosuggestions"><code>zsh-autosuggestions</code></a></td><td class="desc">ghost-text completion from history</td></tr>
       <tr><td class="key"><a href="https://github.com/zsh-users/zsh-syntax-highlighting"><code>zsh-syntax-highlighting</code></a></td><td class="desc">live command-line highlighting</td></tr>
       <tr><td class="key"><a href="https://github.com/junegunn/fzf"><code>fzf</code></a></td><td class="desc">fuzzy finder + Ctrl-R / Ctrl-T bindings</td></tr>
@@ -437,6 +439,46 @@
 </div>
 
 <!-- ═══════════════════════════════════════════════════════════════════════ -->
+<h2 id="xh">xh <span class="tool-tag">modern HTTP</span></h2>
+
+<div class="grid">
+  <div class="card">
+    <h3>Most-used invocations</h3>
+    <table>
+      <tr><td class="key"><code>xh GET httpbin.org/get</code></td><td class="desc">basic GET; pretty-prints JSON in Solarized colors</td></tr>
+      <tr><td class="key"><code>xh POST httpbin.org/post name=alice</code></td><td class="desc">JSON body via <code>key=value</code> shorthand (no <code>--data</code>)</td></tr>
+      <tr><td class="key"><code>xh -a user:pass api.example.com</code></td><td class="desc">basic auth (HTTPie-compatible flag)</td></tr>
+      <tr><td class="key"><code>xh --download url</code></td><td class="desc">save body to a file (filename inferred)</td></tr>
+      <tr><td class="key"><code>xhs api.github.com/zen</code></td><td class="desc">HTTPS-default companion binary (no <code>https://</code> needed)</td></tr>
+      <tr><td class="key"><code>xh --style=monokai GET …</code></td><td class="desc">override the default Solarized theme per-invocation</td></tr>
+    </table>
+  </div>
+
+  <div class="card">
+    <h3>Why a config file (and what's in it)</h3>
+    <p>
+      Solarized is pinned via <code>~/.config/xh/config.json</code>:
+    </p>
+    <pre>{<span class="str">"default_options"</span>: [<span class="str">"--style=solarized"</span>]}</pre>
+    <p>
+      <code>xh --style</code> accepts <code>auto</code>, <code>solarized</code>, <code>monokai</code>,
+      <code>fruity</code>. xh renders through <code>syntect</code> — the same library family as
+      <code>bat</code> — so highlighting matches the rest of the Solarized Dark setup.
+    </p>
+    <p class="note">No <code>.zshrc</code> alias here. Aliases in this repo are reserved for swapping commands; default flags belong in config files.</p>
+  </div>
+
+  <div class="card">
+    <h3>Coexistence with <code>curl</code></h3>
+    <p>
+      <code>curl</code> is unchanged. Scripts, CI, and any non-interactive use keep calling
+      <code>curl</code> verbatim. <code>xh</code>/<code>xhs</code> are the interactive surface only.
+    </p>
+    <p class="note">Don't alias <code>curl</code> to <code>xh</code>, and don't introduce an <code>http</code>/<code>https</code> alias either — the binary's own name is the only entry point.</p>
+  </div>
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════════════════ -->
 <h2 id="vivid">vivid &amp; LS_COLORS</h2>
 
 <div class="grid">
@@ -625,7 +667,7 @@
 </ol>
 
 <footer>
-  Built from <code>~/.zshrc</code>, <code>Brewfile</code>, and project CLAUDE.md on 2026-05-02.
+  Built from <code>~/.zshrc</code>, <code>Brewfile</code>, and project CLAUDE.md on 2026-05-03.
   Refresh after meaningful color-tooling changes.
 </footer>
 


### PR DESCRIPTION
## Summary

Adds [`xh`](https://github.com/ducaale/xh) as a Solarized-themed, HTTPie-compatible
HTTP client for *interactive* use. `curl` is unchanged and unaliased — scripts
and CI keep calling it verbatim.

- **Brewfile entry** `brew "xh"` under the "Shell colors & appearance" cluster.
- **Solarized via `xh` config**: `.config/xh/config.json` →
  `{"default_options": ["--style=solarized"]}`, symlinked from `bootstrap.sh`.
  Per-invocation `xh --style=monokai …` still overrides.
- **No `.zshrc` change.** Native command names only — `xh` (HTTP-default) and
  `xhs` (HTTPS-default). No alias on `curl`, no `http`/`https` synonym.
- **Docs:** CLAUDE.md convention bullet, README "What's where" row + Terminal
  cheatsheet bullet, dedicated `<h2 id="xh">` section in
  `docs/terminal-cheatsheet.html`, footer date refresh to 2026-05-03.

Closes #48.

## Test plan

- [x] `brew bundle check --file=Brewfile --verbose` reports `xh` as a missing
  formula (Brewfile is report-only, as per repo convention).
- [x] `brew install xh && xh --version` → `xh 0.25.3 -native-tls +rustls`.
- [x] `bash -n bootstrap.sh` (syntax check) + `jq . .config/xh/config.json`
  (JSON validity). Live `./bootstrap.sh` from a worktree resolves
  `$PROJECTS_HOME/dotfiles` to the *primary* checkout, so the symlink
  validation lands once this PR merges to main; in the meantime testing was
  done with `~/.config/xh` manually pointed at this worktree's
  `.config/xh/`.
- [x] `xh GET https://httpbin.org/get` → 200; pretty-printed JSON.
- [x] `xhs api.github.com/...` → resolves over HTTPS without explicit prefix.
- [x] `xh --style=monokai GET …` overrides per-invocation.
- [x] `type curl` → `curl is /usr/bin/curl` (no alias).
- [x] `type xh`  → `xh is /opt/homebrew/bin/xh` (no alias).
- [x] Existing test scripts unaffected: `scripts/test-helpers.sh`,
  `scripts/test-prompt-context.zsh`, `scripts/test-tmux-window-label.zsh`,
  `scripts/test-claude-tmux-window-name.zsh`,
  `scripts/test-tmux-fzf-url-newest.sh`, `scripts/test-fzf-file-extract.sh`,
  `scripts/test-s-session-root.sh` all green.
- [ ] On a fresh box, `./bootstrap.sh` from primary worktree links
  `~/.config/xh -> $DOTFILES/.config/xh` and is idempotent on second run.
- [ ] `docs/terminal-cheatsheet.html` opens in a browser; new `xh` section
  renders, ToC link works, header strip lists `xh`, footer date is
  `2026-05-03`.

## Notes

- xh's `--style` accepts `auto`/`solarized`/`monokai`/`fruity`. We pin
  `solarized`. xh renders highlighting through `syntect`, the same library
  family as `bat` — so the result is consistent with the rest of the
  Solarized Dark setup.
- The "no synonym" rule is documented in CLAUDE.md so future-me doesn't drift
  toward `alias http=xh` or `alias curl=xh`. Two ways to do one thing is a
  smell.