### PR TITLE
fix(modern-reminder): per-tool glyphs via \u escapes; no backtick substitution

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -116,9 +116,9 @@ typeset -gA _modern_reminder_pairs=(
   [curl]=xh
 )
 typeset -gA _modern_reminder_hints=(
-  [tail]="tspin is a modern alternative to tail. Try \`tspin -f app.log\`."
-  [grep]="rg is a modern alternative to grep."
-  [curl]="xh (HTTPie-compatible) is a modern alternative to curl."
+  [tail]="%F{yellow}\uF0EB%f tspin is a modern alternative to tail. Try 'tspin -f app.log'."
+  [grep]="%F{yellow}\uF0E7%f rg is a modern alternative to grep."
+  [curl]="%F{yellow}\uF427%f xh (HTTPie-compatible) is a modern alternative to curl."
 )
 typeset -gA _modern_reminder_seen
 typeset -g _modern_reminder_pending=""
@@ -147,7 +147,7 @@ _modern_reminder_precmd() {
   local modern="${_modern_reminder_pairs[$cmd]:-}"
   [[ -z $modern ]] && return
   command -v "$modern" >/dev/null 2>&1 || return
-  print -P "%F{yellow}%f ${_modern_reminder_hints[$cmd]}"
+  print -P "${_modern_reminder_hints[$cmd]}"
   _modern_reminder_seen[$cmd]=1
 }
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -288,8 +288,14 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
   (`_modern_reminder_pairs`, `_modern_reminder_hints`), plus
   `_modern_reminder_preexec` (scan-all-tokens via `${(z)…}`, strips leading
   `\` and dirname) and `_modern_reminder_precmd` (env-var guard, once-per-shell
-  seen set, `command -v` check, `print -P "%F{yellow}%f …"`). Toggled by
-  `export MODERN_REMINDER=1`; comment that line to disable. State is
+  seen set, `command -v` check, `print -P "${_modern_reminder_hints[$cmd]}"`).
+  Each hint embeds its own Nerd Font glyph as a `\u…` escape and Solarized
+  yellow via `%F{yellow}%f` so `print -P` decodes both at runtime — keeps
+  source 7-bit ASCII and avoids editor/clipboard mangling of private-use
+  codepoints. Don't put backticks or `$(…)` inside hint text: under
+  `PROMPT_SUBST` (set by p10k), `print -P` performs command substitution on
+  the prompt string. Use single quotes for sample-syntax emphasis. Toggled
+  by `export MODERN_REMINDER=1`; comment that line to disable. State is
   per-zsh-process — a fresh tmux pane resets the seen set. Tests:
   `scripts/test-modern-reminder.zsh` (which holds a synced copy of the function
   bodies; keep both copies in sync). **When introducing a new modern terminal

--- a/scripts/test-modern-reminder.zsh
+++ b/scripts/test-modern-reminder.zsh
@@ -3,6 +3,12 @@
 # Run: zsh scripts/test-modern-reminder.zsh
 set -u
 
+# Match the interactive shell's prompt-expansion semantics — p10k enables
+# PROMPT_SUBST, so `print -P` performs parameter, command, and arithmetic
+# substitution on prompt strings. Hint text must not contain anything that
+# would be substituted (backticks, $(...), $((...)), unescaped $).
+setopt PROMPT_SUBST
+
 pass=0; fail=0; fail_msgs=()
 
 assert_contains() {
@@ -34,9 +40,9 @@ typeset -gA _modern_reminder_pairs=(
   [curl]=xh
 )
 typeset -gA _modern_reminder_hints=(
-  [tail]="tspin is a modern alternative to tail. Try \`tspin -f app.log\`."
-  [grep]="rg is a modern alternative to grep."
-  [curl]="xh (HTTPie-compatible) is a modern alternative to curl."
+  [tail]="%F{yellow}\uF0EB%f tspin is a modern alternative to tail. Try 'tspin -f app.log'."
+  [grep]="%F{yellow}\uF0E7%f rg is a modern alternative to grep."
+  [curl]="%F{yellow}\uF427%f xh (HTTPie-compatible) is a modern alternative to curl."
 )
 typeset -gA _modern_reminder_seen
 typeset -g _modern_reminder_pending=""
@@ -65,7 +71,7 @@ _modern_reminder_precmd() {
   local modern="${_modern_reminder_pairs[$cmd]:-}"
   [[ -z $modern ]] && return
   command -v "$modern" >/dev/null 2>&1 || return
-  print -P "%F{yellow}%f ${_modern_reminder_hints[$cmd]}"
+  print -P "${_modern_reminder_hints[$cmd]}"
   _modern_reminder_seen[$cmd]=1
 }
 
@@ -122,7 +128,17 @@ out=$(<"$tmp"); rm -f "$tmp"
 assert_contains "$out" "rg is a modern alternative to grep" \
   "Token scan: 'echo x | grep x' fires for grep"
 
-# Test 5: fresh subshell starts empty (validates per-process scope)
+# Test 5: tail hint sample-syntax survives prompt expansion (regression: backticks
+# under PROMPT_SUBST got command-substituted, leaving "Try ." with a side-effect)
+export MODERN_REMINDER=1
+_modern_reminder_seen=()
+tmp=$(mktemp -t mr.XXXXXX)
+_run_hooks "tail /etc/hosts" >"$tmp" 2>&1
+out=$(<"$tmp"); rm -f "$tmp"
+assert_contains "$out" "Try 'tspin -f app.log'." \
+  "tail hint: literal sample syntax preserved (no command substitution)"
+
+# Test 6: fresh subshell starts empty (validates per-process scope)
 export MODERN_REMINDER=1
 runner=$(mktemp -t mr-test.XXXXXX.zsh)
 {


### PR DESCRIPTION
Two bugs visible after #71 merged (see screenshot in conversation).

## What broke

**1. Backtick command substitution.** The tspin hint was
`Try \`tspin -f app.log\`.`. Under `PROMPT_SUBST` (set by p10k),
`print -P` performs command substitution on prompt strings — so
the reminder actually invoked `tspin -f app.log`, printed
`Error: app.log: No such file or directory`, and left `Try .` in
the message.

**2. Glyph went missing.** The lightbulb was a literal Nerd Font
private-use codepoint in source. Without JetBrainsMono Nerd Font
installed (tracked in #70), users see nothing. Source-encoded
private-use chars are also brittle under editor/clipboard round-trips.

## The fix

- Replace backticks with single quotes in the tspin sample syntax
  (visually equivalent; `'` is not a prompt-expansion metacharacter).
- Move the glyph into each hint as a `\uXXXX` escape, decoded by
  `print -P` at runtime. Source stays 7-bit ASCII. Each tool now has
  its own glyph: `` (lightbulb) for tail, `` (bolt) for
  grep, `` (paper-plane) for curl.
- Test runner now sets `PROMPT_SUBST` to match the interactive shell —
  the previous test environment didn't, which is why the backtick bug
  slipped through. Added an explicit regression assertion for the tail
  hint.
- Updated the CLAUDE.md bullet to document the `print -P` shape and
  the "no backticks/`$(…)` in hint text" rule.

## Test plan

- [x] `zsh scripts/test-modern-reminder.zsh` — 8 PASS, 0 FAIL (incl. new
      regression test)
- [x] Other dotfile test suites unchanged: `test-prompt-context.zsh`,
      `test-tmux-window-label.zsh`, `test-helpers.sh` — all pass
- [ ] Manual: reload `.zshrc`, `tail /etc/hosts` →
      `<lightbulb> tspin is a modern alternative to tail. Try 'tspin -f app.log'.`
- [ ] Manual: in a fresh pane, `grep TODO .` → `<bolt> rg is a modern alternative to grep.`
- [ ] Manual: `curl https://httpbin.org/get >/dev/null` → `<plane> xh (HTTPie-compatible) is a modern alternative to curl.`

The lightbulb/bolt/plane glyphs still need JetBrainsMono Nerd Font on
the host terminal; that prerequisite is tracked separately in #70.

## Related

- Fixes regression introduced in #71
- #70 still tracks the Nerd Font cask in Brewfile (out of scope here)