### PR TITLE
Add tmux dashboard for live multi-session preview

### DIFF
--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -97,6 +97,17 @@ bind-key "T" clock-mode
 bind-key "o" display-popup -E -w 70% -h 70% \
   "~/.config/tmux/bin/tmux-fzf-file '#{pane_id}' '#{pane_current_path}'"
 
+# ─── Dashboard pagination ────────────────────
+# `bin/dashboard` is the multi-session live preview command. These keys are
+# no-ops outside dashboard-* sessions (the script checks #S and bails).
+# DASHBOARD_TARGET=#{session_name} disambiguates inside run-shell, where
+# `display-message -p '#S'` returns the global most-recent active session
+# rather than the run-shell target.
+bind-key -N "Dashboard: page rows down" J \
+  run-shell 'DASHBOARD_TARGET=#{session_name} dashboard --page-down 2>/dev/null || true'
+bind-key -N "Dashboard: page rows up" K \
+  run-shell 'DASHBOARD_TARGET=#{session_name} dashboard --page-up 2>/dev/null || true'
+
 # ─── Plugins (TPM) ──────────────────────────
 set -g @plugin 'tmux-plugins/tpm'
 set -g @plugin 'tmux-plugins/tmux-sensible'

--- a/Brewfile
+++ b/Brewfile
@@ -5,6 +5,7 @@
 brew "git"
 brew "tmux"
 brew "jq"   # JSON parsing in shell helpers
+brew "watch"  # procps watch — used by `dashboard` for live tile polling (-c ANSI passthrough)
 
 # Session switcher (sesh + fzf, sesh comes from a tap)
 brew "fzf"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,29 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
   Project list comes from `sesh list -c -j` (the configured-sessions
   source); no separate registry. The picker is tmux-sessionx (see
   the sessionx bullet); `s` does not invoke it.
+- **`dashboard` is the multi-session live preview command** (`bin/dashboard`,
+  symlinked to `~/.local/bin/dashboard` by `bootstrap.sh`). Surface:
+  `dashboard <pattern> [--cols N]`, plus internal subcommands
+  `--page-down`, `--page-up`, `--rebuild`. Pattern is a session-name
+  glob; spawns or rebuilds a `dashboard-<derived>` session with one
+  polled `watch + capture-pane` tile per matched session (excluding
+  `dashboard-*` themselves so dashboards never tile each other). The
+  dashboard prefix uses `-` (not `:`) because tmux silently rewrites
+  `:` in session names. `<prefix> J/K` page rows down/up — bindings
+  are no-ops outside `dashboard-*` (script bails on `#S`). Bindings
+  pass `DASHBOARD_TARGET=#{session_name}` because `display-message
+  -p '#S'` inside `run-shell` returns the global most-recent session,
+  not the run-shell target. `--cols N` forces an N-column grid via a
+  hand-built two-pass split (vertical row seeds, then horizontal
+  column splits per row); without it tmux's `tiled` layout is used.
+  Don't replace polling with `link-window` (only one window visible
+  at a time) or nested `tmux attach` (shows whole client UI). Don't
+  auto-install a `--rebuild` keybinding; the user wires `<prefix> R`
+  themselves if wanted. The script reads `$TMUX_SOCKET` (test-mode
+  socket isolation) and `$DASHBOARD_NO_FINISH` (skip the final
+  attach/switch-client — used by the integration tests because
+  there's no real client to attach against the test server).
+  Production runs leave both unset.
 - **`vim` and `vimdiff` are zsh aliases to nvim**; **`vi` is a zsh alias
   to the legacy minimal vim** (`alias vi='command vim'` — `command`
   suppresses recursive alias expansion). All three are defined in
@@ -364,6 +387,7 @@ served at `https://martinciu.github.io/dotfiles/` via GitHub Pages
 - Claude tmux window-name tests: `scripts/test-claude-tmux-window-name.zsh`
 - URL-picker wrapper tests: `scripts/test-tmux-fzf-url-newest.sh`
 - Session-root binding tests: `scripts/test-s-session-root.sh`
+- Dashboard smoke + integration tests: `scripts/test-dashboard.sh`
 - Reapply symlinks (idempotent): `$PROJECTS_HOME/dotfiles/bootstrap.sh`
 - Check brew deps without installing: `brew bundle check --file=$PROJECTS_HOME/dotfiles/Brewfile --verbose`
 - nvim plugin smoke test: `scripts/test-nvim.sh`

--- a/bin/dashboard
+++ b/bin/dashboard
@@ -3,6 +3,12 @@
 # See .superpowers/specs/2026-05-03-tmux-dashboard.md for design rationale.
 set -euo pipefail
 
+# ─── Preconditions ──────────────────────────
+if ! command -v watch >/dev/null 2>&1; then
+  echo "dashboard: 'watch' not on PATH (install via: brew bundle --file=\$PROJECTS_HOME/dotfiles/Brewfile)" >&2
+  exit 1
+fi
+
 # ─── Constants ──────────────────────────────
 MIN_TILE_HEIGHT=12  # rows; conservative floor so tiles stay legible
 

--- a/bin/dashboard
+++ b/bin/dashboard
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# dashboard — live multi-session tmux preview.
+# See .superpowers/specs/2026-05-03-tmux-dashboard.md for design rationale.
+set -euo pipefail
+
+# ─── Constants ──────────────────────────────
+MIN_TILE_HEIGHT=12  # rows; conservative floor so tiles stay legible
+
+# ─── tmux invocation (honors $TMUX_SOCKET for test isolation) ──
+# When $TMUX_SOCKET is set, every tmux call uses -L "$TMUX_SOCKET".
+# Smoke tests set it; production runs leave it unset (default socket).
+tmx() {
+  if [ -n "${TMUX_SOCKET:-}" ]; then
+    tmux -L "$TMUX_SOCKET" "$@"
+  else
+    tmux "$@"
+  fi
+}
+
+usage() {
+  cat <<'EOF' >&2
+Usage: dashboard <pattern> [--cols N]
+       dashboard --page-down
+       dashboard --page-up
+       dashboard --rebuild
+
+  <pattern>       Session-name glob (e.g. '*-agent', 'claude-*'). Quote it.
+  --cols N        Force N columns per row. Default: tmux's tiled auto-shape.
+  --page-down     Internal: rotate dashboard to next row of matched sessions.
+  --page-up       Internal: rotate dashboard to previous row.
+  --rebuild       Internal: re-discover and rebuild tiles for current dashboard.
+
+  Spawns or rebuilds a `dashboard:<derived>` session showing one polled
+  capture-pane tile per matched source session.
+EOF
+  exit 1
+}
+
+# Strip non-alphanumerics from a pattern to produce a session-name suffix.
+# Echoes the derived name on stdout. Exits 1 if result is empty.
+derived_name() {
+  local pattern="$1" derived
+  derived=$(printf '%s' "$pattern" | LC_ALL=C tr -cd 'a-zA-Z0-9')
+  if [ -z "$derived" ]; then
+    echo "dashboard: pattern '$pattern' produces empty derived name" >&2
+    exit 1
+  fi
+  printf '%s\n' "$derived"
+}
+
+# ─── Test hook: print derived name and exit ──
+# DASHBOARD_TEST_DERIVED=<pattern> dashboard --print-derived
+# Used by scripts/test-dashboard.sh for pure-logic assertions.
+if [ "${1:-}" = "--print-derived" ] && [ -n "${DASHBOARD_TEST_DERIVED:-}" ]; then
+  derived_name "$DASHBOARD_TEST_DERIVED"
+  exit 0
+fi
+
+# ─── Arg parsing ────────────────────────────
+[ $# -eq 0 ] && usage
+
+case "$1" in
+  --page-down|--page-up|--rebuild)
+    # Filled in by later tasks. For now: bail with a clear placeholder.
+    echo "dashboard: $1 not yet implemented" >&2
+    exit 1
+    ;;
+esac
+
+PATTERN="$1"; shift
+COLS=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --cols)
+      shift
+      if [ $# -eq 0 ] || ! printf '%s' "${1:-}" | grep -qE '^[0-9]+$'; then
+        echo "dashboard: --cols requires a positive integer" >&2
+        exit 1
+      fi
+      COLS="$1"; shift
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+
+DERIVED=$(derived_name "$PATTERN")
+SESSION="dashboard:$DERIVED"
+
+# ─── Dispatch (filled in by later tasks) ──
+echo "dashboard: would build $SESSION from pattern '$PATTERN' (cols=${COLS:-tiled})" >&2
+exit 0

--- a/bin/dashboard
+++ b/bin/dashboard
@@ -237,14 +237,19 @@ build_dashboard() {
   done < <(tmx list-panes -t "$session" -F '#{pane_id}')
 
   # ── State + status-right ──
-  local n_total=${#all_sources[@]}
+  # Total = unsliced source count (callers pass DASHBOARD_TOTAL when slicing
+  # for pagination; falls back to in-pane count for unpaginated builds).
+  local n_total=${DASHBOARD_TOTAL:-${#all_sources[@]}}
   local cols_eff=${DASHBOARD_COLS:-0}  # 0 means "auto/tiled" — pages = 1 in auto mode
   local visible_rows page_size pages
 
   if [ "$cols_eff" -gt 0 ]; then
-    local term_height
-    term_height=$(tmx display-message -t "$session" -p '#{client_height}' 2>/dev/null || echo 60)
+    local term_height=${DASHBOARD_TERM_HEIGHT:-}
+    if [ -z "$term_height" ]; then
+      term_height=$(tmx display-message -t "$session" -p '#{client_height}' 2>/dev/null || echo 60)
+    fi
     [ -z "$term_height" ] && term_height=60
+    [ "$term_height" -lt 60 ] && term_height=60
     visible_rows=$(( (term_height - 1) / MIN_TILE_HEIGHT ))
     [ "$visible_rows" -lt 1 ] && visible_rows=1
     page_size=$(( cols_eff * visible_rows ))
@@ -264,8 +269,72 @@ build_dashboard() {
     " [$((cur_page + 1))/$pages] $session "
 }
 
-# ─── Test hook: print derived name and exit ──
-# (test hooks are also handy below; the original --print-derived above remains)
+# Read the current tmux client's session name. Echo on stdout. Exit 1 if no
+# session is reachable (not in tmux, no socket, etc).
+current_session() {
+  tmx display-message -p '#S' 2>/dev/null
+}
+
+# Common page-jump implementation. $1 = "down" or "up".
+page_jump() {
+  local dir="$1" cur sess pattern cols pages cur_page new_page
+  cur=$(current_session) || return 0   # silent bail if not in tmux
+  case "$cur" in
+    dashboard-*) sess="$cur" ;;
+    *) return 0 ;;                     # silent bail when not in a dashboard
+  esac
+
+  pattern=$(tmx show-options -t "$sess" -v @dashboard-pattern 2>/dev/null)
+  cols=$(tmx show-options -t "$sess" -v @dashboard-cols 2>/dev/null)
+  pages=$(tmx show-options -t "$sess" -v @dashboard-pages 2>/dev/null)
+  cur_page=$(tmx show-options -t "$sess" -v @dashboard-page 2>/dev/null)
+  [ -z "$pattern" ] && return 0
+  [ -z "$pages" ] && pages=1
+  [ -z "$cur_page" ] && cur_page=0
+
+  case "$dir" in
+    down) new_page=$((cur_page + 1)) ;;
+    up)   new_page=$((cur_page - 1)) ;;
+  esac
+  [ "$new_page" -lt 0 ] && new_page=0
+  [ "$new_page" -ge "$pages" ] && new_page=$((pages - 1))
+
+  if [ "$new_page" = "$cur_page" ]; then
+    return 0  # already at clamp; nothing to rebuild
+  fi
+
+  # Re-discover and rebuild the visible slice.
+  local sources=()
+  while IFS= read -r _line; do
+    sources+=("$_line")
+  done < <(discover_sessions "$pattern")
+  if [ "${#sources[@]}" -eq 0 ]; then
+    return 0
+  fi
+
+  # Slice for the new page.
+  local term_height visible_rows page_size start slice
+  term_height=$(tmx display-message -t "$sess" -p '#{client_height}' 2>/dev/null || echo 60)
+  [ -z "$term_height" ] && term_height=60
+  visible_rows=$(( (term_height - 1) / MIN_TILE_HEIGHT ))
+  [ "$visible_rows" -lt 1 ] && visible_rows=1
+  page_size=$(( ${cols:-1} * visible_rows ))
+  [ "$page_size" -lt 1 ] && page_size=1
+  start=$(( new_page * page_size ))
+  set +u; slice=("${sources[@]:start:page_size}"); set -u
+
+  DASHBOARD_PATTERN="$pattern" \
+  DASHBOARD_COLS="$cols" \
+  DASHBOARD_PAGE="$new_page" \
+  DASHBOARD_TOTAL="${#sources[@]}" \
+    build_dashboard "$sess" "${slice[@]}"
+}
+
+# ─── Subcommand dispatch (uses functions defined above) ──
+case "${1:-}" in
+  --page-down) page_jump down; exit 0 ;;
+  --page-up)   page_jump up;   exit 0 ;;
+esac
 
 # DASHBOARD_TEST: print-discover <pattern> — list matched sessions, exit 0
 if [ "${1:-}" = "--print-discover" ] && [ -n "${2:-}" ]; then
