### PR TITLE
tmux: add SSH indicator on the session chip

### DIFF
--- a/.config/tmux/bin/tmux-ssh-indicator
+++ b/.config/tmux/bin/tmux-ssh-indicator
@@ -1,0 +1,72 @@
+#!/opt/homebrew/bin/bash
+# Emit a Nerd Font globe glyph (U+F0AC, nf-fa-globe) when any currently-
+# attached tmux client traces back to an `sshd` (or `sshd-session`) ancestor
+# process. Otherwise emit nothing. Intended for use inside the left-side
+# session chip via `#(...)` in tmux's `status-left`.
+#
+# Detection is server-wide (any attached client SSH-rooted -> indicator on),
+# not per-client, because `#(...)` shells run server-global. For a single-
+# user Mac this is accurate enough; a per-client design would require
+# attach/detach hooks plus a per-client option, which is more moving parts
+# than the use case warrants.
+#
+# Mosh is intentionally not detected — mosh sessions root in `mosh-server`,
+# not `sshd`. Add `mosh-server` to the match set if mosh becomes a regular
+# tool here.
+
+set -eu
+set -o pipefail
+
+# Globe glyph as raw UTF-8 bytes — same byte-emission style as
+# tmux-git-status; avoids editor-dependent literal embedding.
+glyph=$(printf '\xef\x82\xac')   # U+F0AC nf-fa-globe
+
+MAX_DEPTH=20
+
+# Returns 0 if walking the parent-process chain of $1 on macOS finds an
+# `sshd` or `sshd-session` ancestor. Returns 1 otherwise. Stops at depth
+# MAX_DEPTH or when ppid is 0 / 1 / equals self / cycles back to a seen pid.
+#
+# Implemented as a single function (no pipeline to a separate matcher) so
+# we don't have to reason about SIGPIPE semantics under `set -o pipefail`.
+client_is_ssh() {
+  local pid="$1"
+  local depth=0
+  local seen=" "
+  local row ppid comm
+  while [ "$depth" -lt "$MAX_DEPTH" ]; do
+    row=$(ps -p "$pid" -o ppid=,comm= 2>/dev/null) || return 1
+    [ -z "$row" ] && return 1
+    # `read` collapses leading whitespace (macOS ps right-pads ppid) and
+    # splits the first run of whitespace as the ppid/comm boundary.
+    read -r ppid comm <<<"$row"
+    [ -z "$ppid" ] && return 1
+    case "$(basename -- "$comm")" in
+      sshd|sshd-session) return 0 ;;
+    esac
+    case "$seen" in
+      *" $ppid "*) return 1 ;;
+    esac
+    seen="$seen$ppid "
+    case "$ppid" in
+      0|1) return 1 ;;
+    esac
+    [ "$ppid" = "$pid" ] && return 1
+    pid="$ppid"
+    depth=$((depth + 1))
+  done
+  return 1
+}
+
+clients=$(tmux list-clients -F '#{client_pid}' 2>/dev/null || true)
+[ -z "$clients" ] && exit 0
+
+while IFS= read -r pid; do
+  [ -z "$pid" ] && continue
+  if client_is_ssh "$pid"; then
+    printf '%s ' "$glyph"
+    exit 0
+  fi
+done <<<"$clients"
+
+exit 0

--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -165,8 +165,8 @@ set -g status-style "bg=#073642,fg=#839496"
 # remaining gap and — given asymmetric content — sit visually off-center.
 set -g status-justify absolute-centre
 
-# Left: session name on a blue chip
-set -g status-left "#[fg=#fdf6e3,bg=#268bd2,bold]  #S #[fg=#268bd2,bg=#073642] "
+# Left: session name on a blue chip; gains a leading globe glyph when any attached tmux client is SSH-rooted (drives tmux-ssh-indicator).
+set -g status-left "#[fg=#fdf6e3,bg=#268bd2,bold]  #(~/.config/tmux/bin/tmux-ssh-indicator)#S #[fg=#268bd2,bg=#073642] "
 set -g status-left-length 80
 
 # Windows

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,25 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
 - **tmux status bar is hand-rolled** in `.config/tmux/tmux.conf` with
   Solarized base16 colors. Don't suggest theme plugins (catppuccin,
   tmux-powerline, etc.) — we deliberately avoid them.
