### PR TITLE
gitignore: ignore .claude/scheduled_tasks.lock

### DIFF
--- a/.gitignore_global
+++ b/.gitignore_global
@@ -4,6 +4,7 @@
 .claude/worktrees/
 .claude/logs/
 .claude/.credentials.json
+.claude/scheduled_tasks.lock
 
 # Planning artefacts and tooling state
 # (per ~/.claude/CLAUDE.md — never committed in any repo)


### PR DESCRIPTION
## Summary
- Add `.claude/scheduled_tasks.lock` to the global gitignore so Claude Code's scheduled-tasks lock file is never committed in any repo on this machine.

## Test plan
- [ ] Confirm `.claude/scheduled_tasks.lock` is ignored in a repo where it appears.