@@ -277,9 +346,9 @@ fi
 [ $# -eq 0 ] && usage
 
 case "$1" in
-  --page-down|--page-up|--rebuild)
-    # Filled in by later tasks. For now: bail with a clear placeholder.
-    echo "dashboard: $1 not yet implemented" >&2
+  --rebuild)
+    # Implementation lands in Task 10.
+    echo "dashboard: --rebuild not yet implemented" >&2
     exit 1
     ;;
 esac
@@ -318,9 +387,31 @@ if [ "${#SOURCES[@]}" -eq 0 ]; then
   exit 1
 fi
 
+# Compute initial slice for page 0.
+# Honor $DASHBOARD_TERM_HEIGHT when set (used by tests to simulate small/large
+# terminals deterministically). Otherwise fall back to `tput lines`, with a
+# floor of 60 so non-TTY contexts (e.g. CI, or `dashboard` invoked from a
+# pipe) get a sane visible_rows count instead of clamping to 1.
+TERM_HEIGHT=${DASHBOARD_TERM_HEIGHT:-$(tput lines 2>/dev/null || echo 60)}
+[ "$TERM_HEIGHT" -lt 60 ] && TERM_HEIGHT=60
+if [ -n "$COLS" ]; then
+  VISIBLE_ROWS=$(( (TERM_HEIGHT - 1) / MIN_TILE_HEIGHT ))
+  [ "$VISIBLE_ROWS" -lt 1 ] && VISIBLE_ROWS=1
+  PAGE_SIZE=$(( COLS * VISIBLE_ROWS ))
+else
+  PAGE_SIZE=${#SOURCES[@]}  # tiled auto mode: show everything on one page
+fi
+[ "$PAGE_SIZE" -lt 1 ] && PAGE_SIZE=1
+
+set +u
+INITIAL_SLICE=("${SOURCES[@]:0:$PAGE_SIZE}")
+set -u
+
 DASHBOARD_PATTERN="$PATTERN" \
 DASHBOARD_COLS="$COLS" \
-DASHBOARD_PAGE="${DASHBOARD_PAGE:-0}" \
-  build_dashboard "$SESSION" "${SOURCES[@]}"
+DASHBOARD_PAGE=0 \
+DASHBOARD_TOTAL="${#SOURCES[@]}" \
+  build_dashboard "$SESSION" "${INITIAL_SLICE[@]}"
 
+# Attach/switch handled in Task 11.
 exit 0

--- a/bin/dashboard
+++ b/bin/dashboard
@@ -48,11 +48,36 @@ derived_name() {
   printf '%s\n' "$derived"
 }
 
+# List source sessions matching the glob, most-recently-attached first.
+# Excludes any session whose name starts with "dashboard:" so dashboards
+# can't tile themselves. Echoes session names, one per line.
+discover_sessions() {
+  local pattern="$1"
+  tmx list-sessions -F '#{session_last_attached} #{session_name}' 2>/dev/null \
+    | sort -rn -k1,1 \
+    | awk '{print $2}' \
+    | while IFS= read -r name; do
+        case "$name" in
+          dashboard:*) continue ;;
+        esac
+        # shellcheck disable=SC2254  # intentional glob expansion of $pattern
+        case "$name" in
+          $pattern) printf '%s\n' "$name" ;;
+        esac
+      done
+}
+
 # ─── Test hook: print derived name and exit ──
 # DASHBOARD_TEST_DERIVED=<pattern> dashboard --print-derived
 # Used by scripts/test-dashboard.sh for pure-logic assertions.
 if [ "${1:-}" = "--print-derived" ] && [ -n "${DASHBOARD_TEST_DERIVED:-}" ]; then
   derived_name "$DASHBOARD_TEST_DERIVED"
+  exit 0
+fi
+
+# DASHBOARD_TEST: print-discover <pattern> — list matched sessions, exit 0
+if [ "${1:-}" = "--print-discover" ] && [ -n "${2:-}" ]; then
+  discover_sessions "$2"
   exit 0
 fi
 

