### PR TITLE
Redesign cheatsheet hero as full-bleed band; refresh card hovers

### DIFF
--- a/docs/nvim-cheatsheet.html
+++ b/docs/nvim-cheatsheet.html
@@ -13,19 +13,21 @@
 </head>
 <body>
 
-<header>
-  <h1>Neovim — Getting Started &amp; Cheatsheet</h1>
-  <div class="sub">
-    LazyVim &middot; Solarized &middot; leader = <code>&lt;Space&gt;</code> &middot; localleader = <code>\</code>
-    &middot; Polish keyboard: <span class="warn">no Alt-bindings</span>
+<section class="hero-band">
+  <a class="hero-img" href="images/example_vim.png" aria-label="Open full-size Neovim screenshot">
+    <img src="images/example_vim-hero.png"
+         alt="Neovim with LazyVim, Solarized Dark, JetBrainsMono Nerd Font"
+         width="1600" height="967" loading="eager" />
+  </a>
+  <div class="hero-inner">
+    <h1>Neovim <span class="accent">— Getting Started &amp; Cheatsheet</span></h1>
+    <div class="sub">
+      LazyVim &middot; Solarized &middot; leader = <code>&lt;Space&gt;</code> &middot; localleader = <code>\</code>
+      &middot; Polish keyboard: <span class="warn">no Alt-bindings</span>
+    </div>
   </div>
-</header>
-
-<a class="shot hero" href="images/example_vim.png">
-  <img src="images/example_vim-hero.png"
-       alt="Neovim with LazyVim, Solarized Dark, JetBrainsMono Nerd Font"
-       width="1600" height="967" loading="eager" />
-</a>
+  <a class="hero-cta" href="images/example_vim.png">view full screenshot</a>
+</section>
 
 <nav class="toc">
   <strong style="color:var(--base2)">Jump:</strong>

--- a/docs/style.css
+++ b/docs/style.css
@@ -11,11 +11,65 @@
 * { box-sizing: border-box; }
 html, body { margin: 0; padding: 0; }
 body { background: var(--base03); color: var(--base1); font-family: var(--sans);
-  line-height: 1.55; font-size: 14.5px; padding: 2.2rem clamp(1rem, 4vw, 3rem) 4rem; }
-header { border-bottom: 1px solid var(--base02); padding-bottom: 1.2rem; margin-bottom: 1.6rem; }
+  line-height: 1.55; font-size: 14.5px; padding: 0 clamp(1rem, 4vw, 3rem) 4rem;
+  overflow-x: hidden; }
+/* Plain header (used on the index page) */
+header { border-bottom: 1px solid var(--base02); padding: 2.2rem 0 1.2rem; margin-bottom: 1.6rem; }
 header h1 { margin: 0 0 .35rem; font-size: 1.8rem; color: var(--base3); font-weight: 600; letter-spacing: -.01em; }
 header .sub { color: var(--base0); font-size: .95rem; }
 header .sub code { color: var(--cyan); }
