### PR TITLE
Fix dashboard tiles showing only history, not live source content

### DIFF
--- a/bin/dashboard
+++ b/bin/dashboard
@@ -112,6 +112,18 @@ apply_grid_layout() {
 
 # Build (or rebuild) the dashboard session with one tile per matched source
 # session. Default layout is `tiled` (auto roughly-square); --cols forces a
+# Command run inside each tile pane. Captures the source pane's visible
+# content, tails to the tile's height so the most recent content lands at
+# the bottom of the tile (and `watch` doesn't truncate the wrong end).
+#
+# Quoting: the outer single-quoted string is passed verbatim through tmux's
+# shell to watch, which feeds it to its own `sh -c`. The `$(tput lines)`
+# inside the single quotes is therefore evaluated INSIDE the tile pane on
+# every poll, so the tile clipping responds to live resizes.
+tile_cmd() {
+  printf "watch -c -n 0.5 -t -- 'tmux capture-pane -ep -t %s | tail -n \$(tput lines)'" "$1"
+}
+
 # hand-built row-major grid via apply_grid_layout().
 #
 # Args: $1 = session name (e.g. dashboard-agent), $2... = source session names
@@ -132,7 +144,7 @@ build_dashboard() {
     # Quote the inner double-dollar so $(tput lines) runs inside the spawned
     # shell, not at the time we hand the command to tmux.
     tmx new-session -d -s "$session" -x 200 -y 60 \
-      -n preview "watch -c -n 0.5 -t -- tmux capture-pane -ep -S -\$(tput lines) -E -1 -t '${sources[0]}'"
+      -n preview "$(tile_cmd "${sources[0]}")"
     first=0  # the new-session already filled the seed tile with the first source
     set +u; sources=("${sources[@]:1}"); set -u
   else
@@ -158,7 +170,7 @@ build_dashboard() {
   # pane id for any follow-up commands. respawn-pane keeps the pane.
   if [ "$first" -eq 1 ] && [ "${#sources[@]}" -gt 0 ]; then
     src="${sources[0]}"
-    cmd="watch -c -n 0.5 -t -- tmux capture-pane -ep -S -\$(tput lines) -E -1 -t '$src'"
+    cmd=$(tile_cmd "$src")
     tmx respawn-pane -k -t "$first_pane" "$cmd"
     set +u; sources=("${sources[@]:1}"); set -u
   fi
@@ -215,7 +227,7 @@ build_dashboard() {
     local idx2=0
     for src in "${all_sources[@]}"; do
       pid="${all_grid_pids[$idx2]}"
-      cmd="watch -c -n 0.5 -t -- tmux capture-pane -ep -S -\$(tput lines) -E -1 -t '$src'"
+      cmd=$(tile_cmd "$src")
       tmx respawn-pane -k -t "$pid" "$cmd"
       idx2=$((idx2 + 1))
     done
@@ -225,7 +237,7 @@ build_dashboard() {
     # One split per remaining source; tmux's tiled layout reflows them.
     if [ "${#sources[@]}" -gt 0 ]; then
       for src in "${sources[@]}"; do
-        cmd="watch -c -n 0.5 -t -- tmux capture-pane -ep -S -\$(tput lines) -E -1 -t '$src'"
+        cmd=$(tile_cmd "$src")
         tmx split-window -t "$session" "$cmd"
       done
     fi

--- a/scripts/test-dashboard.sh
+++ b/scripts/test-dashboard.sh
@@ -385,6 +385,35 @@ SHIM
   out=$("$DASH" --rebuild 2>&1); rc=$?
   assert_eq "$rc" "0" "--rebuild outside dashboard exits 0 (silent bail)"
 
+  # ── Regression: tile renders source's VISIBLE content (not just history) ──
+  # Bug history: capture-pane -E -1 ends one line into history, skipping the
+  # visible pane entirely. With a source pane that has scrollback (anything
+  # long-running like a TUI), tiles rendered only the topmost history line
+  # (typically tmux's own status bar) instead of the live visible content.
+  # Correct flag is `-E -` ("end of visible pane"). This test fills the
+  # source's scrollback with OLD_SENTINEL, then puts NEW_SENTINEL in the
+  # visible area, and asserts the tile contains NEW_SENTINEL — which fails
+  # under the buggy flag because -E -1 returns OLD_SENTINEL from history.
+  reset_test_tmux
+  OLD_SENTINEL="DASHBOARD_OLD_$$"
+  NEW_SENTINEL="DASHBOARD_NEW_$$"
+  tmux -L "$TMUX_SOCKET" new-session -d -s 1-tile -x 80 -y 24 \
+    "for i in \$(seq 1 200); do echo '$OLD_SENTINEL'; done; printf '%s\n' '$NEW_SENTINEL'; sleep 999"
+  # Give the source's loop time to finish so NEW_SENTINEL lands in visible.
+  sleep 1
+  "$DASH" '*-tile' --cols 1 >/dev/null 2>&1
+  # Wait for watch's first poll (0.5s interval).
+  sleep 1
+  tile_content=$(tmux -L "$TMUX_SOCKET" capture-pane -t dashboard-tile -p -S - 2>/dev/null)
+  if printf '%s' "$tile_content" | grep -q -F -- "$NEW_SENTINEL"; then
+    pass=$((pass+1))
+    echo "  PASS  tile renders source pane's latest visible content"
+  else
+    fail=$((fail+1))
+    fail_msgs+=("FAIL  tile must render source pane's latest visible content"$'\n'"        wanted: '$NEW_SENTINEL'"$'\n'"        tile (last 5 lines): '$(printf '%s' "$tile_content" | tail -n 5)'")
+    echo "  FAIL  tile must render source pane's latest visible content"
+  fi
+
   teardown_test_tmux
   unset TMUX_SOCKET
   unset DASHBOARD_NO_FINISH


### PR DESCRIPTION
## Summary

Tiles in `dashboard` (#75 / #76) only ever rendered one line — usually tmux's window-title bar — instead of the live source pane content. Reproducer: `dashboard 'agent-*'` against any active TUI source (e.g. a Claude Code session). Tile shows `dotfiles/./w/...  claude  ✔  17:42:35` and nothing else; the body is blank.

## Root cause

`bin/dashboard`'s per-tile command was `tmux capture-pane -ep -S -$(tput lines) -E -1 -t SRC`. The `-E -1` ends one line into history, **skipping the visible pane entirely**. With any source that has scrollback, capture returns only history rows; with no scrollback it accidentally returns visible content, which is why this slipped through the original integration tests.

(Per `man tmux`: `-` to `-E` means "end of the visible pane". The plan author confused `-1` with `-`.)

## Fix

Switch to `tmux capture-pane -ep -t SRC | tail -n $(tput lines)`:

- Default capture returns the source pane's visible content.
- Piping through `tail` clips to the tile's height so the **most recent** rows land at the bottom — the right end for procps `watch`, which truncates from the bottom when output overflows.
- Centralize the command in a new `tile_cmd` helper so the four call sites (seed pane, rebuild pane, `--cols` grid, default tiled grid) stay in sync.

## Test plan

- [x] New regression test in `scripts/test-dashboard.sh`: fills source scrollback with `OLD_SENTINEL`, puts `NEW_SENTINEL` in the visible area, asserts the tile contains `NEW_SENTINEL`.
- [x] Confirmed the test fails (1/49) under the old `-E -1` flag and passes (0/49) with the fix.
- [x] `bash scripts/test-dashboard.sh` — 49/49.
- [x] `bash scripts/test-helpers.sh` — full suite, 30 helpers + 49 dashboard, 0 failed.
- [x] Live verification: respawned one tile of the user's running `dashboard-agent` with the fixed `capture-pane` flags; tile immediately rendered the source's Claude Code TUI content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)