### PR TITLE
Restyle landing-page cards, shrink cheatsheet hero, reorder screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 Personal config for Ghostty + zsh + tmux + vim, all in Solarized + JetBrainsMono Nerd Font.
 
 <p align="center">
+  <a href="docs/images/example_terminal.png"><img src="docs/images/example_terminal-thumb.png" alt="terminal" width="32%" /></a>
   <a href="docs/images/example_tmux.png"><img src="docs/images/example_tmux-thumb.png" alt="tmux" width="32%" /></a>
   <a href="docs/images/example_vim.png"><img src="docs/images/example_vim-thumb.png" alt="vim" width="32%" /></a>
-  <a href="docs/images/example_terminal.png"><img src="docs/images/example_terminal-thumb.png" alt="terminal" width="32%" /></a>
 </p>
 
 ## Cheatsheets
@@ -13,9 +13,9 @@ Personal config for Ghostty + zsh + tmux + vim, all in Solarized + JetBrainsMono
 Solarized-themed quick references — also browseable at
 [martinciu.github.io/dotfiles](https://martinciu.github.io/dotfiles/):
 
-- [Neovim](https://martinciu.github.io/dotfiles/nvim-cheatsheet.html) — LazyVim leader map, picker, LSP, neotest, Mason/Lazy
-- [tmux](https://martinciu.github.io/dotfiles/tmux-cheatsheet.html) — prefix `C-a` map, sessions/windows/panes, tmux-sessionx picker, status bar, copy mode
 - [Terminal](https://martinciu.github.io/dotfiles/terminal-cheatsheet.html) — eza, bat, less wrapper, git-delta, difftastic, glow, vivid, xh, fzf, zsh plugins
+- [tmux](https://martinciu.github.io/dotfiles/tmux-cheatsheet.html) — prefix `C-a` map, sessions/windows/panes, tmux-sessionx picker, status bar, copy mode
+- [Neovim](https://martinciu.github.io/dotfiles/nvim-cheatsheet.html) — LazyVim leader map, picker, LSP, neotest, Mason/Lazy
 
 ## Setup (new machine)
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,7 +6,8 @@
 <title>Solarized cheatsheets</title>
 <link rel="stylesheet" href="style.css" />
 <style>
-  .card p { color: var(--base0); margin: .35rem 0 0; }
+  .card p { color: var(--base0); margin: .35rem 0 .6rem; }
+  .card .shot { margin-bottom: 0; }
 </style>
 </head>
 <body>
@@ -18,33 +19,33 @@
 </header>
 
 <div class="grid">
-  <div class="card">
-    <a class="shot" href="images/example_vim.png">
-      <img src="images/example_vim-thumb.png"
-           alt="Neovim with LazyVim, Solarized Dark, JetBrainsMono Nerd Font"
-           width="800" height="483" loading="lazy" />
-    </a>
-    <h3><a href="nvim-cheatsheet.html">Neovim</a></h3>
-    <p>LazyVim leader map, picker, LSP, neotest, Mason/Lazy.</p>
-  </div>
-  <div class="card">
-    <a class="shot" href="images/example_tmux.png">
-      <img src="images/example_tmux-thumb.png"
-           alt="tmux session in Solarized Dark with hand-rolled status bar"
-           width="800" height="483" loading="lazy" />
-    </a>
-    <h3><a href="tmux-cheatsheet.html">tmux</a></h3>
-    <p>Prefix <code>C-a</code> map, sessions/windows/panes, tmux-sessionx picker, status bar, copy mode.</p>
-  </div>
-  <div class="card">
-    <a class="shot" href="images/example_terminal.png">
+  <a class="card" href="terminal-cheatsheet.html">
+    <h3>Terminal</h3>
+    <p>eza, bat, less wrapper, git-delta, glow, vivid, fzf, zsh plugins.</p>
+    <span class="shot">
       <img src="images/example_terminal-thumb.png"
            alt="Solarized Dark terminal showing eza, bat, git-delta, fzf"
            width="800" height="483" loading="lazy" />
-    </a>
-    <h3><a href="terminal-cheatsheet.html">Terminal</a></h3>
-    <p>eza, bat, less wrapper, git-delta, glow, vivid, fzf, zsh plugins.</p>
-  </div>
+    </span>
+  </a>
+  <a class="card" href="tmux-cheatsheet.html">
+    <h3>tmux</h3>
+    <p>Prefix <code>C-a</code> map, sessions/windows/panes, tmux-sessionx picker, status bar, copy mode.</p>
+    <span class="shot">
+      <img src="images/example_tmux-thumb.png"
+           alt="tmux session in Solarized Dark with hand-rolled status bar"
+           width="800" height="483" loading="lazy" />
+    </span>
+  </a>
+  <a class="card" href="nvim-cheatsheet.html">
+    <h3>Neovim</h3>
+    <p>LazyVim leader map, picker, LSP, neotest, Mason/Lazy.</p>
+    <span class="shot">
+      <img src="images/example_vim-thumb.png"
+           alt="Neovim with LazyVim, Solarized Dark, JetBrainsMono Nerd Font"
+           width="800" height="483" loading="lazy" />
+    </span>
+  </a>
 </div>
 
 <footer>

--- a/docs/style.css
+++ b/docs/style.css
@@ -31,13 +31,15 @@ code { background: var(--base02); color: var(--cyan); padding: .08em .35em; bord
 kbd, .k { display: inline-block; background: var(--base02); color: var(--yellow); border: 1px solid #0a4655;
   border-bottom-width: 2px; border-radius: 4px; padding: .05em .42em; font-size: .82em; line-height: 1.4; white-space: nowrap; }
 .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(360px, 1fr)); gap: 1rem; }
-.card { background: var(--base02); border: 1px solid #0a4655; border-radius: 8px; padding: .9rem 1rem 1rem; }
+.card { background: var(--base02); border: 1px solid #0a4655; border-radius: 8px; padding: .9rem 1rem 1rem; display: block; color: inherit; text-decoration: none; }
+.card:hover { border-color: var(--blue); text-decoration: none; }
+.card:hover .shot { border-color: var(--blue); }
 .card h3 { margin-top: 0; color: var(--base2); border-bottom: 1px dashed #0a4655; padding-bottom: .35rem; }
 .card h3 .pill { background: var(--base03); color: var(--blue); font-size: .68em; font-weight: 500;
   padding: .15em .5em; border-radius: 3px; margin-left: .5em; vertical-align: middle; letter-spacing: .03em; }
 .shot { display: block; line-height: 0; border-radius: 6px; overflow: hidden; border: 1px solid #0a4655; margin-bottom: .8rem; }
 .shot img { width: 100%; height: auto; display: block; }
-.shot.hero { margin: 0 0 1.6rem; }
+.shot.hero { max-width: 66%; margin: 0 auto 1.6rem; }
 .shot:hover { border-color: var(--blue); }
 table { width: 100%; border-collapse: collapse; margin: .25rem 0; }
 td { padding: .25rem .35rem; vertical-align: top; border-bottom: 1px solid #073642; }


### PR DESCRIPTION
## Summary
- Landing-page cards become single-target anchors with title and description above the thumbnail; clicking anywhere on a card navigates to the matching cheatsheet.
- Cheatsheet hero images shrink to `max-width: 66%` and center — matches landing-thumbnail width (~780px) so click-through from a thumbnail to a cheatsheet doesn't visually jolt the image.
- README image grid, README cheatsheet bullets, and landing-page cards all reorder to **terminal, tmux, neovim** (the three lists were inconsistent before).

## Test plan
- [ ] Open `docs/index.html` and confirm card order (Terminal, tmux, Neovim), title/description above thumb, and that clicking anywhere on a card opens the matching cheatsheet.
- [ ] Hover any landing card — border highlights blue, no underline appears on title or description.
- [ ] Open each cheatsheet (`nvim`, `tmux`, `terminal`) — hero is centered at ~66% width with content below intact.
- [ ] Render `README.md` (e.g. `glow README.md` or via GitHub) — image grid and bullet list both read terminal → tmux → vim/Neovim.