--- a/bin/dashboard
+++ b/bin/dashboard
@@ -235,6 +235,33 @@ build_dashboard() {
     fi
     idx=$((idx + 1))
   done < <(tmx list-panes -t "$session" -F '#{pane_id}')
+
+  # ── State + status-right ──
+  local n_total=${#all_sources[@]}
+  local cols_eff=${DASHBOARD_COLS:-0}  # 0 means "auto/tiled" — pages = 1 in auto mode
+  local visible_rows page_size pages
+
+  if [ "$cols_eff" -gt 0 ]; then
+    local term_height
+    term_height=$(tmx display-message -t "$session" -p '#{client_height}' 2>/dev/null || echo 60)
+    [ -z "$term_height" ] && term_height=60
+    visible_rows=$(( (term_height - 1) / MIN_TILE_HEIGHT ))
+    [ "$visible_rows" -lt 1 ] && visible_rows=1
+    page_size=$(( cols_eff * visible_rows ))
+    pages=$(( (n_total + page_size - 1) / page_size ))
+    [ "$pages" -lt 1 ] && pages=1
+  else
+    pages=1
+  fi
+
+  tmx set-option -t "$session" @dashboard-pattern "${DASHBOARD_PATTERN:-}"
+  tmx set-option -t "$session" @dashboard-cols "${DASHBOARD_COLS:-}"
+  tmx set-option -t "$session" @dashboard-page "${DASHBOARD_PAGE:-0}"
+  tmx set-option -t "$session" @dashboard-pages "$pages"
+
+  local cur_page="${DASHBOARD_PAGE:-0}"
+  tmx set-option -t "$session" status-right \
+    " [$((cur_page + 1))/$pages] $session "
 }
 
 # ─── Test hook: print derived name and exit ──
@@ -291,6 +318,9 @@ if [ "${#SOURCES[@]}" -eq 0 ]; then
   exit 1
 fi
 
-DASHBOARD_COLS="$COLS" build_dashboard "$SESSION" "${SOURCES[@]}"
+DASHBOARD_PATTERN="$PATTERN" \
+DASHBOARD_COLS="$COLS" \
+DASHBOARD_PAGE="${DASHBOARD_PAGE:-0}" \
+  build_dashboard "$SESSION" "${SOURCES[@]}"
 
 exit 0

--- a/bin/dashboard
+++ b/bin/dashboard
@@ -83,11 +83,32 @@ if [ "${1:-}" = "--print-derived" ] && [ -n "${DASHBOARD_TEST_DERIVED:-}" ]; the
   exit 0
 fi
 
+# Hand-build an N-column grid given a flat list of pane ids in creation
+# order. Walks panes by row and resize-pane -x to enforce uniform column
+# widths. Vertical sizing falls out of the bisecting splits naturally.
+apply_grid_layout() {
+  local session="$1" cols="$2"; shift 2
+  local n=$#
+  local term_width
+  term_width=$(tmx display-message -t "$session" -p '#{client_width}' 2>/dev/null || echo 200)
+  if [ -z "$term_width" ] || [ "$term_width" -lt "$cols" ]; then
+    term_width=200
+  fi
+  local col_width=$(( term_width / cols ))
+
+  local i=0 pid
+  while IFS= read -r pid; do
+    tmx resize-pane -t "$pid" -x "$col_width" 2>/dev/null || true
+    i=$((i + 1))
+    [ "$i" -ge "$n" ] && break
+  done < <(tmx list-panes -t "$session" -F '#{pane_id}')
+}
+
 # Build (or rebuild) the dashboard session with one tile per matched source
-# session. Default layout is `tiled` (auto roughly-square); --cols handling
-# lands in a later task.
+# session. Default layout is `tiled` (auto roughly-square); --cols forces a
+# hand-built row-major grid via apply_grid_layout().
 #
-# Args: $1 = session name (e.g. dashboard:agent), $2... = source session names
+# Args: $1 = session name (e.g. dashboard-agent), $2... = source session names
 build_dashboard() {
   local session="$1"; shift
   # Bash 3.2 trips on `local sources=("$@")` under `set -u` if $# is 0,
@@ -136,15 +157,74 @@ build_dashboard() {
     set +u; sources=("${sources[@]:1}"); set -u
   fi
 
-  # One split per remaining source.
-  if [ "${#sources[@]}" -gt 0 ]; then
-    for src in "${sources[@]}"; do
-      cmd="watch -c -n 0.5 -t -- tmux capture-pane -ep -S -\$(tput lines) -E -1 -t '$src'"
-      tmx split-window -t "$session" "$cmd"
-    done
-  fi
+  if [ -n "${DASHBOARD_COLS:-}" ]; then
+    # Build an N-col × ceil(M/N)-row grid via two-pass splits:
+    #   pass 1: vertical splits to lay down (rows-1) row separators on the seed
+    #   pass 2: for each row, horizontal splits (cols-1 times) on that row's
+    #           leftmost pane to fill it.
+    # This gives a clean uniform grid that select-layout/resize doesn't fight.
+    local total=${#all_sources[@]}
+    local rows=$(( (total + DASHBOARD_COLS - 1) / DASHBOARD_COLS ))
+    local row_seed_pid first_row_pid
+    first_row_pid=$(tmx list-panes -t "$session" -F '#{pane_id}' | head -1)
 
-  tmx select-layout -t "$session" tiled
+    # Pass 1: create row seeds. We split with a placeholder cmd so each new
+    # pane keeps a tile slot; respawn-pane below replaces it with the right
+    # source. Using `cat` keeps the pane alive without producing junk output.
+    local r=1
+    while [ "$r" -lt "$rows" ]; do
+      tmx split-window -t "$first_row_pid" -v 'cat' >/dev/null
+      r=$((r + 1))
+    done
+    # tmux splits balance evenly; re-balance vertically just to be safe.
+    tmx select-layout -t "$session" even-vertical >/dev/null
+
+    # Pass 2: for each row, create (cols-1) horizontal splits on its seed.
+    # Collect row seed pane ids in creation order (top to bottom).
+    local row_pids=()
+    while IFS= read -r pid; do
+      row_pids+=("$pid")
+    done < <(tmx list-panes -t "$session" -F '#{pane_top} #{pane_id}' | sort -n -k1,1 | awk '{print $2}')
+
+    local i row_pid c new_pid
+    for ((i = 0; i < rows; i++)); do
+      row_pid="${row_pids[$i]}"
+      c=1
+      while [ "$c" -lt "$DASHBOARD_COLS" ]; do
+        tmx split-window -t "$row_pid" -h 'cat' >/dev/null
+        c=$((c + 1))
+      done
+    done
+    # Re-balance horizontally per-row by selecting layout main-horizontal then
+    # tiled briefly resets, but easier: explicit even-horizontal per row would
+    # require windowing which we can't do per-row. Instead resize each pane's
+    # x explicitly via apply_grid_layout below.
+
+    # Now respawn each pane (in row-major order) with the correct watch cmd.
+    local all_grid_pids=()
+    while IFS= read -r pid; do
+      all_grid_pids+=("$pid")
+    done < <(tmx list-panes -t "$session" -F '#{pane_top} #{pane_left} #{pane_id}' | sort -n -k1,1 -k2,2 | awk '{print $3}')
+
+    local idx2=0
+    for src in "${all_sources[@]}"; do
+      pid="${all_grid_pids[$idx2]}"
+      cmd="watch -c -n 0.5 -t -- tmux capture-pane -ep -S -\$(tput lines) -E -1 -t '$src'"
+      tmx respawn-pane -k -t "$pid" "$cmd"
+      idx2=$((idx2 + 1))
+    done
+
+    apply_grid_layout "$session" "$DASHBOARD_COLS" "${all_sources[@]}"
+  else
+    # One split per remaining source; tmux's tiled layout reflows them.
+    if [ "${#sources[@]}" -gt 0 ]; then
+      for src in "${sources[@]}"; do
+        cmd="watch -c -n 0.5 -t -- tmux capture-pane -ep -S -\$(tput lines) -E -1 -t '$src'"
+        tmx split-window -t "$session" "$cmd"
+      done
+    fi
+    tmx select-layout -t "$session" tiled
+  fi
 
   # Per-tile title and visible pane-border bar (scoped to this session).
   tmx set-option -t "$session" pane-border-status top
@@ -211,6 +291,6 @@ if [ "${#SOURCES[@]}" -eq 0 ]; then
   exit 1
 fi
 
-build_dashboard "$SESSION" "${SOURCES[@]}"
+DASHBOARD_COLS="$COLS" build_dashboard "$SESSION" "${SOURCES[@]}"
 
 exit 0

--- a/bin/dashboard
+++ b/bin/dashboard
@@ -299,6 +299,36 @@ current_session() {
   tmx display-message -p '#S' 2>/dev/null
 }
 
+# Final stage: switch-client (in tmux) or attach (out) to the dashboard session.
+# Uses `exec` so the dashboard process is replaced by the tmux client and the
+# user's caller (sesh, a key binding, etc.) sees a clean exit.
+#
+# `exec` only works on real binaries, not shell functions, so we expand `tmx`
+# inline here (`tmux` or `tmux -L $TMUX_SOCKET`).
+#
+# Integration tests set DASHBOARD_NO_FINISH=1 — `tmux attach` against an
+# unattached test server (no real client) returns non-zero and would mask
+# the build success they're actually verifying.
+finish() {
+  local session="$1"
+  if [ -n "${DASHBOARD_NO_FINISH:-}" ]; then
+    return 0
+  fi
+  if [ -n "${TMUX:-}" ]; then
+    if [ -n "${TMUX_SOCKET:-}" ]; then
+      exec tmux -L "$TMUX_SOCKET" switch-client -t "$session"
+    else
+      exec tmux switch-client -t "$session"
+    fi
+  else
+    if [ -n "${TMUX_SOCKET:-}" ]; then
+      exec tmux -L "$TMUX_SOCKET" attach -t "$session"
+    else
+      exec tmux attach -t "$session"
+    fi
+  fi
+}
+
 # Common page-jump implementation. $1 = "down" or "up".
 page_jump() {
   local dir="$1" cur sess pattern cols pages cur_page new_page
@@ -484,5 +514,4 @@ DASHBOARD_PAGE=0 \
 DASHBOARD_TOTAL="${#SOURCES[@]}" \
   build_dashboard "$SESSION" "${INITIAL_SLICE[@]}"
 
-# Attach/switch handled in Task 11.
-exit 0
+finish "$SESSION"

--- a/bin/dashboard
+++ b/bin/dashboard
@@ -94,10 +94,11 @@ build_dashboard() {
   # and on `${arr[@]:n}` slices that produce empty arrays. Use temporary
   # `set +u` around the array ops as a portable workaround.
   set +u
+  local all_sources=("$@")
   local sources=("$@")
   set -u
   local first=1
-  local src cmd first_pane
+  local src cmd first_pane idx
 
   if ! tmx has-session -t "$session" 2>/dev/null; then
     # -d: detached; -x/-y: ample initial size so splits succeed before resize.
@@ -144,6 +145,16 @@ build_dashboard() {
   fi
 
   tmx select-layout -t "$session" tiled
+
+  # Per-tile title and visible pane-border bar (scoped to this session).
+  tmx set-option -t "$session" pane-border-status top
+  idx=0
+  while IFS= read -r pid; do
+    if [ "$idx" -lt "${#all_sources[@]}" ]; then
+      tmx select-pane -t "$pid" -T "${all_sources[$idx]}"
+    fi
+    idx=$((idx + 1))
+  done < <(tmx list-panes -t "$session" -F '#{pane_id}')
 }
 
 # ─── Test hook: print derived name and exit ──

--- a/bin/dashboard
+++ b/bin/dashboard
@@ -269,9 +269,33 @@ build_dashboard() {
     " [$((cur_page + 1))/$pages] $session "
 }
 
-# Read the current tmux client's session name. Echo on stdout. Exit 1 if no
+# Read the current tmux session name. Echo on stdout. Returns empty if no
 # session is reachable (not in tmux, no socket, etc).
+#
+# Resolution order:
+#   1. $DASHBOARD_TARGET — set explicitly by callers (e.g. tmux key bindings
+#      run `DASHBOARD_TARGET=#{session_name} run-shell ...`). Authoritative.
+#   2. $TMUX_PANE via `display-message -t "$TMUX_PANE" -p '#S'` — works for
+#      interactive panes on the same socket.
+#   3. Plain `display-message -p '#S'` — last resort; returns the most-recently
+#      active session globally, which can be wrong inside `run-shell -t <target>`
+#      when the target session isn't the global most-recent.
 current_session() {
+  if [ -n "${DASHBOARD_TARGET:-}" ]; then
+    printf '%s\n' "$DASHBOARD_TARGET"
+    return 0
+  fi
+  local s
+  if [ -n "${TMUX_PANE:-}" ]; then
+    s=$(tmx display-message -t "$TMUX_PANE" -p '#S' 2>/dev/null) || true
+    if [ -n "$s" ]; then
+      printf '%s\n' "$s"
+      return 0
+    fi
+    # Fall through if TMUX_PANE was stale (e.g. inherited from outer tmux on
+    # a different socket — common when tests run inside a real tmux session
+    # but spin up an isolated `-L dash-test` server).
+  fi
   tmx display-message -p '#S' 2>/dev/null
 }
 
@@ -330,10 +354,63 @@ page_jump() {
     build_dashboard "$sess" "${slice[@]}"
 }
 
+rebuild_current() {
+  local cur sess pattern cols cur_page
+  cur=$(current_session) || return 0
+  case "$cur" in
+    dashboard-*) sess="$cur" ;;
+    *) return 0 ;;
+  esac
+
+  pattern=$(tmx show-options -t "$sess" -v @dashboard-pattern 2>/dev/null)
+  cols=$(tmx show-options -t "$sess" -v @dashboard-cols 2>/dev/null)
+  cur_page=$(tmx show-options -t "$sess" -v @dashboard-page 2>/dev/null)
+  [ -z "$pattern" ] && return 0
+  [ -z "$cur_page" ] && cur_page=0
+
+  local sources=()
+  while IFS= read -r _line; do
+    sources+=("$_line")
+  done < <(discover_sessions "$pattern")
+  if [ "${#sources[@]}" -eq 0 ]; then
+    return 0  # leave the existing tiles; user can dismiss the session
+  fi
+
+  local term_height visible_rows page_size
+  term_height=$(tmx display-message -t "$sess" -p '#{client_height}' 2>/dev/null || echo 60)
+  [ -z "$term_height" ] && term_height=60
+  [ "$term_height" -lt 60 ] && term_height=60
+  if [ -n "$cols" ]; then
+    visible_rows=$(( (term_height - 1) / MIN_TILE_HEIGHT ))
+    [ "$visible_rows" -lt 1 ] && visible_rows=1
+    page_size=$(( cols * visible_rows ))
+  else
+    page_size=${#sources[@]}
+  fi
+  [ "$page_size" -lt 1 ] && page_size=1
+
+  # Clamp current page to new pages count.
+  local new_pages new_page start slice
+  new_pages=$(( (${#sources[@]} + page_size - 1) / page_size ))
+  [ "$new_pages" -lt 1 ] && new_pages=1
+  new_page=$cur_page
+  [ "$new_page" -ge "$new_pages" ] && new_page=$((new_pages - 1))
+  [ "$new_page" -lt 0 ] && new_page=0
+  start=$(( new_page * page_size ))
+  set +u; slice=("${sources[@]:start:page_size}"); set -u
+
+  DASHBOARD_PATTERN="$pattern" \
+  DASHBOARD_COLS="$cols" \
+  DASHBOARD_PAGE="$new_page" \
+  DASHBOARD_TOTAL="${#sources[@]}" \
+    build_dashboard "$sess" "${slice[@]}"
+}
+
 # ─── Subcommand dispatch (uses functions defined above) ──
 case "${1:-}" in
   --page-down) page_jump down; exit 0 ;;
   --page-up)   page_jump up;   exit 0 ;;
+  --rebuild)   rebuild_current; exit 0 ;;
 esac
 
 # DASHBOARD_TEST: print-discover <pattern> — list matched sessions, exit 0
@@ -345,13 +422,7 @@ fi
 # ─── Arg parsing ────────────────────────────
 [ $# -eq 0 ] && usage
 
-case "$1" in
-  --rebuild)
-    # Implementation lands in Task 10.
-    echo "dashboard: --rebuild not yet implemented" >&2
-    exit 1
-    ;;
-esac
+# (--rebuild handled in earlier dispatch above; here only catch unknown flags)
 
 PATTERN="$1"; shift
 COLS=""

--- a/bin/dashboard
+++ b/bin/dashboard
@@ -49,16 +49,24 @@ derived_name() {
 }
 
 # List source sessions matching the glob, most-recently-attached first.
-# Excludes any session whose name starts with "dashboard:" so dashboards
-# can't tile themselves. Echoes session names, one per line.
+# Excludes any session whose name starts with "dashboard-" so dashboards
+# can't tile themselves. (tmux disallows ':' in session names — silently
+# rewrites it — so the dashboard convention here is `dashboard-<derived>`.)
+# Echoes session names, one per line.
 discover_sessions() {
   local pattern="$1"
+  # Format: "<last_attached> <session_name>". Unattached sessions emit an
+  # empty timestamp (leading space), so normalize to 0 for sorting and pull
+  # the name field with a sed strip rather than awk's whitespace splitting
+  # (awk treats leading-space lines as having $1=name, dropping our zero).
   tmx list-sessions -F '#{session_last_attached} #{session_name}' 2>/dev/null \
+    | sed -E 's/^ /0 /' \
     | sort -rn -k1,1 \
-    | awk '{print $2}' \
+    | sed -E 's/^[0-9]+ //' \
     | while IFS= read -r name; do
+        [ -z "$name" ] && continue
         case "$name" in
-          dashboard:*) continue ;;
+          dashboard-*) continue ;;
         esac
         # shellcheck disable=SC2254  # intentional glob expansion of $pattern
         case "$name" in
@@ -74,6 +82,72 @@ if [ "${1:-}" = "--print-derived" ] && [ -n "${DASHBOARD_TEST_DERIVED:-}" ]; the
   derived_name "$DASHBOARD_TEST_DERIVED"
   exit 0
 fi
+
+# Build (or rebuild) the dashboard session with one tile per matched source
+# session. Default layout is `tiled` (auto roughly-square); --cols handling
+# lands in a later task.
+#
+# Args: $1 = session name (e.g. dashboard:agent), $2... = source session names
+build_dashboard() {
+  local session="$1"; shift
+  # Bash 3.2 trips on `local sources=("$@")` under `set -u` if $# is 0,
+  # and on `${arr[@]:n}` slices that produce empty arrays. Use temporary
+  # `set +u` around the array ops as a portable workaround.
+  set +u
+  local sources=("$@")
+  set -u
+  local first=1
+  local src cmd first_pane
+
+  if ! tmx has-session -t "$session" 2>/dev/null; then
+    # -d: detached; -x/-y: ample initial size so splits succeed before resize.
+    # Quote the inner double-dollar so $(tput lines) runs inside the spawned
+    # shell, not at the time we hand the command to tmux.
+    tmx new-session -d -s "$session" -x 200 -y 60 \
+      -n preview "watch -c -n 0.5 -t -- tmux capture-pane -ep -S -\$(tput lines) -E -1 -t '${sources[0]}'"
+    first=0  # the new-session already filled the seed tile with the first source
+    set +u; sources=("${sources[@]:1}"); set -u
+  else
+    # Kill all but the first pane; we'll re-fill panes from scratch.
+    # tmux's pane-base-index varies (0 or 1 by config), so use pane ids to
+    # target the surviving pane and the doomed ones unambiguously.
+    local first_id="" pid
+    while IFS= read -r pid; do
+      if [ -z "$first_id" ]; then
+        first_id="$pid"
+      else
+        tmx kill-pane -t "$pid" 2>/dev/null || true
+      fi
+    done < <(tmx list-panes -t "$session" -F '#{pane_id}')
+    first_pane="$first_id"
+    first=1  # the surviving pane will be reassigned in the loop below
+  fi
+
+  # On rebuild path, the surviving first pane gets respawned with the new
+  # first source's watch loop. We use `respawn-pane -k` (force-kill the running
+  # command first) instead of send-keys+C-c — sending C-c to the only
+  # foreground process exits it, which closes the pane and invalidates the
+  # pane id for any follow-up commands. respawn-pane keeps the pane.
+  if [ "$first" -eq 1 ] && [ "${#sources[@]}" -gt 0 ]; then
+    src="${sources[0]}"
+    cmd="watch -c -n 0.5 -t -- tmux capture-pane -ep -S -\$(tput lines) -E -1 -t '$src'"
+    tmx respawn-pane -k -t "$first_pane" "$cmd"
+    set +u; sources=("${sources[@]:1}"); set -u
+  fi
+
+  # One split per remaining source.
+  if [ "${#sources[@]}" -gt 0 ]; then
+    for src in "${sources[@]}"; do
+      cmd="watch -c -n 0.5 -t -- tmux capture-pane -ep -S -\$(tput lines) -E -1 -t '$src'"
+      tmx split-window -t "$session" "$cmd"
+    done
+  fi
+
+  tmx select-layout -t "$session" tiled
+}
+
+# ─── Test hook: print derived name and exit ──
+# (test hooks are also handy below; the original --print-derived above remains)
 
 # DASHBOARD_TEST: print-discover <pattern> — list matched sessions, exit 0
 if [ "${1:-}" = "--print-discover" ] && [ -n "${2:-}" ]; then
@@ -112,8 +186,20 @@ while [ $# -gt 0 ]; do
 done
 
 DERIVED=$(derived_name "$PATTERN")
-SESSION="dashboard:$DERIVED"
+SESSION="dashboard-$DERIVED"
 
-# ─── Dispatch (filled in by later tasks) ──
-echo "dashboard: would build $SESSION from pattern '$PATTERN' (cols=${COLS:-tiled})" >&2
+# ─── Dispatch ───────────────────────────────
+# Bash 3.2 (macOS) lacks `mapfile`; use a read loop into a positional array.
+SOURCES=()
+while IFS= read -r _src_line; do
+  SOURCES+=("$_src_line")
+done < <(discover_sessions "$PATTERN")
+
+if [ "${#SOURCES[@]}" -eq 0 ]; then
+  echo "dashboard: no sessions match '$PATTERN'" >&2
+  exit 1
+fi
+
+build_dashboard "$SESSION" "${SOURCES[@]}"
+
 exit 0

--- a/docs/tmux-cheatsheet.html
+++ b/docs/tmux-cheatsheet.html
@@ -158,6 +158,29 @@
     </table>
     <p class="note">Defaults only: no <code>@resurrect-processes</code> (panes get fresh shells in <code>cwd</code>; nvim/ssh are NOT relaunched), no <code>@resurrect-capture-pane-contents</code> (scrollback is not saved). Auto-restore only fires on a brand-new server with zero sessions, so attaching to an already-running server (sesh's normal flow) is unaffected.</p>
   </div>
+
+  <div class="card">
+    <h3>Dashboard <span class="pill">live multi-session preview</span></h3>
+    <p>
+      <code>dashboard '&lt;pattern&gt;' [--cols N]</code> from the shell.
+      Spawns or rebuilds a <code>dashboard-&lt;derived&gt;</code> session
+      tiling live <code>capture-pane</code> output for every tmux session
+      whose name matches the glob. One tile per match; default layout is
+      tmux's <code>tiled</code> auto-shape. <code>--cols N</code> forces
+      an N-column grid.
+    </p>
+    <table>
+      <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">J</span></td><td class="desc">page rows down (no-op outside <code>dashboard-*</code>)</td></tr>
+      <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">K</span></td><td class="desc">page rows up</td></tr>
+      <tr><td class="key"><code>dashboard --rebuild</code></td><td class="desc">re-discover sources, refresh tiles (run inside the dashboard)</td></tr>
+    </table>
+    <p class="note">
+      Re-running <code>dashboard '&lt;pattern&gt;'</code> is idempotent —
+      kills only stale tiles and adds tiles for new matches. Outside tmux
+      the script <code>attach</code>es; inside tmux it
+      <code>switch-client</code>s to the dashboard.
+    </p>
+  </div>
 </div>
 
 <!-- ═══════════════════════════════════════════════════════════════════════ -->
@@ -391,7 +414,7 @@
 </table>
 
 <footer>
-  Built from <code>~/.config/tmux/tmux.conf</code> on 2026-05-02. Refresh after meaningful config changes.
+  Built from <code>~/.config/tmux/tmux.conf</code> on 2026-05-03. Refresh after meaningful config changes.
   <br>
   When in doubt: <span class="k prefix">C-a</span> <span class="k">?</span> for the live keymap list.
 </footer>

--- a/scripts/test-dashboard.sh
+++ b/scripts/test-dashboard.sh
@@ -163,6 +163,19 @@ SHIM
   assert_eq "$rc" "0" "rebuild after source kill exits 0"
   assert_eq "$(pane_count dashboard-agent)" "1" "rebuild drops vanished session's tile"
 
+  # ── Pane border titles == source session names ──
+  reset_test_tmux
+  tmux -L "$TMUX_SOCKET" new-session -d -s 1-agent 'sleep 999'
+  tmux -L "$TMUX_SOCKET" new-session -d -s 2-agent 'sleep 999'
+  "$DASH" '*-agent' >/dev/null 2>&1
+
+  titles=$(tmux -L "$TMUX_SOCKET" list-panes -t dashboard-agent -F '#{pane_title}' | sort)
+  expected=$(printf '%s\n' 1-agent 2-agent | sort)
+  assert_eq "$titles" "$expected" "pane titles match source session names"
+
+  status=$(tmux -L "$TMUX_SOCKET" show-options -t dashboard-agent -v pane-border-status 2>/dev/null)
+  assert_eq "$status" "top" "pane-border-status set to 'top' on dashboard session"
+
   teardown_test_tmux
   unset TMUX_SOCKET
 fi

--- a/scripts/test-dashboard.sh
+++ b/scripts/test-dashboard.sh
@@ -216,6 +216,40 @@ SHIM
   assert_contains "$status_r" "dashboard-grid" "status-right shows session name"
   assert_contains "$status_r" "/" "status-right shows page indicator"
 
+  # ── Pagination ──
+  reset_test_tmux
+  for n in 1 2 3 4 5 6; do
+    tmux -L "$TMUX_SOCKET" new-session -d -s "test-pg-$n" 'sleep 999'
+  done
+  "$DASH" '*-pg-*' --cols 1 >/dev/null 2>&1
+
+  page_down_via_run_shell() {
+    tmux -L "$TMUX_SOCKET" run-shell -t "$1" "TMUX_SOCKET=$TMUX_SOCKET $DASH --page-down"
+  }
+  page_up_via_run_shell() {
+    tmux -L "$TMUX_SOCKET" run-shell -t "$1" "TMUX_SOCKET=$TMUX_SOCKET $DASH --page-up"
+  }
+
+  page_down_via_run_shell dashboard-pg
+  p=$(tmux -L "$TMUX_SOCKET" show-options -t dashboard-pg -v @dashboard-page 2>/dev/null)
+  assert_eq "$p" "1" "--page-down advances @dashboard-page from 0 to 1"
+
+  page_down_via_run_shell dashboard-pg
+  p=$(tmux -L "$TMUX_SOCKET" show-options -t dashboard-pg -v @dashboard-page 2>/dev/null)
+  assert_eq "$p" "1" "--page-down clamps at last page"
+
+  page_up_via_run_shell dashboard-pg
+  p=$(tmux -L "$TMUX_SOCKET" show-options -t dashboard-pg -v @dashboard-page 2>/dev/null)
+  assert_eq "$p" "0" "--page-up returns to first page"
+
+  page_up_via_run_shell dashboard-pg
+  p=$(tmux -L "$TMUX_SOCKET" show-options -t dashboard-pg -v @dashboard-page 2>/dev/null)
+  assert_eq "$p" "0" "--page-up clamps at 0"
+
+  # ── --page-down outside dashboard:* bails silently ──
+  out=$("$DASH" --page-down 2>&1); rc=$?
+  assert_eq "$rc" "0" "--page-down outside dashboard exits 0 (silent bail)"
+
   teardown_test_tmux
   unset TMUX_SOCKET
 fi

--- a/scripts/test-dashboard.sh
+++ b/scripts/test-dashboard.sh
@@ -78,7 +78,7 @@ else
 case "$*" in
   "list-sessions -F #{session_last_attached} #{session_name}")
     cat <<-EOF
-		3000 dashboard:agent
+		3000 dashboard-agent
 		2500 claude-prod
 		2000 build-1
 		1500 build-2
@@ -100,15 +100,15 @@ SHIM
   expected=$'claude-prod\nclaude-staging'
   assert_eq "$out" "$expected" "'claude-*' matches claude-prod, claude-staging"
 
-  # Match '*' -> excludes dashboard:agent
+  # Match '*' -> excludes dashboard-agent
   out=$(PATH="$shimdir:$PATH" "$DASH" --print-discover '*' 2>&1)
-  if printf '%s' "$out" | grep -qx 'dashboard:agent'; then
+  if printf '%s' "$out" | grep -qx 'dashboard-agent'; then
     fail=$((fail+1))
-    fail_msgs+=("FAIL  '*' must exclude dashboard:agent"$'\n'"        got: '$out'")
-    echo "  FAIL  '*' must exclude dashboard:agent"
+    fail_msgs+=("FAIL  '*' must exclude dashboard-agent"$'\n'"        got: '$out'")
+    echo "  FAIL  '*' must exclude dashboard-agent"
   else
     pass=$((pass+1))
-    echo "  PASS  '*' excludes dashboard:agent"
+    echo "  PASS  '*' excludes dashboard-agent"
   fi
 
   # No match -> empty stdout, exit 0
@@ -117,6 +117,54 @@ SHIM
   assert_eq "$out" "" "no match -> empty stdout"
 
   rm -rf "$shimdir"
+
+  # ── Integration tests against an isolated tmux server ──
+  # Use TMUX_SOCKET=dash-test so the dashboard script's `tmx` helper passes
+  # `-L dash-test` to every tmux invocation.
+  TMUX_SOCKET=dash-test
+  export TMUX_SOCKET
+
+  # Helper: ensure clean test server before each integration block.
+  reset_test_tmux() {
+    tmux -L "$TMUX_SOCKET" kill-server 2>/dev/null || true
+    tmux -L "$TMUX_SOCKET" start-server
+  }
+
+  # Helper: count panes in a window of a session on the test server.
+  pane_count() {
+    tmux -L "$TMUX_SOCKET" list-panes -t "$1" 2>/dev/null | wc -l | tr -d ' '
+  }
+
+  # Helper: tear down the test server after assertions in a block.
+  teardown_test_tmux() {
+    tmux -L "$TMUX_SOCKET" kill-server 2>/dev/null || true
+  }
+
+  # ── build_dashboard: 2 matching sessions -> 2 tiles ──
+  # Session names end in '-agent' so the '*-agent' glob actually matches.
+  reset_test_tmux
+  tmux -L "$TMUX_SOCKET" new-session -d -s 1-agent 'sleep 999'
+  tmux -L "$TMUX_SOCKET" new-session -d -s 2-agent 'sleep 999'
+  tmux -L "$TMUX_SOCKET" new-session -d -s test-build-1 'sleep 999'
+
+  out=$("$DASH" '*-agent' 2>&1); rc=$?
+  assert_eq "$rc" "0" "dashboard '*-agent' exits 0"
+  if tmux -L "$TMUX_SOCKET" has-session -t dashboard-agent 2>/dev/null; then
+    pass=$((pass+1)); echo "  PASS  dashboard-agent session created"
+  else
+    fail=$((fail+1)); fail_msgs+=("FAIL  dashboard-agent session not created")
+    echo "  FAIL  dashboard-agent session not created"
+  fi
+  assert_eq "$(pane_count dashboard-agent)" "2" "dashboard-agent has 2 tiles for *-agent matches"
+
+  # ── Idempotent rebuild: re-run with same pattern, kill one source, expect 1 tile ──
+  tmux -L "$TMUX_SOCKET" kill-session -t 2-agent 2>/dev/null || true
+  out=$("$DASH" '*-agent' 2>&1); rc=$?
+  assert_eq "$rc" "0" "rebuild after source kill exits 0"
+  assert_eq "$(pane_count dashboard-agent)" "1" "rebuild drops vanished session's tile"
+
+  teardown_test_tmux
+  unset TMUX_SOCKET
 fi
 
 # ─── Summary ────────────────────────────────

--- a/scripts/test-dashboard.sh
+++ b/scripts/test-dashboard.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Smoke + integration tests for bin/dashboard.
+# Invoked from scripts/test-helpers.sh; can also be run standalone.
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+DASH="$REPO/bin/dashboard"
+
+pass=0
+fail=0
+fail_msgs=()
+
+assert_eq() {
+  local got="$1" want="$2" desc="$3"
+  if [ "$got" = "$want" ]; then
+    pass=$((pass+1))
+    echo "  PASS  $desc"
+  else
+    fail=$((fail+1))
+    fail_msgs+=("FAIL  $desc"$'\n'"        got:  '$got'"$'\n'"        want: '$want'")
+    echo "  FAIL  $desc"
+  fi
+}
+
+assert_contains() {
+  local got="$1" needle="$2" desc="$3"
+  if printf '%s' "$got" | grep -q -F -- "$needle"; then
+    pass=$((pass+1))
+    echo "  PASS  $desc"
+  else
+    fail=$((fail+1))
+    fail_msgs+=("FAIL  $desc"$'\n'"        got:  '$got'"$'\n'"        needle: '$needle'")
+    echo "  FAIL  $desc"
+  fi
+}
+
+echo
+echo "bin/dashboard"
+echo "─────────────"
+
+if [ ! -x "$DASH" ]; then
+  echo "  SKIP — $DASH not present yet"
+else
+  # ── arg parsing: 0 args -> usage on stderr, exit 1 ──
+  out=$("$DASH" 2>&1); rc=$?
+  assert_eq "$rc" "1" "0 args -> exit 1"
+  assert_contains "$out" "Usage:" "0 args -> usage on stderr"
+
+  # ── arg parsing: --cols requires a numeric value ──
+  out=$("$DASH" '*-test' --cols 2>&1); rc=$?
+  assert_eq "$rc" "1" "--cols without value -> exit 1"
+  assert_contains "$out" "--cols requires" "--cols without value -> error message"
+
+  out=$("$DASH" '*-test' --cols abc 2>&1); rc=$?
+  assert_eq "$rc" "1" "--cols non-numeric -> exit 1"
+  assert_contains "$out" "--cols requires" "--cols non-numeric -> error message"
+
+  # ── derived_name: pattern -> session-name suffix ──
+  out=$(DASHBOARD_TEST_DERIVED='*-agent' "$DASH" --print-derived 2>&1)
+  assert_eq "$out" "agent" "'*-agent' -> derived 'agent'"
+
+  out=$(DASHBOARD_TEST_DERIVED='claude-*-prod' "$DASH" --print-derived 2>&1)
+  assert_eq "$out" "claudeprod" "'claude-*-prod' -> derived 'claudeprod'"
+
+  out=$(DASHBOARD_TEST_DERIVED='build-*' "$DASH" --print-derived 2>&1)
+  assert_eq "$out" "build" "'build-*' -> derived 'build'"
+
+  # ── derived_name: empty result -> error ──
+  out=$(DASHBOARD_TEST_DERIVED='***' "$DASH" --print-derived 2>&1); rc=$?
+  assert_eq "$rc" "1" "all-special pattern -> exit 1"
+  assert_contains "$out" "empty derived name" "all-special pattern -> error message"
+fi
+
+# ─── Summary ────────────────────────────────
+echo
+echo "─────────────────"
+echo "test-dashboard.sh passed: $pass"
+echo "test-dashboard.sh failed: $fail"
+if [ "$fail" -gt 0 ]; then
+  echo
+  printf '%s\n' "${fail_msgs[@]}"
+  exit 1
+fi
+exit 0

--- a/scripts/test-dashboard.sh
+++ b/scripts/test-dashboard.sh
@@ -223,11 +223,15 @@ SHIM
   done
   "$DASH" '*-pg-*' --cols 1 >/dev/null 2>&1
 
+  # tmux key bindings will pass DASHBOARD_TARGET=#{session_name} so the script
+  # knows which session triggered the call (mirrors what Task 13 wires up).
   page_down_via_run_shell() {
-    tmux -L "$TMUX_SOCKET" run-shell -t "$1" "TMUX_SOCKET=$TMUX_SOCKET $DASH --page-down"
+    tmux -L "$TMUX_SOCKET" run-shell -t "$1" \
+      "TMUX_SOCKET=$TMUX_SOCKET DASHBOARD_TARGET=$1 $DASH --page-down"
   }
   page_up_via_run_shell() {
-    tmux -L "$TMUX_SOCKET" run-shell -t "$1" "TMUX_SOCKET=$TMUX_SOCKET $DASH --page-up"
+    tmux -L "$TMUX_SOCKET" run-shell -t "$1" \
+      "TMUX_SOCKET=$TMUX_SOCKET DASHBOARD_TARGET=$1 $DASH --page-up"
   }
 
   page_down_via_run_shell dashboard-pg
@@ -249,6 +253,23 @@ SHIM
   # ── --page-down outside dashboard:* bails silently ──
   out=$("$DASH" --page-down 2>&1); rc=$?
   assert_eq "$rc" "0" "--page-down outside dashboard exits 0 (silent bail)"
+
+  # ── --rebuild reads stored pattern and refreshes ──
+  reset_test_tmux
+  tmux -L "$TMUX_SOCKET" new-session -d -s test-reb-1 'sleep 999'
+  tmux -L "$TMUX_SOCKET" new-session -d -s test-reb-2 'sleep 999'
+  "$DASH" '*-reb-*' --cols 1 >/dev/null 2>&1
+
+  # Spawn a third source after dashboard exists; --rebuild should pick it up.
+  tmux -L "$TMUX_SOCKET" new-session -d -s test-reb-3 'sleep 999'
+  tmux -L "$TMUX_SOCKET" run-shell -t dashboard-reb \
+    "TMUX_SOCKET=$TMUX_SOCKET DASHBOARD_TARGET=dashboard-reb $DASH --rebuild"
+  count=$(pane_count dashboard-reb)
+  assert_eq "$count" "3" "--rebuild adds tile for newly-spawned source"
+
+  # ── --rebuild outside dashboard bails silently ──
+  out=$("$DASH" --rebuild 2>&1); rc=$?
+  assert_eq "$rc" "0" "--rebuild outside dashboard exits 0 (silent bail)"
 
   teardown_test_tmux
   unset TMUX_SOCKET

--- a/scripts/test-dashboard.sh
+++ b/scripts/test-dashboard.sh
@@ -118,11 +118,89 @@ SHIM
 
   rm -rf "$shimdir"
 
+  # ── Inside tmux: switch-client is used ──
+  # Shim tmux so we can record which subcommand the script invokes at the end.
+  shimdir=$(mktemp -d)
+  cat >"$shimdir/tmux" <<'SHIM'
+#!/usr/bin/env bash
+echo "$@" >>"$(dirname "$0")/tmux.log"
+case "$*" in
+  "list-sessions -F #{session_last_attached} #{session_name}")
+    cat <<-EOF
+		2000 test-attach-1
+		1000 test-attach-2
+	EOF
+    ;;
+  "has-session -t dashboard-attach") exit 1 ;;
+  "display-message -p #S") exit 1 ;;
+  "display-message"*"client_width"*) echo 200 ;;
+  "display-message"*"client_height"*) echo 60 ;;
+  "show-options"*) echo "" ;;
+  *) ;;
+esac
+exit 0
+SHIM
+  chmod +x "$shimdir/tmux"
+  cat >"$shimdir/watch" <<'SHIM'
+#!/usr/bin/env bash
+exit 0
+SHIM
+  chmod +x "$shimdir/watch"
+
+  out=$(env TMUX=fake PATH="$shimdir:$PATH" "$DASH" '*-attach-*' 2>&1); rc=$?
+  assert_eq "$rc" "0" "in-tmux flow exits 0"
+  log=$(cat "$shimdir/tmux.log")
+  assert_contains "$log" "switch-client -t dashboard-attach" "in-tmux uses switch-client"
+  if printf '%s' "$log" | grep -qE '^attach -t '; then
+    fail=$((fail+1))
+    fail_msgs+=("FAIL  in-tmux must not use 'attach -t'"$'\n'"        log: '$log'")
+    echo "  FAIL  in-tmux must not use 'attach -t'"
+  else
+    pass=$((pass+1))
+    echo "  PASS  in-tmux does not use 'attach -t'"
+  fi
+  rm -rf "$shimdir"
+
+  # ── Outside tmux: attach is used ──
+  shimdir=$(mktemp -d)
+  cat >"$shimdir/tmux" <<'SHIM'
+#!/usr/bin/env bash
+echo "$@" >>"$(dirname "$0")/tmux.log"
+case "$*" in
+  "list-sessions -F #{session_last_attached} #{session_name}")
+    cat <<-EOF
+		2000 test-attach-1
+	EOF
+    ;;
+  "has-session -t dashboard-attach") exit 1 ;;
+  "display-message"*"client_width"*) echo 200 ;;
+  "display-message"*"client_height"*) echo 60 ;;
+  "show-options"*) echo "" ;;
+  *) ;;
+esac
+exit 0
+SHIM
+  chmod +x "$shimdir/tmux"
+  cat >"$shimdir/watch" <<'SHIM'
+#!/usr/bin/env bash
+exit 0
+SHIM
+  chmod +x "$shimdir/watch"
+
+  out=$(env -u TMUX PATH="$shimdir:$PATH" "$DASH" '*-attach-*' 2>&1); rc=$?
+  assert_eq "$rc" "0" "out-of-tmux flow exits 0"
+  log=$(cat "$shimdir/tmux.log")
+  assert_contains "$log" "attach -t dashboard-attach" "out-of-tmux uses attach"
+  rm -rf "$shimdir"
+
   # ── Integration tests against an isolated tmux server ──
   # Use TMUX_SOCKET=dash-test so the dashboard script's `tmx` helper passes
   # `-L dash-test` to every tmux invocation.
   TMUX_SOCKET=dash-test
   export TMUX_SOCKET
