### PR TITLE
Launch claude in window 1 and add background window 2 on fresh s sessions

### DIFF
--- a/bin/s
+++ b/bin/s
@@ -57,6 +57,15 @@ resolve_project_name() {
     | head -n1
 }
 
+# Lay out a brand-new worktree session: window 1 runs claude, window 2
+# is a blank shell. -d on new-window keeps the active window unchanged,
+# so the user sees no flicker when the session attaches.
+bootstrap_worktree_windows() {
+  local session="$1" target_path="$2"
+  tmux send-keys -t "$session" 'claude' Enter
+  tmux new-window -d -t "$session" -c "$target_path"
+}
+
 # Final stage: switch-client (in tmux) or attach (out) to an existing session.
 # The caller is responsible for creating the session with new-session first.
 finish() {
@@ -83,6 +92,7 @@ case $# in
     target_path=$(ensure_worktree "$project_path" "$name")
     if ! tmux has-session -t "$session" 2>/dev/null; then
       tmux new-session -d -s "$session" -c "$target_path"
+      bootstrap_worktree_windows "$session" "$target_path"
     fi
     tmux set-option -t "$session" @session_root "$target_path"
     finish "$session"
@@ -106,6 +116,7 @@ case $# in
       target_path=$(ensure_worktree "$project_path" "$name")
       if ! tmux has-session -t "$session" 2>/dev/null; then
         tmux new-session -d -s "$session" -c "$target_path"
+        bootstrap_worktree_windows "$session" "$target_path"
       fi
       tmux set-option -t "$session" @session_root "$target_path"
       finish "$session"

--- a/scripts/test-s.sh
+++ b/scripts/test-s.sh
@@ -43,6 +43,18 @@ assert_contains() {
   fi
 }
 
+assert_not_contains() {
+  local got="$1" needle="$2" desc="$3"
+  if printf '%s' "$got" | grep -q -F -- "$needle"; then
+    fail=$((fail+1))
+    fail_msgs+=("FAIL  $desc"$'\n'"        got:  '$got'"$'\n'"        unwanted: '$needle'")
+    echo "  FAIL  $desc"
+  else
+    pass=$((pass+1))
+    echo "  PASS  $desc"
+  fi
+}
+
 echo
 echo "bin/s"
 echo "─────"
@@ -247,6 +259,8 @@ SHIM
   assert_contains "$log" "attach -t dotfiles" "1-arg-out attaches (TMUX unset)"
   assert_contains "$log" "set-option -t dotfiles @session_root /tmp/fakerepo" \
     "1-arg-out stamps @session_root with project root"
+  assert_not_contains "$log" "send-keys" "1-arg-out does not bootstrap claude (project main session, no worktree)"
+  assert_not_contains "$log" "new-window" "1-arg-out does not open a second window"
   rm -rf "$shimdir"
 
   # ─── 2-arg out: session=<project>/<name>, wt creates worktree ──────
@@ -328,6 +342,8 @@ SHIM
   assert_contains "$log" "set-option -t dotfiles/feature-x @session_root /tmp/fakerepo/.claude/worktrees/feature-x" \
     "has-session=0 still stamps @session_root (handles post-restore wipe)"
   assert_contains "$log" "attach -t dotfiles/feature-x" "has-session=0 still attaches"
+  assert_not_contains "$log" "send-keys" "existing session is not re-bootstrapped (no extra send-keys)"
+  assert_not_contains "$log" "new-window" "existing session is not re-bootstrapped (no extra new-window)"
   rm -rf "$shimdir"
 
   # ─── 0-arg picker -> session=<project>, no worktree ────────────────
@@ -351,6 +367,8 @@ SHIM
     "picker creates session at picked project path"
   assert_contains "$log" "set-option -t dotfiles @session_root $fixture_real" \
     "picker stamps @session_root with picked project path"
+  assert_not_contains "$log" "send-keys" "picker does not bootstrap claude (project main session, no worktree)"
+  assert_not_contains "$log" "new-window" "picker does not open a second window"
   rm -rf "$shimdir" "$fixture"
 
   # ─── 1-arg in tmux: session=<project>/<name>, wt creates worktree ──

--- a/scripts/test-s.sh
+++ b/scripts/test-s.sh
@@ -267,6 +267,10 @@ SHIM
   assert_contains "$log" "attach -t dotfiles/feature-x" "2-arg-out attaches (TMUX unset)"
   assert_contains "$log" "set-option -t dotfiles/feature-x @session_root /tmp/fakerepo/.claude/worktrees/feature-x" \
     "2-arg-out stamps @session_root on the session"
+  assert_contains "$log" "send-keys -t dotfiles/feature-x claude Enter" \
+    "2-arg-out fresh session sends 'claude' to window 1"
+  assert_contains "$log" "new-window -d -t dotfiles/feature-x -c /tmp/fakerepo/.claude/worktrees/feature-x" \
+    "2-arg-out fresh session opens window 2 in background at worktree path"
   rm -rf "$shimdir"
 
   # ─── 2-arg in tmux: switch-client instead of attach ─────────────────
@@ -372,6 +376,10 @@ SHIM
     "1-arg in-tmux uses switch-client"
   assert_contains "$log" "set-option -t fixproject/feature-y @session_root $fixture_real/.claude/worktrees/feature-y" \
     "1-arg-in stamps @session_root with worktree path"
+  assert_contains "$log" "send-keys -t fixproject/feature-y claude Enter" \
+    "1-arg-in fresh session sends 'claude' to window 1"
+  assert_contains "$log" "new-window -d -t fixproject/feature-y -c $fixture_real/.claude/worktrees/feature-y" \
+    "1-arg-in fresh session opens window 2 in background at worktree path"
   rm -rf "$shimdir" "$fixture"
 fi
 


### PR DESCRIPTION
## Summary

- When `s` creates a brand-new worktree session (2-arg form or 1-arg-in-tmux), window 1 now launches `claude` and a second blank-shell window is added in the background.
- No flicker on attach: the session is built detached, and `tmux new-window -d` keeps the active window unchanged so `switch-client`/`attach` renders a single frame with window 1 already focused.
- Scoped to fresh worktree sessions only — picker, 1-arg-out (project main session), and re-attaches to existing sessions stay single-window.

## Test plan

- [x] `scripts/test-s.sh` (53/53 pass — 4 new positive assertions for the bootstrap, 6 new negative assertions guarding the no-bootstrap paths)
- [x] `scripts/test-helpers.sh` full suite (132/132 pass, exit 0)
- [ ] Manual smoke from inside an existing tmux session: `s <project> <name>` against a fresh name should attach with window 1 active, `claude` running, window 2 present in the status bar but not focused, no visible flicker.