### PR TITLE
feat: modern-reminder zsh nudge for unaliased default tools

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -106,6 +106,56 @@ _tmux_record_last_cmd() {
 }
 add-zsh-hook preexec _tmux_record_last_cmd
 
+# modern-reminder (keep in sync with scripts/test-modern-reminder.zsh)
+# One-line nudge after running a default tool whose modern alternative is
+# installed and intentionally unaliased. Once per zsh process, per command.
+# Disable by commenting out `export MODERN_REMINDER=1` at the bottom of this block.
+typeset -gA _modern_reminder_pairs=(
+  [tail]=tspin
+  [grep]=rg
+  [curl]=xh
+)
+typeset -gA _modern_reminder_hints=(
+  [tail]="tspin is a modern alternative to tail. Try \`tspin -f app.log\`."
+  [grep]="rg is a modern alternative to grep."
+  [curl]="xh (HTTPie-compatible) is a modern alternative to curl."
+)
+typeset -gA _modern_reminder_seen
+typeset -g _modern_reminder_pending=""
+
+_modern_reminder_preexec() {
+  [[ -z ${MODERN_REMINDER:-} ]] && return
+  _modern_reminder_pending=""
+  local -a tokens=(${(z)1})
+  local t base
+  for t in "${tokens[@]}"; do
+    base="${t##*/}"      # strip directory prefix (/usr/bin/grep -> grep)
+    base="${base#\\}"    # strip leading backslash (\grep -> grep)
+    if [[ -n "${_modern_reminder_pairs[$base]:-}" ]]; then
+      _modern_reminder_pending="$base"
+      return
+    fi
+  done
+}
+
+_modern_reminder_precmd() {
+  local cmd="$_modern_reminder_pending"
+  _modern_reminder_pending=""
+  [[ -z ${MODERN_REMINDER:-} ]] && return
+  [[ -z $cmd ]] && return
+  [[ -n "${_modern_reminder_seen[$cmd]:-}" ]] && return
+  local modern="${_modern_reminder_pairs[$cmd]:-}"
+  [[ -z $modern ]] && return
+  command -v "$modern" >/dev/null 2>&1 || return
+  print -P "%F{yellow}%f ${_modern_reminder_hints[$cmd]}"
+  _modern_reminder_seen[$cmd]=1
+}
+
+add-zsh-hook preexec _modern_reminder_preexec
+add-zsh-hook precmd  _modern_reminder_precmd
+
+export MODERN_REMINDER=1
+
 # To customize prompt, run `p10k configure` or edit ~/.p10k.zsh.
 [[ ! -f ~/.p10k.zsh ]] || source ~/.p10k.zsh
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -281,6 +281,25 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
   `curl` stays available verbatim for scripts and CI. **Don't add an
   `http`/`https` alias** either; the rule is "no synonyms, just the
   binary's name". No `.zshrc` change for this tool.