+  # The integration server has no real client to attach, so skip finish().
+  DASHBOARD_NO_FINISH=1
+  export DASHBOARD_NO_FINISH
 
   # Helper: ensure clean test server before each integration block.
   reset_test_tmux() {
@@ -273,6 +351,7 @@ SHIM
 
   teardown_test_tmux
   unset TMUX_SOCKET
+  unset DASHBOARD_NO_FINISH
 fi
 
 # ─── Summary ────────────────────────────────

--- a/scripts/test-dashboard.sh
+++ b/scripts/test-dashboard.sh
@@ -194,6 +194,28 @@ SHIM
   assert_eq "$cols_seen" "2" "--cols 2 produces 2 distinct columns"
   assert_eq "$rows_seen" "3" "--cols 2 with 6 sources produces 3 rows"
 
+  # ── State stored on dashboard session ──
+  pat=$(tmux -L "$TMUX_SOCKET" show-options -t dashboard-grid -v @dashboard-pattern 2>/dev/null)
+  assert_eq "$pat" "*-grid-*" "@dashboard-pattern stored on dashboard session"
+
+  c=$(tmux -L "$TMUX_SOCKET" show-options -t dashboard-grid -v @dashboard-cols 2>/dev/null)
+  assert_eq "$c" "2" "@dashboard-cols stored on dashboard session"
+
+  p=$(tmux -L "$TMUX_SOCKET" show-options -t dashboard-grid -v @dashboard-page 2>/dev/null)
+  assert_eq "$p" "0" "@dashboard-page initialized to 0"
+
+  pages=$(tmux -L "$TMUX_SOCKET" show-options -t dashboard-grid -v @dashboard-pages 2>/dev/null)
+  if printf '%s' "$pages" | grep -qE '^[1-9][0-9]*$'; then
+    pass=$((pass+1)); echo "  PASS  @dashboard-pages is a positive integer ($pages)"
+  else
+    fail=$((fail+1)); fail_msgs+=("FAIL  @dashboard-pages should be positive int; got '$pages'")
+    echo "  FAIL  @dashboard-pages should be positive int; got '$pages'"
+  fi
+
+  status_r=$(tmux -L "$TMUX_SOCKET" show-options -t dashboard-grid -v status-right 2>/dev/null)
+  assert_contains "$status_r" "dashboard-grid" "status-right shows session name"
+  assert_contains "$status_r" "/" "status-right shows page indicator"
+
   teardown_test_tmux
   unset TMUX_SOCKET
 fi

--- a/scripts/test-dashboard.sh
+++ b/scripts/test-dashboard.sh
@@ -176,6 +176,24 @@ SHIM
   status=$(tmux -L "$TMUX_SOCKET" show-options -t dashboard-agent -v pane-border-status 2>/dev/null)
   assert_eq "$status" "top" "pane-border-status set to 'top' on dashboard session"
 
+  # ── --cols N: explicit grid shape ──
+  reset_test_tmux
+  for n in 1 2 3 4 5 6; do
+    tmux -L "$TMUX_SOCKET" new-session -d -s "test-grid-$n" 'sleep 999'
+  done
+
+  # --cols 1 -> all 6 in a single column (6 rows)
+  "$DASH" '*-grid-*' --cols 1 >/dev/null 2>&1
+  cols_seen=$(tmux -L "$TMUX_SOCKET" list-panes -t dashboard-grid -F '#{pane_left}' | sort -u | wc -l | tr -d ' ')
+  assert_eq "$cols_seen" "1" "--cols 1 produces a single column"
+
+  # --cols 2 -> 2 columns, 3 rows
+  "$DASH" '*-grid-*' --cols 2 >/dev/null 2>&1
+  cols_seen=$(tmux -L "$TMUX_SOCKET" list-panes -t dashboard-grid -F '#{pane_left}' | sort -u | wc -l | tr -d ' ')
+  rows_seen=$(tmux -L "$TMUX_SOCKET" list-panes -t dashboard-grid -F '#{pane_top}' | sort -u | wc -l | tr -d ' ')
+  assert_eq "$cols_seen" "2" "--cols 2 produces 2 distinct columns"
+  assert_eq "$rows_seen" "3" "--cols 2 with 6 sources produces 3 rows"
+
   teardown_test_tmux
   unset TMUX_SOCKET
 fi

--- a/scripts/test-dashboard.sh
+++ b/scripts/test-dashboard.sh
@@ -193,6 +193,42 @@ SHIM
   assert_contains "$log" "attach -t dashboard-attach" "out-of-tmux uses attach"
   rm -rf "$shimdir"
 
+  # ── 0 matches -> exit 1 with clear message ──
+  shimdir=$(mktemp -d)
+  cat >"$shimdir/tmux" <<'SHIM'
+#!/usr/bin/env bash
+case "$*" in
+  "list-sessions -F #{session_last_attached} #{session_name}") echo "" ;;
+  *) ;;
+esac
+exit 0
+SHIM
+  chmod +x "$shimdir/tmux"
+  cat >"$shimdir/watch" <<'SHIM'
+#!/usr/bin/env bash
+exit 0
+SHIM
+  chmod +x "$shimdir/watch"
+  out=$(env -u TMUX PATH="$shimdir:$PATH" "$DASH" 'no-such-*' 2>&1); rc=$?
+  assert_eq "$rc" "1" "0 matches -> exit 1"
+  assert_contains "$out" "no sessions match" "0 matches -> error message"
+  rm -rf "$shimdir"
+
+  # ── watch missing -> exit 1 with clear message ──
+  shimdir=$(mktemp -d)
+  cat >"$shimdir/tmux" <<'SHIM'
+#!/usr/bin/env bash
+exit 0
+SHIM
+  chmod +x "$shimdir/tmux"
+  # Deliberately do NOT create $shimdir/watch. Path includes /bin:/usr/bin so
+  # the bash interpreter resolves, but `command -v watch` still fails because
+  # macOS's /usr/bin doesn't ship watch (BSD has no procps).
+  out=$(env -u TMUX PATH="$shimdir:/bin:/usr/bin" "$DASH" '*-anything-*' 2>&1); rc=$?
+  assert_eq "$rc" "1" "missing watch -> exit 1"
+  assert_contains "$out" "watch" "missing watch -> error mentions watch"
+  rm -rf "$shimdir"
+
   # ── Integration tests against an isolated tmux server ──
   # Use TMUX_SOCKET=dash-test so the dashboard script's `tmx` helper passes
   # `-L dash-test` to every tmux invocation.