+- **SSH indicator on the session chip** is wired into `status-left` via
+  `#(~/.config/tmux/bin/tmux-ssh-indicator)`. The helper walks each
+  attached client's parent-process chain on macOS using
+  `ps -p <pid> -o ppid=,comm=` and emits a Nerd Font globe glyph (``
+  `nf-fa-globe`, U+F0AC) plus a single space when any ancestor is `sshd`
+  or `sshd-session`. The glyph inherits the chip's `fg=#fdf6e3,bg=#268bd2`
+  styling — no color flip, presence/absence is the signal. Detection is
+  server-wide (any attached client is SSH → indicator on), not
+  per-client: `#(...)` shells run server-global. For a single-user Mac
+  with one client at a time this is accurate enough; a per-client design
+  would need `client-attached` / `client-detached` hooks and more moving
+  parts than the use case warrants. Refresh piggybacks on the existing 5 s
+  `status-interval` — don't add a `client-attached` hook for sub-second
+  refresh without an explicit ask. Mosh is **not** detected (sessions
+  root in `mosh-server`, not `sshd`); add `mosh-server` to the basename
+  match set in the script if mosh becomes regular tooling. Env-var
+  detection (`$SSH_CONNECTION`) intentionally not used — it's set in
+  the SSH-spawned shell's env, not the tmux server's, so `#(...)` calls
+  never see it.
 - **tmux prefix is `C-a`** (screen-style; `C-Space` conflicts with macOS
   input-source switching). Pane nav: `<prefix> h/j/k/l` (Alt is reserved for
   Polish diacritics — never use `bind -n M-*`). Splits: `|` and `-`.
@@ -363,7 +382,7 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
 - Targets: `~/.config/{ghostty,tmux,ccstatusline,nvim,worktrunk,glow}`, `~/.config/sesh/sesh.toml`, `~/.local/bin/<command>`, `~/.vimrc`, `~/.vim/colors`, `~/.zshrc`, `~/.zprofile`, `~/.p10k.zsh`, `~/.gitignore_global`, `~/.claude/CLAUDE.md`
 - The repo's `.claude/CLAUDE.md` IS the user-global Claude config (symlinked to `~/.claude/CLAUDE.md`). Edits there apply to every project on this machine, not just dotfiles.
 - Machine-specific overrides: `~/.zshrc.local` (untracked; copy from `.zshrc.local.template`)
-- Helpers: `.config/tmux/bin/{tmux-git-status,claude-tmux-window-name,tmux-fzf-file,tmux-fzf-url-newest,tmux-open-in-nvim}`
+- Helpers: `.config/tmux/bin/{tmux-git-status,claude-tmux-window-name,tmux-fzf-file,tmux-fzf-url-newest,tmux-open-in-nvim,tmux-ssh-indicator}`
 - Smoke tests for helpers: `scripts/test-helpers.sh`
 
 ## Cheatsheets (`docs/`)
@@ -417,6 +436,7 @@ filename is the source of truth).
 - Pre-remove save-shared tests: `scripts/test-wt-pre-remove-save.sh`
 - Claude tmux window-name tests: `scripts/test-claude-tmux-window-name.zsh`
 - URL-picker wrapper tests: `scripts/test-tmux-fzf-url-newest.sh`
+- tmux SSH-indicator tests: `scripts/test-tmux-ssh-indicator.sh`
 - Session-root binding tests: `scripts/test-s-session-root.sh`
 - Dashboard smoke + integration tests: `scripts/test-dashboard.sh`
 - Reapply symlinks (idempotent): `$PROJECTS_HOME/dotfiles/bootstrap.sh`

--- a/docs/tmux-cheatsheet.html
+++ b/docs/tmux-cheatsheet.html
@@ -311,7 +311,7 @@
     <h3>Layout</h3>
     <p>Bottom bar, <code>bg=base02</code> / <code>fg=base0</code>. Three segments:</p>
     <ul class="compact">
-      <li><strong>Left:</strong> session name on a blue chip with a powerline arrow.</li>
+      <li><strong>Left:</strong> session name on a blue chip with a powerline arrow. Gains a leading globe glyph (<code></code> <code>nf-fa-globe</code>) when any attached tmux client is SSH-rooted (drives <code>tmux-ssh-indicator</code>).</li>
       <li><strong>Center (absolute-centered on the full bar):</strong> windows. Inactive = <code>base01</code> on <code>base02</code>; active = <code>yellow</code>-on-<code>base02</code> chip.</li>
       <li><strong>Right:</strong> branch chip — violet for main checkout, yellow for worktree (drives <code>tmux-git-status</code>).</li>
     </ul>
