### PR TITLE
Bootstrap: install JetBrainsMono Nerd Font via Brewfile cask

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -39,3 +39,6 @@ brew "lnav"                     # TUI log file navigator
 
 # System monitoring
 brew "btop"                     # modern top replacement (themed Solarized)
+
+# Fonts
+cask "font-jetbrains-mono-nerd-font"  # Solarized + JetBrainsMono Nerd Font everywhere (CLAUDE.md)


### PR DESCRIPTION
## Summary
- Adds a single `cask "font-jetbrains-mono-nerd-font"` line under a new `# Fonts` section at the end of `Brewfile`.
- `bootstrap.sh`'s existing `brew bundle check --verbose` step now flags the foundational JetBrainsMono Nerd Font as missing on a fresh machine — closing the silent-degradation gap behind every Nerd-Font-dependent UI element (powerline arrows, eza icons, `modern-reminder` glyphs, etc.).
- Zero behaviour change to `bootstrap.sh` (still report-only); no new tap, no README rewrite, no CLAUDE.md edit.

Closes #70.

## Spec

[`.superpowers/specs/2026-05-03-jetbrainsmono-nerd-font-cask-design.md`](https://github.com/martinciu/dotfiles/blob/70-nerdfonts/.superpowers/specs/2026-05-03-jetbrainsmono-nerd-font-cask-design.md) (gitignored locally — included here as the live worktree path; the file is not committed per the `.superpowers/` convention).

## Plan

[`.superpowers/plans/2026-05-03-jetbrainsmono-nerd-font-cask.md`](https://github.com/martinciu/dotfiles/blob/70-nerdfonts/.superpowers/plans/2026-05-03-jetbrainsmono-nerd-font-cask.md) — 4 tasks (capture pre-state → append section → verify → commit), single-file diff.

## Assumptions

Best-effort calls made by the autonomous pipeline (none were high-stakes; all surfaced for review):

- **Section placement:** new `# Fonts` group appended at end of `Brewfile` (vs. folding into `# Shell colors & appearance`) — matches the file's existing comment-grouped layout and keeps "Shell colors" semantically focused on CLI rendering.
- **Trailing comment:** `# Solarized + JetBrainsMono Nerd Font everywhere (CLAUDE.md)` annotated on the cask line for greppability with the convention bullet (matches the rest of the file's annotation style).
- **No README edit.** Issue #70 marks README updates *optional*.
- **No CLAUDE.md edit.** The existing convention bullet already covers the font; the install-path detail belongs in `Brewfile`, not the convention list.
- **Commit message phrasing.** Imperative subject + "why" body matching recent commits (e.g. `Drop tmp/…`, `Add machine-wide …`); `Closes #70` so the merge auto-closes the issue. No co-author trailer per `~/.claude/CLAUDE.md`.
- **Negative-case round-trip skipped on this run.** The font isn't installed on the maintainer's machine, so the post-change `brew bundle check` already exercises the missing-state path directly (see Test plan below) — no need to uninstall-and-reinstall.

## Test plan
- [x] `brew info --cask font-jetbrains-mono-nerd-font` resolves from `Homebrew/homebrew-cask` (3.4.0, no extra tap).
- [x] Pre-change `brew bundle check --file=Brewfile --verbose` exits 0 with `The Brewfile's dependencies are satisfied.`
- [x] Post-change `brew bundle check --file=Brewfile --verbose` exits 1 with `→ Cask font-jetbrains-mono-nerd-font needs to be installed or updated.` — exactly the missing-on-fresh-machine signal #70 asked for.
- [x] `git diff bootstrap.sh` is empty — bootstrap is untouched.
- [x] `git diff Brewfile` is exactly +3 lines (blank separator, `# Fonts` header, cask line).
- [ ] Optional, on a machine where the font is already installed: `brew uninstall --cask font-jetbrains-mono-nerd-font` → `brew bundle check` flags missing → `brew bundle` reinstalls → `brew bundle check` reports satisfied. (Not exercised here; the font is currently uninstalled, which already covers the missing case.)

## Session stats

=== Timeline ===
  start:    2026-05-03T08:56:58.814Z
  end:      2026-05-03T09:07:22.259Z
  elapsed:  0:10:23 (623s, 10.4 min)
  working:  0:16:06 (966s, 16.1 min, 155% of elapsed)
  idle:     0:00:01 (1s, 0.0 min)  (controller wait-for-user only)

| Model      | Msgs | Input | Output |    CacheR |   CW-5m |   CW-1h | Cost USD |
|------------|------|-------|--------|-----------|---------|---------|----------|
| opus-4-7   |  136 |   756 | 67,399 | 7,040,431 | 508,967 | 412,504 | $37.5452 |
| **TOTAL**  |  136 |   756 | 67,399 | 7,040,431 | 508,967 | 412,504 | **$37.5452** |

- Total billed tokens: 8,030,057
- Effective rate: \$139.93/hr (cost ÷ working time, includes parallel subagent compute)

Notes:
- Public-rate estimate (Anthropic API prices, may change). Plan billing (Max / Pro / Team / Enterprise) differs.
- Cache reads dominate — normal under prompt caching at ~10% of base input price.
- Subagent costs are aggregated by model, not task; agent ID → task mapping is in `agent-<id>.meta.json`.
- Working > elapsed because two phase subagents (brainstorm, plan) ran inside the controller's wall-clock window.

🤖 Opened by /autonomo