### PR TITLE
tmux: absolute-center the window list on the status bar

### DIFF
--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -160,9 +160,14 @@ set -g status-interval 5
 set -g status-position bottom
 set -g status-style "bg=#073642,fg=#839496"
 
+# Center the window list on the full status-bar width (ignores the widths
+# of status-left / status-right). Plain `centre` would center within the
+# remaining gap and — given asymmetric content — sit visually off-center.
+set -g status-justify absolute-centre
+
 # Left: session name on a blue chip
 set -g status-left "#[fg=#fdf6e3,bg=#268bd2,bold]  #S #[fg=#268bd2,bg=#073642] "
-set -g status-left-length 40
+set -g status-left-length 80
 
 # Windows
 setw -g window-status-format         "#[fg=#586e75,bg=#073642] #I:#W "

--- a/docs/tmux-cheatsheet.html
+++ b/docs/tmux-cheatsheet.html
@@ -312,7 +312,7 @@
     <p>Bottom bar, <code>bg=base02</code> / <code>fg=base0</code>. Three segments:</p>
     <ul class="compact">
       <li><strong>Left:</strong> session name on a blue chip with a powerline arrow.</li>
-      <li><strong>Center:</strong> windows. Inactive = <code>base01</code> on <code>base02</code>; active = <code>yellow</code>-on-<code>base02</code> chip.</li>
+      <li><strong>Center (absolute-centered on the full bar):</strong> windows. Inactive = <code>base01</code> on <code>base02</code>; active = <code>yellow</code>-on-<code>base02</code> chip.</li>
       <li><strong>Right:</strong> project name (violet chip) → git/worktree status from <code>tmux-git-status</code>.</li>
     </ul>
   </div>
@@ -421,7 +421,7 @@
 </table>
 
 <footer>
-  Built from <code>~/.config/tmux/tmux.conf</code> on 2026-05-03. Refresh after meaningful config changes.
+  Built from <code>~/.config/tmux/tmux.conf</code> on 2026-05-04. Refresh after meaningful config changes.
   <br>
   When in doubt: <span class="k prefix">C-a</span> <span class="k">?</span> for the live keymap list.
 </footer>


### PR DESCRIPTION
## Summary

- `set -g status-justify absolute-centre` so the window list is centered on the full status-bar width, not left-aligned in the gap between `status-left` and `status-right`.
- Bump `status-left-length` 40 → 80 so the left/right caps are symmetric.
- Cheatsheet: tighten the "Center: windows" bullet and refresh the footer date.

Trade-off: on narrow terminals or with long session names + long branch/worktree names, the centered list may collide with the side chips. Explicit accepted choice for visual balance — no fallback wired in.

Spec: `.superpowers/specs/2026-05-04-tmux-centered-window-list-design.md` (gitignored).
Plan: `.superpowers/plans/2026-05-04-tmux-centered-window-list.md` (gitignored).

## Test plan

- [x] `tmux source-file ~/.config/tmux/tmux.conf` reload — clean exit.
- [x] `tmux show-options -g status-justify` → `absolute-centre`; `status-left-length` → `80`.
- [x] Cheatsheet opened in browser — bullet wording and footer date updated, no layout breakage.
- [x] Visual confirmation: 3+ windows of varying name length, list centered on the full bar; active-window yellow chip travels with active window inside the centered list.