@@ -345,6 +345,7 @@
       <tr><td class="key"><code>~/.config/tmux/bin/tmux-fzf-file</code></td><td class="desc">scans pane + scrollback for paths, fzf picker — backs <span class="k prefix">C-a</span> <span class="k">o</span></td></tr>
       <tr><td class="key"><code>~/.config/tmux/bin/tmux-fzf-url-newest</code></td><td class="desc">wraps <code>tmux-fzf-url</code> so the newest occurrence of duplicate URLs wins — backs <span class="k prefix">C-a</span> <span class="k">u</span></td></tr>
       <tr><td class="key"><code>~/.config/tmux/bin/tmux-open-in-nvim</code></td><td class="desc">remote-sends <code>:edit</code> to the per-session nvim socket; falls back to a fresh nvim in a new window</td></tr>
+      <tr><td class="key"><code>~/.config/tmux/bin/tmux-ssh-indicator</code></td><td class="desc">walks each attached client's <code>ps</code> ancestry; prints <code></code> + space when any ancestor is <code>sshd</code>/<code>sshd-session</code> — prepended inside the session chip</td></tr>
       <tr><td class="key"><code>scripts/test-helpers.sh</code></td><td class="desc">smoke-tests for the helpers</td></tr>
     </table>
     <p class="note">Worktree detection uses <code>git rev-parse --git-dir</code> vs <code>--git-common-dir</code> so it works for <code>.claude/worktrees/*</code>, worktrunk paths, and sibling worktrees alike.</p>
@@ -417,6 +418,7 @@
   <tr><td class="key"><code>scripts/test-fzf-file-extract.sh</code></td><td class="desc">file-picker path-extraction tests (regex + OSC 8)</td></tr>
   <tr><td class="key"><code>scripts/test-tmux-fzf-url-newest.sh</code></td><td class="desc">URL-picker wrapper tests (newest-occurrence dedup)</td></tr>
   <tr><td class="key"><code>scripts/test-claude-tmux-window-name.zsh</code></td><td class="desc">tests for the <code>claude[&lt;name&gt;]</code> window-title helper</td></tr>
+  <tr><td class="key"><code>scripts/test-tmux-ssh-indicator.sh</code></td><td class="desc">SSH-indicator tests (mocks <code>tmux</code>+<code>ps</code> via PATH shim, asserts globe glyph emission)</td></tr>
 </table>
 
 <footer>

--- a/scripts/test-tmux-ssh-indicator.sh
+++ b/scripts/test-tmux-ssh-indicator.sh
@@ -1,0 +1,219 @@
+#!/opt/homebrew/bin/bash
+# Smoke tests for tmux-ssh-indicator.
+#
+# Each test creates a tmpdir with mock `tmux` and `ps` binaries, prepends
+# it to PATH, runs the script under test, and asserts the output. Mocks
+# read fixture files (client list, ps table) prepared per-test.
+set -euo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO/.config/tmux/bin/tmux-ssh-indicator"
+
+# Globe glyph as raw UTF-8 (U+F0AC, nf-fa-globe). Must match the helper.
+GLYPH=$(printf '\xef\x82\xac')
+EXPECT_SSH="$GLYPH "  # glyph + single space
+
+pass=0
+fail=0
+fail_msgs=()
+
+check() {
+  local name="$1"; shift
+  if "$@"; then
+    printf 'PASS  %s\n' "$name"
+    pass=$((pass + 1))
+  else
+    printf 'FAIL  %s\n' "$name"
+    fail=$((fail + 1))
+    fail_msgs+=("$name")
+  fi
+}
+
+# Build mock tmux + ps in $1 (a tmpdir).
+#   $2 = path to a file containing client PIDs (one per line; may be empty)
+#   $3 = path to a file containing "pid ppid comm" rows for `ps` to answer
+build_shim() {
+  local dir="$1" clients="$2" table="$3"
+
+  cat > "$dir/tmux" <<EOF
+#!/opt/homebrew/bin/bash
+if [ "\$1" = "list-clients" ]; then
+  cat "$clients"
+fi
+EOF
+  chmod +x "$dir/tmux"
+
+  cat > "$dir/ps" <<EOF
+#!/opt/homebrew/bin/bash
+# Minimal mock of \`ps -p <pid> -o ppid=,comm=\`.
+target=""
+while [ \$# -gt 0 ]; do
+  case "\$1" in
+    -p) target="\$2"; shift 2 ;;
+    -o) shift 2 ;;
+    *)  shift ;;
+  esac
+done
+[ -n "\$target" ] || exit 1
+while IFS=' ' read -r pid ppid comm; do
+  if [ "\$pid" = "\$target" ]; then
+    printf '%s %s\n' "\$ppid" "\$comm"
+    exit 0
+  fi
+done < "$table"
+exit 1
+EOF
+  chmod +x "$dir/ps"
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: no attached clients -> empty output
+# ---------------------------------------------------------------------------
+test_no_clients() {
+  local dir; dir=$(mktemp -d)
+  # shellcheck disable=SC2064
+  trap "rm -rf '$dir'" RETURN
+  : > "$dir/clients"
+  : > "$dir/table"
+  build_shim "$dir" "$dir/clients" "$dir/table"
+  local out
+  out=$(PATH="$dir:$PATH" "$SCRIPT")
+  [ -z "$out" ] || { echo "  expected empty, got: $(printf %q "$out")"; return 1; }
+}
+check "no attached clients -> empty output" test_no_clients
+
+# ---------------------------------------------------------------------------
+# Test 2: one client whose ancestry includes sshd -> glyph + space
+# ---------------------------------------------------------------------------
+test_ssh_ancestor() {
+  local dir; dir=$(mktemp -d)
+  # shellcheck disable=SC2064
+  trap "rm -rf '$dir'" RETURN
+  printf '%s\n' "1001" > "$dir/clients"
+  cat > "$dir/table" <<'EOF'
+1001 900 tmux
+900 800 zsh
+800 700 sshd
+700 1 launchd
+EOF
+  build_shim "$dir" "$dir/clients" "$dir/table"
+  local out
+  out=$(PATH="$dir:$PATH" "$SCRIPT")
+  [ "$out" = "$EXPECT_SSH" ] || { echo "  expected glyph+space, got: $(printf %q "$out")"; return 1; }
+}
+check "client ancestry through sshd -> glyph + space" test_ssh_ancestor
+
+# ---------------------------------------------------------------------------
+# Test 3: ancestry rooted in sshd-session (modern macOS naming) -> glyph
+# ---------------------------------------------------------------------------
+test_sshd_session_ancestor() {
+  local dir; dir=$(mktemp -d)
+  # shellcheck disable=SC2064
+  trap "rm -rf '$dir'" RETURN
+  printf '%s\n' "2001" > "$dir/clients"
+  cat > "$dir/table" <<'EOF'
+2001 1900 tmux
+1900 1800 zsh
+1800 1700 sshd-session
+1700 1 launchd
+EOF
+  build_shim "$dir" "$dir/clients" "$dir/table"
+  local out
+  out=$(PATH="$dir:$PATH" "$SCRIPT")
+  [ "$out" = "$EXPECT_SSH" ] || { echo "  expected glyph+space, got: $(printf %q "$out")"; return 1; }
+}
+check "client ancestry through sshd-session -> glyph + space" test_sshd_session_ancestor
+
+# ---------------------------------------------------------------------------
+# Test 4: only-local ancestry -> empty
+# ---------------------------------------------------------------------------
+test_local_only() {
+  local dir; dir=$(mktemp -d)
+  # shellcheck disable=SC2064
+  trap "rm -rf '$dir'" RETURN
+  printf '%s\n' "3001" > "$dir/clients"
+  cat > "$dir/table" <<'EOF'
+3001 2900 tmux
+2900 2800 zsh
+2800 2700 login
+2700 1 launchd
+EOF
+  build_shim "$dir" "$dir/clients" "$dir/table"
+  local out
+  out=$(PATH="$dir:$PATH" "$SCRIPT")
+  [ -z "$out" ] || { echo "  expected empty, got: $(printf %q "$out")"; return 1; }
+}
+check "local-only ancestry -> empty output" test_local_only
+
+# ---------------------------------------------------------------------------
+# Test 5: two clients, one local + one SSH -> glyph + space
+# ---------------------------------------------------------------------------
+test_mixed_clients() {
+  local dir; dir=$(mktemp -d)
+  # shellcheck disable=SC2064
+  trap "rm -rf '$dir'" RETURN
+  printf '%s\n%s\n' "4001" "4002" > "$dir/clients"
+  cat > "$dir/table" <<'EOF'
+4001 3900 tmux
+3900 3800 zsh
+3800 3700 login
+3700 1 launchd
+4002 3500 tmux
+3500 3400 zsh
+3400 3300 sshd
+3300 1 launchd
+EOF
+  build_shim "$dir" "$dir/clients" "$dir/table"
+  local out
+  out=$(PATH="$dir:$PATH" "$SCRIPT")
+  [ "$out" = "$EXPECT_SSH" ] || { echo "  expected glyph+space, got: $(printf %q "$out")"; return 1; }
+}
+check "mixed local + SSH clients -> glyph + space" test_mixed_clients
+
+# ---------------------------------------------------------------------------
+# Test 6: full-path comm (basename match defends against absolute paths)
+# ---------------------------------------------------------------------------
+test_fullpath_comm() {
+  local dir; dir=$(mktemp -d)
+  # shellcheck disable=SC2064
+  trap "rm -rf '$dir'" RETURN
+  printf '%s\n' "5001" > "$dir/clients"
+  cat > "$dir/table" <<'EOF'
+5001 4900 tmux
+4900 4800 zsh
+4800 4700 /usr/sbin/sshd
+4700 1 launchd
+EOF
+  build_shim "$dir" "$dir/clients" "$dir/table"
+  local out
+  out=$(PATH="$dir:$PATH" "$SCRIPT")
+  [ "$out" = "$EXPECT_SSH" ] || { echo "  expected glyph+space, got: $(printf %q "$out")"; return 1; }
+}
+check "absolute-path comm '/usr/sbin/sshd' still matches via basename" test_fullpath_comm
+
+# ---------------------------------------------------------------------------
+# Test 7: ps cycle (ppid points back to seen pid) -> loop guard, empty
+# ---------------------------------------------------------------------------
+test_ps_cycle() {
+  local dir; dir=$(mktemp -d)
+  # shellcheck disable=SC2064
+  trap "rm -rf '$dir'" RETURN
+  printf '%s\n' "6001" > "$dir/clients"
+  cat > "$dir/table" <<'EOF'
+6001 6002 tmux
+6002 6001 zsh
+EOF
+  build_shim "$dir" "$dir/clients" "$dir/table"
+  local out
+  out=$(PATH="$dir:$PATH" "$SCRIPT")
+  [ -z "$out" ] || { echo "  expected empty (loop guard), got: $(printf %q "$out")"; return 1; }
+}
+check "ps cycle (ppid loops back) -> loop guard, empty output" test_ps_cycle
+
+# ---------------------------------------------------------------------------
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+if [ "$fail" -gt 0 ]; then
+  printf 'Failed:\n'
+  for msg in "${fail_msgs[@]}"; do printf '  - %s\n' "$msg"; done
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- New helper `~/.config/tmux/bin/tmux-ssh-indicator` walks each attached tmux client's parent-process chain (`ps -p <pid> -o ppid=,comm=`) and emits a Nerd Font globe glyph (`` U+F0AC `nf-fa-globe`) plus a single space when any ancestor is `sshd` / `sshd-session`. The glyph inherits the existing blue session-chip styling — no color flip, presence/absence is the signal.
- Wired into `status-left` via `#(~/.config/tmux/bin/tmux-ssh-indicator)`. Refresh piggybacks on the existing 5 s `status-interval`.
- Detection is server-wide rather than per-client (a single `#(...)` runs server-global). For a single-user Mac with one attached client at a time this is accurate enough; a per-client design would need `client-attached` / `client-detached` hooks plus a per-client option, which is more moving parts than the use case warrants.
- Env-var detection (`$SSH_CONNECTION`) intentionally not used — it lives in the SSH-spawned shell's env, not the tmux server's, so `#(...)` calls never see it.
- Mosh is intentionally not detected (mosh sessions root in `mosh-server`, not `sshd`).
- New smoke test `scripts/test-tmux-ssh-indicator.sh` mocks `tmux` and `ps` via a temp `$PATH` shim and asserts: no clients, sshd ancestor, sshd-session ancestor, local-only, mixed local + SSH, absolute-path comm basename match, and `ps` cycle (loop guard).
- CLAUDE.md and `docs/tmux-cheatsheet.html` updated to document the chip variant, the new helper, and the new test script.

## Test plan

- [x] `scripts/test-tmux-ssh-indicator.sh` — 7/7 PASS locally.
- [ ] Reload tmux config and verify the chip is unchanged for a local attach.
- [ ] Attach over SSH from another machine; verify the leading globe glyph appears within ~5 s.
- [ ] Detach the SSH client; verify the glyph disappears within ~5 s.