+- **`modern-reminder` is a zsh-level discoverability nudge** for default→modern
+  tool pairs that this setup intentionally leaves *unaliased* (the "no synonyms,
+  just the binary's name" pattern shared by `tail`/`tspin`, `grep`/`rg`, and
+  `curl`/`xh`). Defined in `.zshrc` as two associative arrays
+  (`_modern_reminder_pairs`, `_modern_reminder_hints`), plus
+  `_modern_reminder_preexec` (scan-all-tokens via `${(z)…}`, strips leading
+  `\` and dirname) and `_modern_reminder_precmd` (env-var guard, once-per-shell
+  seen set, `command -v` check, `print -P "%F{yellow}%f …"`). Toggled by
+  `export MODERN_REMINDER=1`; comment that line to disable. State is
+  per-zsh-process — a fresh tmux pane resets the seen set. Tests:
+  `scripts/test-modern-reminder.zsh` (which holds a synced copy of the function
+  bodies; keep both copies in sync). **When introducing a new modern terminal
+  tool under the "no synonyms" pattern, evaluate it against the inclusion
+  criteria (default in common interactive use; modern alternative installed and
+  Solarized-themed; default deliberately unaliased) and add it to
+  `_modern_reminder_pairs` and `_modern_reminder_hints` in the same change.
+  Symmetrically, if a default tool gains an alias to its modern alternative
+  later, drop it from the catalog** — no point reminding when the alias already
+  redirects.
 
 ## Where things live
 
@@ -322,6 +341,7 @@ served at `https://martinciu.github.io/dotfiles/` via GitHub Pages
 - File-picker path-extraction tests: `scripts/test-fzf-file-extract.sh`
 - Zsh prompt-context tests: `scripts/test-prompt-context.zsh`
 - Tmux window-label tests: `scripts/test-tmux-window-label.zsh`
+- Modern-reminder tests: `scripts/test-modern-reminder.zsh`
 - Claude tmux window-name tests: `scripts/test-claude-tmux-window-name.zsh`
 - URL-picker wrapper tests: `scripts/test-tmux-fzf-url-newest.sh`
 - Session-root binding tests: `scripts/test-s-session-root.sh`

--- a/docs/terminal-cheatsheet.html
+++ b/docs/terminal-cheatsheet.html
@@ -33,6 +33,7 @@
   <a href="#glow">glow / md</a>
   <a href="#tspin">tspin</a>
   <a href="#xh">xh</a>
+  <a href="#modern-reminder">modern-reminder</a>
   <a href="#vivid">vivid / LS_COLORS</a>
   <a href="#fzf">fzf</a>
   <a href="#fzf-tab">fzf-tab</a>
@@ -475,6 +476,46 @@
       <code>curl</code> verbatim. <code>xh</code>/<code>xhs</code> are the interactive surface only.
     </p>
     <p class="note">Don't alias <code>curl</code> to <code>xh</code>, and don't introduce an <code>http</code>/<code>https</code> alias either — the binary's own name is the only entry point.</p>
+  </div>
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════════════════ -->
+<h2 id="modern-reminder">modern-reminder <span class="tool-tag">discoverability nudge</span></h2>
+
+<div class="grid">
+  <div class="card">
+    <h3>What it does</h3>
+    <p>
+      One-line nudge after running a default tool whose modern alternative is
+      installed and deliberately left unaliased. Fires at most once per zsh
+      process, per command name. A fresh tmux pane resets the seen set.
+    </p>
+    <table>
+      <tr><th>Default</th><th>Modern</th></tr>
+      <tr><td><code>tail</code></td><td><code>tspin</code></td></tr>
+      <tr><td><code>grep</code></td><td><code>rg</code> (ripgrep)</td></tr>
+      <tr><td><code>curl</code></td><td><code>xh</code> (HTTPie-compatible)</td></tr>
+    </table>
+  </div>
+
+  <div class="card">
+    <h3>Toggle</h3>
+    <p>
+      <code>export MODERN_REMINDER=1</code> in <code>~/.zshrc</code> turns it on
+      (set there by default). Comment that line — or <code>unset MODERN_REMINDER</code>
+      in a single shell — to silence.
+    </p>
+    <p class="note">Hooks register only in interactive shells, so scripts and CI never see them.</p>
+  </div>
+
+  <div class="card">
+    <h3>Where it lives</h3>
+    <p>
+      Implementation: <code>_modern_reminder_preexec</code> +
+      <code>_modern_reminder_precmd</code> in <code>~/.zshrc</code>; tests in
+      <code>scripts/test-modern-reminder.zsh</code> (which holds a synced copy
+      of the function bodies — keep both in sync).
+    </p>
   </div>
 </div>
 

--- a/scripts/test-modern-reminder.zsh
+++ b/scripts/test-modern-reminder.zsh
@@ -1,0 +1,53 @@
+#!/usr/bin/env zsh
+# Tests for the modern-reminder zsh hooks.
+# Run: zsh scripts/test-modern-reminder.zsh
+set -u
+
+pass=0; fail=0; fail_msgs=()
+
+assert_contains() {
+  local got="$1" needle="$2" desc="$3"
+  if printf '%s' "$got" | grep -q -F -- "$needle"; then
+    pass=$((pass+1)); echo "  PASS  $desc"
+  else
+    fail=$((fail+1))
+    fail_msgs+=("FAIL  $desc"$'\n'"        got:    '$got'"$'\n'"        needle: '$needle'")
+    echo "  FAIL  $desc"
+  fi
+}
+
+assert_not_contains() {
+  local got="$1" needle="$2" desc="$3"
+  if ! printf '%s' "$got" | grep -q -F -- "$needle"; then
+    pass=$((pass+1)); echo "  PASS  $desc"
+  else
+    fail=$((fail+1))
+    fail_msgs+=("FAIL  $desc"$'\n'"        got contained: '$needle'")
+    echo "  FAIL  $desc"
+  fi
+}
+
+# helper: clear state, run preexec then precmd, return captured stdout
+_run_hooks() {
+  local cmdline="$1"
+  _modern_reminder_pending=""
+  _modern_reminder_preexec "$cmdline"
+  _modern_reminder_precmd
+}
+
+echo
+echo "modern-reminder"
+
+# Test 1: disabled when env var unset
+unset MODERN_REMINDER
+out=$( _run_hooks "grep TODO src/" 2>&1 )
+assert_not_contains "$out" "modern alternative" \
+  "MODERN_REMINDER unset -> no reminder"
+
+echo
+echo "Total: $((pass+fail))  pass: $pass  fail: $fail"
+if (( fail > 0 )); then
+  for msg in "${fail_msgs[@]}"; do echo; echo "$msg"; done
+  exit 1
+fi
+exit 0

--- a/scripts/test-modern-reminder.zsh
+++ b/scripts/test-modern-reminder.zsh
@@ -44,11 +44,16 @@ typeset -g _modern_reminder_pending=""
 _modern_reminder_preexec() {
   [[ -z ${MODERN_REMINDER:-} ]] && return
   _modern_reminder_pending=""
-  # Stub: real token scan added in Task 5. For now: first-token-only.
-  local first="${${(z)1}[1]}"
-  if [[ -n "${_modern_reminder_pairs[$first]:-}" ]]; then
-    _modern_reminder_pending="$first"
-  fi
+  local -a tokens=(${(z)1})
+  local t base
+  for t in "${tokens[@]}"; do
+    base="${t##*/}"      # strip directory prefix (/usr/bin/grep -> grep)
+    base="${base#\\}"    # strip leading backslash (\grep -> grep)
+    if [[ -n "${_modern_reminder_pairs[$base]:-}" ]]; then
+      _modern_reminder_pending="$base"
+      return
+    fi
+  done
 }
 
 _modern_reminder_precmd() {
@@ -107,6 +112,15 @@ PATH="$saved_path"
 out=$(<"$tmp"); rm -f "$tmp"
 assert_not_contains "$out" "modern alternative" \
   "Modern tool missing from \$PATH -> no reminder"
+
+# Test 4: token scan handles pipes
+export MODERN_REMINDER=1
+_modern_reminder_seen=()
+tmp=$(mktemp -t mr.XXXXXX)
+_run_hooks "echo x | grep x" >"$tmp" 2>&1
+out=$(<"$tmp"); rm -f "$tmp"
+assert_contains "$out" "rg is a modern alternative to grep" \
+  "Token scan: 'echo x | grep x' fires for grep"
 
 echo
 echo "Total: $((pass+fail))  pass: $pass  fail: $fail"

--- a/scripts/test-modern-reminder.zsh
+++ b/scripts/test-modern-reminder.zsh
@@ -122,6 +122,30 @@ out=$(<"$tmp"); rm -f "$tmp"
 assert_contains "$out" "rg is a modern alternative to grep" \
   "Token scan: 'echo x | grep x' fires for grep"
 
+# Test 5: fresh subshell starts empty (validates per-process scope)
+export MODERN_REMINDER=1
+runner=$(mktemp -t mr-test.XXXXXX.zsh)
+{
+  typeset -p _modern_reminder_pairs
+  typeset -p _modern_reminder_hints
+  echo 'typeset -gA _modern_reminder_seen'
+  echo 'typeset -g _modern_reminder_pending=""'
+  typeset -f _modern_reminder_preexec
+  typeset -f _modern_reminder_precmd
+  echo 'export MODERN_REMINDER=1'
+  echo '_modern_reminder_preexec "grep TODO"'
+  echo '_modern_reminder_precmd'
+} > "$runner"
+
+out_a=$( zsh "$runner" )
+out_b=$( zsh "$runner" )
+rm -f "$runner"
+
+assert_contains "$out_a" "modern alternative to grep" \
+  "Subshell A: grep fires reminder"
+assert_contains "$out_b" "modern alternative to grep" \
+  "Subshell B (fresh process): grep fires again — no shared state"
+
 echo
 echo "Total: $((pass+fail))  pass: $pass  fail: $fail"
 if (( fail > 0 )); then

--- a/scripts/test-modern-reminder.zsh
+++ b/scripts/test-modern-reminder.zsh
@@ -27,6 +27,36 @@ assert_not_contains() {
   fi
 }
 
+# Functions under test (keep in sync with .zshrc)
+typeset -gA _modern_reminder_pairs=(
+  [tail]=tspin
+  [grep]=rg
+  [curl]=xh
+)
+typeset -gA _modern_reminder_hints=(
+  [tail]="tspin is a modern alternative to tail. Try \`tspin -f app.log\`."
+  [grep]="rg is a modern alternative to grep."
+  [curl]="xh (HTTPie-compatible) is a modern alternative to curl."
+)
+typeset -gA _modern_reminder_seen
+typeset -g _modern_reminder_pending=""
+
+_modern_reminder_preexec() {
+  [[ -z $MODERN_REMINDER ]] && return
+  _modern_reminder_pending=""
+  # Stub: real token scan added in Task 5. For now: first-token-only.
+  local first="${${(z)1}[1]}"
+  if [[ -n "${_modern_reminder_pairs[$first]}" ]]; then
+    _modern_reminder_pending="$first"
+  fi
+}
+
+_modern_reminder_precmd() {
+  [[ -z $MODERN_REMINDER ]] && return
+  # Stub: real fire-once logic added in Task 3.
+  _modern_reminder_pending=""
+}
+
 # helper: clear state, run preexec then precmd, return captured stdout
 _run_hooks() {
   local cmdline="$1"

--- a/scripts/test-modern-reminder.zsh
+++ b/scripts/test-modern-reminder.zsh
@@ -42,19 +42,23 @@ typeset -gA _modern_reminder_seen
 typeset -g _modern_reminder_pending=""
 
 _modern_reminder_preexec() {
-  [[ -z $MODERN_REMINDER ]] && return
+  [[ -z ${MODERN_REMINDER:-} ]] && return
   _modern_reminder_pending=""
   # Stub: real token scan added in Task 5. For now: first-token-only.
   local first="${${(z)1}[1]}"
-  if [[ -n "${_modern_reminder_pairs[$first]}" ]]; then
+  if [[ -n "${_modern_reminder_pairs[$first]:-}" ]]; then
     _modern_reminder_pending="$first"
   fi
 }
 
 _modern_reminder_precmd() {
-  [[ -z $MODERN_REMINDER ]] && return
-  # Stub: real fire-once logic added in Task 3.
+  local cmd="$_modern_reminder_pending"
   _modern_reminder_pending=""
+  [[ -z ${MODERN_REMINDER:-} ]] && return
+  [[ -z $cmd ]] && return
+  [[ -n "${_modern_reminder_seen[$cmd]:-}" ]] && return
+  print -P "%F{yellow}%f ${_modern_reminder_hints[$cmd]}"
+  _modern_reminder_seen[$cmd]=1
 }
 
 # helper: clear state, run preexec then precmd, return captured stdout
@@ -70,9 +74,24 @@ echo "modern-reminder"
 
 # Test 1: disabled when env var unset
 unset MODERN_REMINDER
-out=$( _run_hooks "grep TODO src/" 2>&1 )
+tmp=$(mktemp -t mr.XXXXXX)
+_run_hooks "grep TODO src/" >"$tmp" 2>&1
+out=$(<"$tmp"); rm -f "$tmp"
 assert_not_contains "$out" "modern alternative" \
   "MODERN_REMINDER unset -> no reminder"
+
+# Test 2: fires once per session
+export MODERN_REMINDER=1
+_modern_reminder_seen=()
+tmp1=$(mktemp -t mr.XXXXXX); tmp2=$(mktemp -t mr.XXXXXX)
+_run_hooks "grep TODO src/"   >"$tmp1" 2>&1
+_run_hooks "grep TODO other/" >"$tmp2" 2>&1
+out1=$(<"$tmp1"); out2=$(<"$tmp2")
+rm -f "$tmp1" "$tmp2"
+assert_contains "$out1" "rg is a modern alternative to grep" \
+  "First grep call -> reminder fires"
+assert_not_contains "$out2" "modern alternative" \
+  "Second grep call in same shell -> silent"
 
 echo
 echo "Total: $((pass+fail))  pass: $pass  fail: $fail"

--- a/scripts/test-modern-reminder.zsh
+++ b/scripts/test-modern-reminder.zsh
@@ -57,6 +57,9 @@ _modern_reminder_precmd() {
   [[ -z ${MODERN_REMINDER:-} ]] && return
   [[ -z $cmd ]] && return
   [[ -n "${_modern_reminder_seen[$cmd]:-}" ]] && return
+  local modern="${_modern_reminder_pairs[$cmd]:-}"
+  [[ -z $modern ]] && return
+  command -v "$modern" >/dev/null 2>&1 || return
   print -P "%F{yellow}%f ${_modern_reminder_hints[$cmd]}"
   _modern_reminder_seen[$cmd]=1
 }
@@ -92,6 +95,18 @@ assert_contains "$out1" "rg is a modern alternative to grep" \
   "First grep call -> reminder fires"
 assert_not_contains "$out2" "modern alternative" \
   "Second grep call in same shell -> silent"
+
+# Test 3: skips when modern tool missing
+export MODERN_REMINDER=1
+_modern_reminder_seen=()
+tmp=$(mktemp -t mr.XXXXXX)
+saved_path="$PATH"
+PATH="/nonexistent"
+_run_hooks "grep TODO src/" >"$tmp" 2>&1
+PATH="$saved_path"
+out=$(<"$tmp"); rm -f "$tmp"
+assert_not_contains "$out" "modern alternative" \
+  "Modern tool missing from \$PATH -> no reminder"
 
 echo
 echo "Total: $((pass+fail))  pass: $pass  fail: $fail"


### PR DESCRIPTION
## Summary

- Adds a zsh `preexec`/`precmd` hook pair that prints a one-line reminder
  after running a default tool (`tail`, `grep`, `curl`) whose modern
  alternative (`tspin`, `rg`, `xh`) is installed and deliberately
  unaliased.
- One reminder per command name per zsh process. New tmux pane = fresh
  state.
- Toggled by `export MODERN_REMINDER=1` in `.zshrc`; comment the line to
  disable.
- Implements the system-level expression of the "no synonyms, just the
  binary's name" convention pinned in CLAUDE.md (tspin/rg/xh bullets).

## Test plan

- [x] `zsh scripts/test-modern-reminder.zsh` — 7 PASS, 0 FAIL
- [x] `zsh scripts/test-prompt-context.zsh` — unchanged, 10 PASS
- [x] `zsh scripts/test-tmux-window-label.zsh` — unchanged, 11 PASS
- [x] `bash scripts/test-helpers.sh` — unchanged, 30 PASS
- [ ] Manual: `grep TODO .` in a fresh pane → reminder prints; second
      `grep` → silent
- [ ] Manual: `tail /etc/hosts` → reminder prints
- [ ] Manual: `echo x | grep x` → reminder prints (verifies token-scan)
- [ ] Manual: `unset MODERN_REMINDER` in shell → no reminder

## Related

- Builds on PR #69 (xh installed alongside curl)
- Tracks #70 separately (Nerd Font cask in Brewfile — required for the
  lightbulb glyph; not bundled per #48 guidance)