--- a/scripts/test-dashboard.sh
+++ b/scripts/test-dashboard.sh
@@ -69,6 +69,54 @@ else
   out=$(DASHBOARD_TEST_DERIVED='***' "$DASH" --print-derived 2>&1); rc=$?
   assert_eq "$rc" "1" "all-special pattern -> exit 1"
   assert_contains "$out" "empty derived name" "all-special pattern -> error message"
+
+  # ── discover_sessions: filter + dashboard:* exclusion ──
+  shimdir=$(mktemp -d)
+  cat >"$shimdir/tmux" <<'SHIM'
+#!/usr/bin/env bash
+# Shim: tmux list-sessions -F '#{session_last_attached} #{session_name}'
+case "$*" in
+  "list-sessions -F #{session_last_attached} #{session_name}")
+    cat <<-EOF
+		3000 dashboard:agent
+		2500 claude-prod
+		2000 build-1
+		1500 build-2
+		1000 claude-staging
+	EOF
+    ;;
+  *) echo "tmux shim: unsupported: $*" >&2; exit 99 ;;
+esac
+SHIM
+  chmod +x "$shimdir/tmux"
+
+  # Match 'build-*' -> build-1, build-2 (most-recently-attached first)
+  out=$(PATH="$shimdir:$PATH" "$DASH" --print-discover 'build-*' 2>&1)
+  expected=$'build-1\nbuild-2'
+  assert_eq "$out" "$expected" "'build-*' matches build-1, build-2 (mru order)"
+
+  # Match 'claude-*' -> claude-prod, claude-staging
+  out=$(PATH="$shimdir:$PATH" "$DASH" --print-discover 'claude-*' 2>&1)
+  expected=$'claude-prod\nclaude-staging'
+  assert_eq "$out" "$expected" "'claude-*' matches claude-prod, claude-staging"
+
+  # Match '*' -> excludes dashboard:agent
+  out=$(PATH="$shimdir:$PATH" "$DASH" --print-discover '*' 2>&1)
+  if printf '%s' "$out" | grep -qx 'dashboard:agent'; then
+    fail=$((fail+1))
+    fail_msgs+=("FAIL  '*' must exclude dashboard:agent"$'\n'"        got: '$out'")
+    echo "  FAIL  '*' must exclude dashboard:agent"
+  else
+    pass=$((pass+1))
+    echo "  PASS  '*' excludes dashboard:agent"
+  fi
+
+  # No match -> empty stdout, exit 0
+  out=$(PATH="$shimdir:$PATH" "$DASH" --print-discover 'no-such-*' 2>&1); rc=$?
+  assert_eq "$rc" "0" "no match -> exit 0"
+  assert_eq "$out" "" "no match -> empty stdout"
+
+  rm -rf "$shimdir"
 fi
 
 # ─── Summary ────────────────────────────────

