### PR TITLE
tmux: fix SSH indicator on macOS (use ucomm, not comm)

### DIFF
--- a/.config/tmux/bin/tmux-ssh-indicator
+++ b/.config/tmux/bin/tmux-ssh-indicator
@@ -27,21 +27,27 @@ MAX_DEPTH=20
 # `sshd` or `sshd-session` ancestor. Returns 1 otherwise. Stops at depth
 # MAX_DEPTH or when ppid is 0 / 1 / equals self / cycles back to a seen pid.
 #
+# Uses `ps -o ucomm=` (kernel-recorded short command name), not `comm=`.
+# On macOS, `comm` for sshd's privsep children renders as the descriptive
+# argv string (e.g. `sshd-session: martinciu@ttys008`, `sshd-session:
+# martinciu [priv]`), which never basename-equals `sshd-session`. `ucomm`
+# always returns the executable basename, so the case match below is exact.
+#
 # Implemented as a single function (no pipeline to a separate matcher) so
 # we don't have to reason about SIGPIPE semantics under `set -o pipefail`.
 client_is_ssh() {
   local pid="$1"
   local depth=0
   local seen=" "
-  local row ppid comm
+  local row ppid ucomm
   while [ "$depth" -lt "$MAX_DEPTH" ]; do
-    row=$(ps -p "$pid" -o ppid=,comm= 2>/dev/null) || return 1
+    row=$(ps -p "$pid" -o ppid=,ucomm= 2>/dev/null) || return 1
     [ -z "$row" ] && return 1
     # `read` collapses leading whitespace (macOS ps right-pads ppid) and
-    # splits the first run of whitespace as the ppid/comm boundary.
-    read -r ppid comm <<<"$row"
+    # splits the first run of whitespace as the ppid/ucomm boundary.
+    read -r ppid ucomm <<<"$row"
     [ -z "$ppid" ] && return 1
-    case "$(basename -- "$comm")" in
+    case "$ucomm" in
       sshd|sshd-session) return 0 ;;
     esac
     case "$seen" in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,9 +41,14 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
 - **SSH indicator on the session chip** is wired into `status-left` via
   `#(~/.config/tmux/bin/tmux-ssh-indicator)`. The helper walks each
   attached client's parent-process chain on macOS using
-  `ps -p <pid> -o ppid=,comm=` and emits a Nerd Font globe glyph (``
+  `ps -p <pid> -o ppid=,ucomm=` and emits a Nerd Font globe glyph (``
   `nf-fa-globe`, U+F0AC) plus a single space when any ancestor is `sshd`
-  or `sshd-session`. The glyph inherits the chip's `fg=#fdf6e3,bg=#268bd2`
+  or `sshd-session`. **Use `ucomm`, not `comm`.** macOS `ps -o comm=`
+  for sshd's privsep children renders the descriptive argv string
+  (e.g. `sshd-session: martinciu@ttys008`, `sshd-session: martinciu [priv]`),
+  which never basename-equals `sshd-session` and would silently never
+  match. `ucomm` is the kernel-recorded short executable name and is
+  always the clean basename. The glyph inherits the chip's `fg=#fdf6e3,bg=#268bd2`
   styling — no color flip, presence/absence is the signal. Detection is
   server-wide (any attached client is SSH → indicator on), not
   per-client: `#(...)` shells run server-global. For a single-user Mac

--- a/scripts/test-tmux-ssh-indicator.sh
+++ b/scripts/test-tmux-ssh-indicator.sh
@@ -45,7 +45,7 @@ EOF
 
   cat > "$dir/ps" <<EOF
 #!/opt/homebrew/bin/bash
-# Minimal mock of \`ps -p <pid> -o ppid=,comm=\`.
+# Minimal mock of \`ps -p <pid> -o ppid=,ucomm=\`.
 target=""
 while [ \$# -gt 0 ]; do
   case "\$1" in
@@ -55,9 +55,53 @@ while [ \$# -gt 0 ]; do
   esac
 done
 [ -n "\$target" ] || exit 1
-while IFS=' ' read -r pid ppid comm; do
+while IFS=' ' read -r pid ppid ucomm; do
   if [ "\$pid" = "\$target" ]; then
-    printf '%s %s\n' "\$ppid" "\$comm"
+    printf '%s %s\n' "\$ppid" "\$ucomm"
+    exit 0
+  fi
+done < "$table"
+exit 1
+EOF
+  chmod +x "$dir/ps"
+}
+
+# Build a dual-field mock that distinguishes \`ps -o ucomm=\` (basename) from
+# \`-o comm=\` (full argv-rendered string). Used by the macOS-quirk regression
+# test below. Fixture rows are "pid ppid ucomm comm-rest..." — first three
+# tokens are pid/ppid/ucomm, rest of the line is comm.
+build_shim_dual_field() {
+  local dir="$1" clients="$2" table="$3"
+
+  cat > "$dir/tmux" <<EOF
+#!/opt/homebrew/bin/bash
+if [ "\$1" = "list-clients" ]; then
+  cat "$clients"
+fi
+EOF
+  chmod +x "$dir/tmux"
+
+  cat > "$dir/ps" <<EOF
+#!/opt/homebrew/bin/bash
+target=""
+flag=""
+while [ \$# -gt 0 ]; do
+  case "\$1" in
+    -p) target="\$2"; shift 2 ;;
+    -o) flag="\$2"; shift 2 ;;
+    *)  shift ;;
+  esac
+done
+[ -n "\$target" ] || exit 1
+while IFS= read -r line; do
+  [ -z "\$line" ] && continue
+  read -r pid ppid ucomm comm <<<"\$line"
+  if [ "\$pid" = "\$target" ]; then
+    case "\$flag" in
+      *ucomm*) printf '%s %s\n' "\$ppid" "\$ucomm" ;;
+      *comm*)  printf '%s %s\n' "\$ppid" "\$comm" ;;
+      *)       printf '%s %s\n' "\$ppid" "\$ucomm" ;;
+    esac
     exit 0
   fi
 done < "$table"
