### PR TITLE
zsh: add .zprofile with brew shellenv to fix bash 3.2 / PATH order

### DIFF
--- a/.zprofile
+++ b/.zprofile
@@ -1,0 +1,1 @@
+eval "$(/opt/homebrew/bin/brew shellenv)"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,14 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
   shims — `brew bundle` runs before `bootstrap.sh` in the README's "Setup
   (new machine)" order, so brew bash is always present before a pinned-
   shebang script runs.
+- **`.zprofile` runs `brew shellenv`** to prepend `/opt/homebrew/bin` ahead
+  of the system paths that macOS's `/etc/zprofile` (`path_helper`) installs.
+  Without it, `bash`, `make`, and other tools resolve to `/usr/bin` versions
+  even though brew ships newer ones. Don't move the line into `.zshrc` —
+  interactive subshells re-source `.zshrc`, which would re-stack
+  `/opt/homebrew/bin` in PATH (the same duplication already visible for
+  `~/.cargo/bin` exports there). `.zprofile` runs once per login session
+  and child shells inherit cleanly.
 - **`Brewfile` is report-only.** `bootstrap.sh` runs `brew bundle check` and
   prints what's missing — it does not install. Don't change that.
 - **Global gitignore is symlinked from `.gitignore_global`** (repo root,
@@ -351,8 +359,8 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
 
 ## Where things live
 
-- Sources: `$PROJECTS_HOME/dotfiles/{.config,.vimrc,.vim/colors,.zshrc,.p10k.zsh,.gitignore_global,.claude/CLAUDE.md}` (`.config/` includes `nvim/`, `worktrunk/`, `glow/`)
-- Targets: `~/.config/{ghostty,tmux,ccstatusline,nvim,worktrunk,glow}`, `~/.config/sesh/sesh.toml`, `~/.local/bin/<command>`, `~/.vimrc`, `~/.vim/colors`, `~/.zshrc`, `~/.p10k.zsh`, `~/.gitignore_global`, `~/.claude/CLAUDE.md`
+- Sources: `$PROJECTS_HOME/dotfiles/{.config,.vimrc,.vim/colors,.zshrc,.zprofile,.p10k.zsh,.gitignore_global,.claude/CLAUDE.md}` (`.config/` includes `nvim/`, `worktrunk/`, `glow/`)
+- Targets: `~/.config/{ghostty,tmux,ccstatusline,nvim,worktrunk,glow}`, `~/.config/sesh/sesh.toml`, `~/.local/bin/<command>`, `~/.vimrc`, `~/.vim/colors`, `~/.zshrc`, `~/.zprofile`, `~/.p10k.zsh`, `~/.gitignore_global`, `~/.claude/CLAUDE.md`
 - The repo's `.claude/CLAUDE.md` IS the user-global Claude config (symlinked to `~/.claude/CLAUDE.md`). Edits there apply to every project on this machine, not just dotfiles.
 - Machine-specific overrides: `~/.zshrc.local` (untracked; copy from `.zshrc.local.template`)
 - Helpers: `.config/tmux/bin/{tmux-git-status,claude-tmux-window-name,tmux-fzf-file,tmux-fzf-url-newest,tmux-open-in-nvim}`

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ These drive the `claude[<name>]` window title (tmux's
 | [tmux](https://github.com/tmux/tmux) | `.config/tmux/`      | `~/.config/tmux`    |
 | [nvim](https://neovim.io/) | `.config/nvim/`                | `~/.config/nvim`    |
 | [vim](https://www.vim.org/) | `.vimrc`, `.vim/colors/`      | `~/.vimrc`, `~/.vim/colors` |
-| [zsh](https://www.zsh.org/) | `.zshrc`, `.p10k.zsh`         | `~/.zshrc`, `~/.p10k.zsh` |
+| [zsh](https://www.zsh.org/) | `.zshrc`, `.zprofile`, `.p10k.zsh` | `~/.zshrc`, `~/.zprofile`, `~/.p10k.zsh` |
 | [sesh](https://github.com/joshmedeski/sesh) | `.config/sesh/sesh.toml` | `~/.config/sesh/sesh.toml` |
 | [worktrunk](https://worktrunk.dev/) | `.config/worktrunk/` | `~/.config/worktrunk` |
 | [glow](https://github.com/charmbracelet/glow) | `.config/glow/` | `~/.config/glow` |

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -98,6 +98,7 @@ mkdir -p "$HOME/.vim/undo" "$HOME/.vim/backup" "$HOME/.vim/swap"
 
 # --- zsh
 link ".zshrc"     "$HOME/.zshrc"
+link ".zprofile"  "$HOME/.zprofile"
 link ".p10k.zsh"  "$HOME/.p10k.zsh"
 
 # --- git (global ignore — paths excluded across every repo on this machine)


### PR DESCRIPTION
## Summary
- Adds `.zprofile` that runs `eval "$(/opt/homebrew/bin/brew shellenv)"` so `/opt/homebrew/bin` lands ahead of macOS's `path_helper`-injected system paths.
- Wires it into `bootstrap.sh` next to `.zshrc`/`.p10k.zsh`.
- Documents the convention in `CLAUDE.md` and the symlink inventory in `README.md`.

## Why
On a clean Apple Silicon login shell, `bash` resolved to `/bin/bash` (3.2) instead of brew's 5.x because nothing prepended `/opt/homebrew/bin` after `/etc/zprofile`'s `path_helper`. In-repo scripts use the pinned shebang `#!/opt/homebrew/bin/bash` so they were unaffected, but bare `bash` at the prompt and any third-party tooling resolving via PATH got the system version.

## Test plan
- [ ] `bootstrap.sh` is idempotent (re-running shows `ok:` for `~/.zprofile`).
- [ ] `zsh -lc 'command -v bash; bash --version | head -1'` returns `/opt/homebrew/bin/bash` and `GNU bash, version 5.x ...`.
- [ ] First two entries of `$PATH` in a fresh login shell are `/opt/homebrew/bin` and `/opt/homebrew/sbin`.
- [ ] Re-bootstrap on a second machine reproduces the same setup with no manual steps.