--- a/scripts/test-helpers.sh
+++ b/scripts/test-helpers.sh
@@ -265,6 +265,11 @@ if ! bash "$(dirname "$0")/test-s.sh"; then
   fail_msgs+=("FAIL  scripts/test-s.sh reported failures")
 fi
 
+if ! bash "$(dirname "$0")/test-dashboard.sh"; then
+  fail=$((fail+1))
+  fail_msgs+=("FAIL  scripts/test-dashboard.sh reported failures")
+fi
+
 # ─── Summary ────────────────────────────────
 echo
 echo "─────────────────"


### PR DESCRIPTION
## Summary

- New `bin/dashboard` command (~250 LOC bash) spawns or rebuilds a `dashboard-<derived>` session showing live `watch + capture-pane` tiles for each tmux session matching a glob pattern.
- Supports `--cols N` for explicit grid shape, `<prefix> J/K` for row pagination, and `--rebuild` for in-dashboard refresh.
- 48-assertion smoke + integration test suite (`scripts/test-dashboard.sh`) wired into `scripts/test-helpers.sh`; runs against an isolated `tmux -L dash-test` socket so it never touches the user's live tmux.

Closes #75.

## Spec

Issue body of #75 — saved verbatim to `.superpowers/specs/2026-05-03-tmux-dashboard.md` (gitignored; not committed).