@@ -171,25 +215,31 @@ EOF
 check "mixed local + SSH clients -> glyph + space" test_mixed_clients
 
 # ---------------------------------------------------------------------------
-# Test 6: full-path comm (basename match defends against absolute paths)
+# Test 6: macOS regression — sshd-session privsep child renders its argv
+# string in `comm` (e.g. "sshd-session: martinciu@ttys008"), but `ucomm`
+# returns the clean basename "sshd-session". Script must detect the SSH
+# ancestry from `ucomm`. This case is what made the original PR ship a
+# silent no-op on real machines — the prior tests all used clean comm
+# strings the in-memory mock returned verbatim, missing the divergence.
 # ---------------------------------------------------------------------------
-test_fullpath_comm() {
+test_macos_sshd_session_argv_rendering() {
   local dir; dir=$(mktemp -d)
   # shellcheck disable=SC2064
   trap "rm -rf '$dir'" RETURN
   printf '%s\n' "5001" > "$dir/clients"
+  # Fixture columns: pid ppid ucomm comm-rest...
   cat > "$dir/table" <<'EOF'
-5001 4900 tmux
-4900 4800 zsh
-4800 4700 /usr/sbin/sshd
-4700 1 launchd
+5001 4900 tmux tmux
+4900 4800 zsh -zsh
+4800 4700 sshd-session sshd-session: martinciu@ttys008
+4700 1 sshd-session sshd-session: martinciu [priv]
 EOF
-  build_shim "$dir" "$dir/clients" "$dir/table"
+  build_shim_dual_field "$dir" "$dir/clients" "$dir/table"
   local out
   out=$(PATH="$dir:$PATH" "$SCRIPT")
   [ "$out" = "$EXPECT_SSH" ] || { echo "  expected glyph+space, got: $(printf %q "$out")"; return 1; }
 }
-check "absolute-path comm '/usr/sbin/sshd' still matches via basename" test_fullpath_comm
+check "macOS sshd-session: clean ucomm matches despite descriptive comm" test_macos_sshd_session_argv_rendering
 
 # ---------------------------------------------------------------------------
 # Test 7: ps cycle (ppid points back to seen pid) -> loop guard, empty


### PR DESCRIPTION
## Summary

- Follow-up to #88. The merged SSH indicator silently never fired on real macOS attaches because `ps -p <pid> -o comm=` for sshd's privilege-separation children renders the descriptive argv string, e.g. `sshd-session: martinciu@ttys008` and `sshd-session: martinciu [priv]`. `basename` is a no-op on a string with no `/`, so the `case sshd|sshd-session)` match never hit.
- Switch the helper to `-o ucomm=` (the kernel-recorded short executable name, which is always the clean basename) and drop the now-redundant `basename --` call.
- Update CLAUDE.md to document the choice and the macOS quirk so this doesn't regress.
- Test suite: drop the obsolete absolute-path-comm test (ucomm never returns paths), add a dual-field mock that distinguishes `-o ucomm=` from `-o comm=`, and add a regression test that feeds real macOS-style data — descriptive `comm`, clean `ucomm` — to prove the fix sticks.

## Diagnosis (live, on this machine)

```
$ /bin/ps -p 78863 -o ucomm=,comm=,command=
sshd-session     sshd-session: ma sshd-session: martinciu@ttys008
$ /bin/ps -p 78860 -o ucomm=,comm=,command=
sshd-session     sshd-session: ma sshd-session: martinciu [priv]
```

`ucomm` is the binary basename. `comm` is the argv-rendered descriptive string. The PR's mock emitted clean `comm` (`sshd-session`), so all 7 tests passed in CI, but no real-world ssh attach ever produced that output.

## Test plan

- [x] `scripts/test-tmux-ssh-indicator.sh` — 7/7 PASS (one test rotated from absolute-path-comm to a macOS-quirk regression).
- [x] Live verification on this machine: SSH'd in via a separate client, ran the helper standalone, confirmed `ef82 ac 20` (globe + space) bytes are emitted; `tmux refresh-client -S` makes the chip update within the existing 5 s status interval.
- [x] On the local-attached client side, verify the chip stays unchanged (no globe).