### PR TITLE
Add hyperfine for command benchmarking (additive to time)

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -39,8 +39,9 @@ brew "zsh-autosuggestions"      # ghost-text completion from history
 brew "fzf-tab"                  # fzf-driven Tab completion menu
 brew "lnav"                     # TUI log file navigator
 
-# System monitoring
+# System monitoring & benchmarking
 brew "btop"                     # modern top replacement (themed Solarized)
+brew "hyperfine"                # command benchmarking (warmups, multi-run stats)
 
 # Fonts
 cask "font-jetbrains-mono-nerd-font"  # Solarized + JetBrainsMono Nerd Font everywhere (CLAUDE.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -361,6 +361,23 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
   `curl` stays available verbatim for scripts and CI. **Don't add an
   `http`/`https` alias** either; the rule is "no synonyms, just the
   binary's name". No `.zshrc` change for this tool.
+- **`hyperfine` is the benchmark tool, additive to `time`** (homebrew
+  `hyperfine`; raw command, no alias, no wrapper, no shell-config). `time`
+  (zsh builtin / `/usr/bin/time`) stays the default for one-shot wall-clock
+  measurements; reach for `hyperfine` when you need warmups, multiple runs,
+  or A/B comparisons (`hyperfine 'cmd-a' 'cmd-b'` produces a relative
+  summary). Output is ANSI-colored and inherits Ghostty's Solarized
+  palette — there is no static config file format (CLI flags only), so no
+  theme pin is needed. **Deliberately NOT in the modern-reminder catalog.**
+  The catalog's inclusion criterion is "modern alternative for the same
+  use case" (`tail`/`tspin`, `grep`/`rg`, `curl`/`xh` are 1:1 same-use
+  swaps); `time foo` runs once, `hyperfine 'foo'` benchmarks N times with
+  warmups — different use cases, not the same use case. A reminder firing
+  after every `time` invocation would mis-fire on most of them. This is
+  the explicit-rejection record so the next "modern alternative" candidate
+  can re-use the same evaluation. Don't alias `time` to `hyperfine`, don't
+  ship a wrapper that pins `--warmup` defaults (warmup count is workload-
+  specific — wrong as often as right). No `.zshrc` change for this tool.
 - **`modern-reminder` is a zsh-level discoverability nudge** for default→modern
   tool pairs that this setup intentionally leaves *unaliased* (the "no synonyms,
   just the binary's name" pattern shared by `tail`/`tspin`, `grep`/`rg`, and

--- a/docs/terminal-cheatsheet.html
+++ b/docs/terminal-cheatsheet.html
@@ -488,6 +488,46 @@
 </div>
 
 <!-- ═══════════════════════════════════════════════════════════════════════ -->
+<h2 id="hyperfine">hyperfine <span class="tool-tag">command benchmarking</span></h2>
+
+<div class="grid">
+  <div class="card">
+    <h3>Most-used invocations</h3>
+    <table>
+      <tr><th>Command</th><th>What it does</th></tr>
+      <tr><td><code>hyperfine 'cmd'</code></td><td>10 runs, no warmup, summary with mean/stddev</td></tr>
+      <tr><td><code>hyperfine --warmup 3 'cmd'</code></td><td>discard 3 warmup runs first (cache, JIT)</td></tr>
+      <tr><td><code>hyperfine 'a' 'b'</code></td><td>A/B compare; prints "X is N× faster than Y"</td></tr>
+      <tr><td><code>hyperfine -N 'cmd'</code></td><td>skip shell wrapper; measure binary directly</td></tr>
+      <tr><td><code>hyperfine --export-markdown out.md 'cmd'</code></td><td>share results in markdown</td></tr>
+    </table>
+  </div>
+
+  <div class="card">
+    <h3>When to reach for it vs <code>time</code></h3>
+    <p>
+      <code>time</code> (zsh builtin / <code>/usr/bin/time</code>) is the right tool for
+      one-shot wall-clock measurements — scripts, CI, "did this finish quickly?".
+      Reach for <code>hyperfine</code> when you want warmups, multiple runs, variance
+      characterization, or A/B comparison.
+    </p>
+    <p class="note">
+      Deliberately not aliased to <code>time</code> — semantics differ. See
+      CLAUDE.md for the catalog-rejection rationale.
+    </p>
+  </div>
+
+  <div class="card">
+    <h3>Caveats</h3>
+    <p>
+      First run includes filesystem cold-cache effects. Use <code>--warmup N</code>
+      or <code>--prepare 'sync'</code> to control. macOS <code>purge</code> needs
+      <code>sudo</code> if you want to flush page cache between runs.
+    </p>
+  </div>
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════════════════ -->
 <h2 id="modern-reminder">modern-reminder <span class="tool-tag">discoverability nudge</span></h2>
 
 <div class="grid">
@@ -716,7 +756,7 @@
 </ol>
 
 <footer>
-  Built from <code>~/.zshrc</code>, <code>Brewfile</code>, and project CLAUDE.md on 2026-05-03.
+  Built from <code>~/.zshrc</code>, <code>Brewfile</code>, and project CLAUDE.md on 2026-05-04.
   Refresh after meaningful color-tooling changes.
 </footer>
 


### PR DESCRIPTION
## Summary

Adds [`hyperfine`](https://github.com/sharkdp/hyperfine) as an **additive** benchmarking tool alongside the shell builtin `time`. `time` stays the default for one-shot wall-clock measurements; `hyperfine` covers warmups, multi-run statistics, and A/B command comparison.

- Brewfile: `brew "hyperfine"` under a renamed `# System monitoring & benchmarking` section.
- CLAUDE.md: convention bullet recording that hyperfine is **deliberately NOT in the modern-reminder catalog** — semantics differ from `time` (one-shot vs N-run benchmark). Bullet doubles as the explicit-rejection precedent for future "modern alternative" candidates.
- `docs/terminal-cheatsheet.html`: dedicated `<h2 id="hyperfine">` section with three cards (most-used invocations, when to reach for it vs `time`, caveats). Footer date refreshed.

No `.zshrc` changes, no `.config/hyperfine/*`, no helper script, no test script. hyperfine has no static config file format (CLI flags only) and its ANSI output already inherits Ghostty's Solarized palette.

Closes #52.

## Test plan

- [ ] \`brew bundle check --file=./Brewfile --verbose\` reports hyperfine satisfied (or missing then satisfied after \`brew bundle\`)
- [ ] \`hyperfine --version\` prints a v1.x release line
- [ ] \`hyperfine 'sleep 0.1' 'sleep 0.2'\` prints a relative summary ("…ran ~2× faster than…")
- [ ] \`open docs/terminal-cheatsheet.html\` — new hyperfine section renders with sibling rhythm; footer reads 2026-05-04
- [ ] CLAUDE.md grep ordering: \`xh\` → \`hyperfine\` → \`modern-reminder\` bullets
- [ ] No other files changed