## Plan

Issue comments of #75 (Parts 1 & 2, 17 tasks) — saved verbatim to `.superpowers/plans/2026-05-03-tmux-dashboard.md` (gitignored; not committed). Tasks 1 & 17 skipped in this run (branch already correct; manual verification needs interactive tmux — covered by the wired smoke suite instead).

## Assumptions

- **Branch reuse.** Stayed on existing `75-tmux-dashboard` worktree branch instead of creating `autonomo/<slug>` per the autonomo workspace decision table — the worktree was purpose-built for this issue and has zero commits ahead of `main`.
- **Brainstorm/plan phases skipped.** Issue body + comments already contain a complete spec and 17-task TDD plan. Re-dispatching brainstorm/plan would have wasted tokens and risked drift; the issue artifacts were saved to `.superpowers/` and only the execute phase ran.
- **Session-name separator changed `:` → `-`.** Plan called for `dashboard:<derived>` but tmux silently rewrites `:` in session names; switched to `dashboard-<derived>` consistently across script, tests, conventions, and exclusion logic.
- **Two-pass `--cols N` build.** Plan's single-pass `apply_grid_layout` (post-hoc resize) produced lopsided shapes; replaced with vertical row seeds → per-row horizontal splits → row-major respawn so each row's panes start equal-width.
- **`respawn-pane -k` for tile recycling.** Plan used `send-keys C-c` to kill prior `watch` loops, but killing the only foreground process closes the pane and invalidates its id; `respawn-pane -k` is the correct primitive.
- **`current_session()` resolution under `run-shell -t <target>`.** `tmux display-message -p '#S'` returns the global most-recent session, not the run-shell target, and `$TMUX_PANE` leaks from the outer tmux when tests run inside a real tmux session. Added `DASHBOARD_TARGET` env var that takes precedence; tmux key bindings pass `DASHBOARD_TARGET=#{session_name}` and the `--rebuild` test passes it explicitly.
- **`finish()` and shell functions.** `exec` rejects shell functions; `finish()` expands the `tmx` helper inline. Added `DASHBOARD_NO_FINISH=1` escape hatch for integration tests since attaching to an unattached test server fails.
- **`watch`-missing test PATH.** Extended to `$shimdir:/bin:/usr/bin` so the bash interpreter resolves; `watch` is still absent because macOS BSD doesn't ship procps.
- **Task 13 live tmux reload skipped.** The plan's `tmux source-file ~/.config/tmux/tmux.conf` requires the user's live tmux server; substituted parse-check via isolated `-L dash-cfg-test` socket.
- **Task 14 `open` skipped.** Cheatsheet HTML smoke-render is interactive; `git diff` substitutes for visual verification.
- **Task 17 manual verification skipped.** Steps 1-6 require a live interactive tmux client; the wired `scripts/test-dashboard.sh` (48 assertions) substitutes; Step 7 ("commit only if bugs surfaced") is a no-op when no bugs surface.

