### PR TITLE
docs: mark dashboard as experimental

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,3 +137,11 @@ These drive the `claude[<name>]` window title (tmux's
   lines for paths that exist on disk (OSC 8 hyperlinks + plain `path:line`
   regex), fzf-picks one, jumps the per-session nvim. Falls back to a fresh
   nvim in a new tmux window if no live nvim socket exists for the session.
+- **Dashboard (`bin/dashboard`) is experimental.** Spawns a tiled
+  `dashboard-<derived>` session that polls `capture-pane` for every
+  matched session — useful for keeping eyes on N parallel runs at
+  once. Wired up and tested for the author's daily flow, but not
+  battle-hardened: edge cases around layout, pagination, and
+  re-discovery may misbehave. Expect the surface (flags, bindings,
+  session-name shape) to shift. Cheatsheet card:
+  [`docs/tmux-cheatsheet.html`](docs/tmux-cheatsheet.html#dashboard).

--- a/docs/tmux-cheatsheet.html
+++ b/docs/tmux-cheatsheet.html
@@ -166,7 +166,7 @@
   </div>
 
   <div class="card">
-    <h3>Dashboard <span class="pill">live multi-session preview</span></h3>
+    <h3 id="dashboard">Dashboard <span class="pill warn">experimental</span></h3>
     <p>
       <code>dashboard '&lt;pattern&gt;' [--cols N]</code> from the shell.
       Spawns or rebuilds a <code>dashboard-&lt;derived&gt;</code> session


### PR DESCRIPTION
## Summary

- Tmux cheatsheet's Dashboard card now shows an orange `experimental` pill (reuses existing `.pill` + `.warn` classes) and has an `id="dashboard"` anchor.
- README's `## Quirks` section gains a new bullet introducing `bin/dashboard` as experimental, linking back to the cheatsheet card.

No changes to the dashboard script, tests, or CLAUDE.md. Spec lives at `.superpowers/specs/2026-05-03-dashboard-wip-disclaimer-design.md` (gitignored).

## Test plan

- [ ] `open docs/tmux-cheatsheet.html` — orange "experimental" pill renders next to the Dashboard card title.
- [ ] `open 'docs/tmux-cheatsheet.html#dashboard'` — page jumps to the Dashboard card.
- [ ] Render `README.md` — new Quirks bullet appears at the end of the list with the bold lead-in and a clickable link to the cheatsheet card.
- [ ] Print preview the cheatsheet — orange pill is legible.