+
+/* ─── Hero band ───────────────────────────────────────────────────────────────────
+   Used on the three cheatsheet pages. Image is full-bleed (breaks the body
+   padding via 100vw), masked to fade into the page background on all four
+   edges. The page title overlays the upper-left on a soft vignette. */
+.hero-band { position: relative; width: 100vw; left: 50%; right: 50%;
+  margin-left: -50vw; margin-right: -50vw; margin-bottom: 1.6rem;
+  padding: 0; overflow: hidden;
+  background: var(--base03);
+  isolation: isolate; }
+.hero-band .hero-img { position: absolute; inset: 0; z-index: 0; display: block; }
+.hero-band .hero-img img { width: 100%; height: 100%; object-fit: cover;
+  object-position: center top; display: block;
+  /* Fade out toward bottom AND sides so the screenshot dissolves into the page */
+  -webkit-mask-image:
+    linear-gradient(to bottom, #000 0%, #000 38%, rgba(0,0,0,.55) 72%, transparent 100%),
+    linear-gradient(to right,  transparent 0%, #000 6%, #000 94%, transparent 100%);
+  -webkit-mask-composite: source-in;
+          mask-image:
+    linear-gradient(to bottom, #000 0%, #000 38%, rgba(0,0,0,.55) 72%, transparent 100%),
+    linear-gradient(to right,  transparent 0%, #000 6%, #000 94%, transparent 100%);
+          mask-composite: intersect; }
+/* Vignette behind the title for legibility, scoped to upper-left */
+.hero-band::before { content: ""; position: absolute; inset: 0; z-index: 1; pointer-events: none;
+  background:
+    radial-gradient(ellipse 60% 80% at 0% 0%, rgba(0,43,54,.85), rgba(0,43,54,0) 70%),
+    linear-gradient(to bottom, rgba(0,43,54,.55) 0%, rgba(0,43,54,0) 40%); }
+.hero-band .hero-inner { position: relative; z-index: 2;
+  padding: 2.4rem clamp(1rem, 4vw, 3rem) 11rem;
+  min-height: clamp(360px, 38vw, 560px);
+  display: flex; flex-direction: column; justify-content: flex-start; }
+.hero-band h1 { margin: 0 0 .55rem; font-size: clamp(1.9rem, 3.6vw, 2.6rem);
+  color: var(--base3); font-weight: 600; letter-spacing: -.015em;
+  text-shadow: 0 1px 22px rgba(0,21,28,.85), 0 1px 2px rgba(0,21,28,.9); }
+.hero-band h1 .accent { color: var(--blue); font-weight: 400; }
+.hero-band .sub { color: var(--yellow); font-size: .98rem; max-width: 70ch;
+  text-shadow: 0 1px 14px rgba(0,21,28,.95), 0 1px 2px rgba(0,21,28,.9); }
+.hero-band .sub code { color: var(--cyan); background: rgba(7,54,66,.7); }
+.hero-band .sub .warn { color: var(--orange); }
+/* Variant: zoom on the middle of the screenshot (used on the tmux page so
+   the hand-rolled status bar / pane content is the focal point) */
+.hero-band--zoom-bottom .hero-img img { object-position: center center;
+  transform: scale(1.6); transform-origin: center center; }
+/* "view full screenshot" affordance, anchored bottom-right of the band */
+.hero-band .hero-cta { position: absolute; right: clamp(1rem, 4vw, 3rem); bottom: 1.4rem;
+  z-index: 2; font-family: var(--mono); font-size: .76rem; letter-spacing: .04em;
+  color: var(--base1); background: rgba(0,43,54,.7); border: 1px solid #0a4655;
+  padding: .35em .7em; border-radius: 3px; text-decoration: none;
+  backdrop-filter: blur(2px); }
+.hero-band .hero-cta:hover { color: var(--cyan); border-color: var(--cyan); text-decoration: none; }
+.hero-band .hero-cta::before { content: "↗ "; color: var(--blue); }
+.hero-band .hero-cta:hover::before { color: var(--cyan); }
 nav.toc { margin: 1rem 0 1.6rem; padding: .65rem .9rem; background: var(--base02); border-radius: 6px; font-size: .9rem; color: var(--base0); }
 a { color: var(--blue); text-decoration: none; }
 a:hover { color: var(--cyan); text-decoration: underline; }
@@ -31,16 +85,19 @@ code { background: var(--base02); color: var(--cyan); padding: .08em .35em; bord
 kbd, .k { display: inline-block; background: var(--base02); color: var(--yellow); border: 1px solid #0a4655;
   border-bottom-width: 2px; border-radius: 4px; padding: .05em .42em; font-size: .82em; line-height: 1.4; white-space: nowrap; }
 .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(360px, 1fr)); gap: 1rem; }
-.card { background: var(--base02); border: 1px solid #0a4655; border-radius: 8px; padding: .9rem 1rem 1rem; display: block; color: inherit; text-decoration: none; }
-.card:hover { border-color: var(--blue); text-decoration: none; }
-.card:hover .shot { border-color: var(--blue); }
+.card { background: var(--base02); border: 1px solid #0a4655; border-radius: 8px; padding: .9rem 1rem 1rem; display: flex; flex-direction: column; color: inherit; text-decoration: none;
+  transition: transform .25s ease, box-shadow .25s ease, background-color .25s ease; }
+.card > .shot { margin-top: auto; }
+.card:hover { text-decoration: none;
+  transform: translateY(-3px);
+  background: #0a3a47;
+  box-shadow: 0 8px 22px rgba(0,21,28,.55), 0 0 0 1px rgba(38,139,210,.18); }
+.card:hover h3 { color: var(--base3); }
 .card h3 { margin-top: 0; color: var(--base2); border-bottom: 1px dashed #0a4655; padding-bottom: .35rem; }
 .card h3 .pill { background: var(--base03); color: var(--blue); font-size: .68em; font-weight: 500;
   padding: .15em .5em; border-radius: 3px; margin-left: .5em; vertical-align: middle; letter-spacing: .03em; }
-.shot { display: block; line-height: 0; border-radius: 6px; overflow: hidden; border: 1px solid #0a4655; margin-bottom: .8rem; }
+.shot { display: block; line-height: 0; border-radius: 6px; overflow: hidden; margin-bottom: .8rem; }
 .shot img { width: 100%; height: auto; display: block; }
-.shot.hero { max-width: 66%; margin: 0 auto 1.6rem; }
-.shot:hover { border-color: var(--blue); }
 table { width: 100%; border-collapse: collapse; margin: .25rem 0; }
 td { padding: .25rem .35rem; vertical-align: top; border-bottom: 1px solid #073642; }
 tr:last-child td { border-bottom: 0; }
@@ -66,5 +123,5 @@ footer { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--base02
   code { background: #f3f3f3; color: #2aa198; }
   nav.toc { display: none; } a { color: #268bd2 !important; }
   pre { background: #f6f6f6; color: #222; }
-  .shot { display: none; }
+  .shot, .hero-band { display: none; }
 }

--- a/docs/terminal-cheatsheet.html
+++ b/docs/terminal-cheatsheet.html
@@ -13,18 +13,20 @@
 </head>
 <body>
 
-<header>
-  <h1>Terminal — Getting Started &amp; Cheatsheet</h1>
-  <div class="sub">
-    Solarized Dark, end-to-end &middot; eza · bat · git-delta · difftastic · glow · vivid · procs · lnav · xh · fzf · fzf-tab · zsh-autosuggestions · zsh-syntax-highlighting
+<section class="hero-band">
+  <a class="hero-img" href="images/example_terminal.png" aria-label="Open full-size terminal screenshot">
+    <img src="images/example_terminal-hero.png"
+         alt="Solarized Dark terminal showing eza, bat, git-delta, fzf"
+         width="1600" height="967" loading="eager" />
+  </a>
+  <div class="hero-inner">
+    <h1>Terminal <span class="accent">— Getting Started &amp; Cheatsheet</span></h1>
+    <div class="sub">
+      Solarized Dark, end-to-end &middot; eza · bat · git-delta · difftastic · glow · vivid · procs · lnav · xh · fzf · fzf-tab · zsh-autosuggestions · zsh-syntax-highlighting
+    </div>
   </div>
-</header>
-
-<a class="shot hero" href="images/example_terminal.png">
-  <img src="images/example_terminal-hero.png"
-       alt="Solarized Dark terminal showing eza, bat, git-delta, fzf"
-       width="1600" height="967" loading="eager" />
-</a>
+  <a class="hero-cta" href="images/example_terminal.png">view full screenshot</a>
+</section>
 
 <nav class="toc">
   <strong style="color:var(--base2)">Jump:</strong>

--- a/docs/tmux-cheatsheet.html
+++ b/docs/tmux-cheatsheet.html
@@ -15,19 +15,20 @@
 </head>
 <body>
 
-<header>
-  <h1>tmux — Getting Started &amp; Cheatsheet</h1>
-  <div class="sub">
-    Prefix = <code>C-a</code> &middot; Solarized hand-rolled status bar &middot; vim-style pane nav
-    &middot; Polish keyboard: <span class="warn">no Alt-bindings</span>
+<section class="hero-band hero-band--zoom-bottom">
+  <a class="hero-img" href="images/example_tmux.png" aria-label="Open full-size tmux screenshot">
+    <img src="images/example_tmux-hero.png"
+         alt="tmux session in Solarized Dark with hand-rolled status bar"
+         width="1600" height="967" loading="eager" />
+  </a>
+  <div class="hero-inner">
+    <h1>tmux <span class="accent">— Getting Started &amp; Cheatsheet</span></h1>
+    <div class="sub">
+      Prefix = <code>C-a</code> &middot; Solarized hand-rolled status bar &middot; vim-style pane nav
+    </div>
   </div>
-</header>
-
-<a class="shot hero" href="images/example_tmux.png">
-  <img src="images/example_tmux-hero.png"
-       alt="tmux session in Solarized Dark with hand-rolled status bar"
-       width="1600" height="967" loading="eager" />
-</a>
+  <a class="hero-cta" href="images/example_tmux.png">view full screenshot</a>
+</section>
 
 <nav class="toc">
   <strong style="color:var(--base2)">Jump:</strong>


### PR DESCRIPTION
## Summary
- Cheatsheet pages: replace the centered 66% hero screenshot + plain header with a full-bleed `.hero-band` (edge-fade image, title overlay, "view full screenshot" pill). Tmux uses a `--zoom-bottom` modifier focusing the status bar, and drops the "no Alt-bindings" subtitle note.
- Landing page: cards are flex columns with the screenshot pinned to the bottom (vertically aligned thumbs); hover replaces the blue border with a soft lift (translateY + shadow + lighter background). `.shot` border removed.
- Body padding-top moved into `header` so the cheatsheet hero can break the bleed; print hides `.hero-band` alongside `.shot`.

## Test plan
- [x] Open `docs/terminal-cheatsheet.html`, `docs/tmux-cheatsheet.html`, `docs/nvim-cheatsheet.html` in a browser; confirm full-bleed hero, edge fades, title legibility, and that the "view full screenshot" pill links to the full-size PNG.
- [x] Tmux page hero zooms onto the status-bar / pane content (not the top of the capture).
- [x] Open `docs/index.html`; confirm all three card thumbs align at the same vertical baseline despite different copy lengths, and that hover lifts each card.
- [x] Print preview each cheatsheet — `.hero-band` should not render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)