## Test plan

- [x] `bash scripts/test-dashboard.sh` — 48 assertions, 0 failed (isolated `-L dash-test` socket).
- [x] `bash scripts/test-helpers.sh` — full suite, 30 helpers + 48 dashboard, 0 failed.
- [x] Tree clean; 15 commits ahead of `origin/main` (Tasks 2-16).
- [ ] Manual smoke: `dashboard 'agent-*'` against 3+ live agent sessions, verify tile labels, ~0.5s liveness, `<prefix> J/K` pagination — runs against the user's live tmux server (deferred; not safe to do unattended).

## Session stats

| Timeline | |
|---|---|
| Start | 2026-05-03 10:03 UTC |
| End | 2026-05-03 10:47 UTC |
| Elapsed | 43m 24s |
| Working | 48m 37s (112% of elapsed) |
| Idle | 32m 13s (controller wait-for-user only) |

| Model | Messages | Input | Output | Cache Read | Cache Write 5m | Cache Write 1h | Cost |
|---|---:|---:|---:|---:|---:|---:|---:|
| Opus 4.7 | 431 | 1.5k | 161k | 41.5M | 2.0M | 710k | \$133.99 |
| **TOTAL** | **431** | **1.5k** | **161k** | **41.5M** | **2.0M** | **710k** | **\$133.99** |

Total billed tokens: 44.4M. Effective rate: \$165.35/hr (cost ÷ working time, includes parallel subagent compute).

_Public-rate estimate against published Anthropic API prices; plan billing (Max/Pro/Team/Enterprise) differs. Cache reads dominate (~93% of tokens) — that's normal for prompt caching. Subagent compute is included in the working-time figure, which is why working > elapsed._

🤖 Opened by /autonomo