### PR TITLE
worktrunk: pre-remove uses wt step copy-ignored symmetrically

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -47,9 +47,11 @@ Why: worktrunk's lifecycle hooks (`pre-start`, `post-start`,
 setup relies on them — `[post-start] copy = "wt step copy-ignored"`
 carries gitignored content (`.superpowers/`, `.autonomo/`,
 `.claude/settings.local.json`, etc.) into new worktrees, and
-`[pre-remove] save-shared` rsyncs `.superpowers/` and `.autonomo/`
-back to the primary worktree before deletion. Bypassing `wt`
-silently skips both, which usually means lost specs/plans/logs.
+`[pre-remove] save-shared` runs `wt step copy-ignored` in reverse
+to flow gitignored content (specs, plans, autonomo logs,
+`autonomo-workspace/`, anything else gitignored) back to the
+primary worktree before deletion. Bypassing `wt` silently skips
+both, which usually means lost specs/plans/logs.
 
 How to apply: when a task says "spawn a worktree for X", "switch
 to the foo worktree", or "remove/cleanup the worktree", reach for

--- a/.config/worktrunk/config.toml
+++ b/.config/worktrunk/config.toml
@@ -255,11 +255,20 @@ copy = "wt step copy-ignored"
 
 # Before wt remove deletes a worktree, save any new gitignored
 # content (planning artefacts under .superpowers/, autonomo logs
-# under .autonomo/) back to the primary worktree. `rsync
-# --ignore-existing` only copies files absent from primary — never
-# clobbers. Combined with [post-start] copy above, gitignored state
-# flows: primary → worktree on create, worktree → primary on remove.
-# Existing-but-diverged files are dropped on remove (acceptable for
-# the write-once artefacts these dirs hold).
+# under .autonomo/, and any other gitignored top-level dirs the
+# worktree picked up during its lifetime) back to the primary
+# worktree. Mirrors the [post-start] hook above: same `wt step
+# copy-ignored`, same default-skip-existing semantics — files
+# present on primary are never overwritten. `-C {{ main_worktree_path }}`
+# sets wt's cwd to primary so --to defaults to primary's worktree
+# without needing primary's branch name (no {{ primary_branch }}
+# template variable exists in pre-remove).
+#
+# Caveat: the same exclude config applies to both directions, so
+# bulky derived-state dirs (node_modules/, target/, .next/, dist/)
+# carried IN on post-start will also flow OUT on pre-remove if they
+# diverged in the worktree. Accepted trade-off — package-manager
+# operations inside worktrees are rare; if it bites, revisit
+# (see .superpowers/specs/2026-05-04-wt-pre-remove-symmetric-copy-ignored-design.md).
 [pre-remove]
-save-shared = "for d in .superpowers .autonomo; do [ -d \"$d\" ] || continue; rsync -a --ignore-existing \"$d/\" \"{{ primary_worktree_path }}/$d/\"; done"
+save-shared = "wt -C {{ main_worktree_path }} step copy-ignored --from {{ branch }}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,15 +205,24 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
   Per-project hook approvals (`approvals.toml`) are machine-local and
   gitignored.
 - **Gitignored content flows between primary and worktrees in two
-  stages.** `[post-start] copy = "wt step copy-ignored"` copies primary's
-  gitignored content into a new worktree at creation.
-  `[pre-remove] save-shared` rsyncs `.superpowers/` and `.autonomo/`
-  back to primary just before `wt remove`, using `--ignore-existing` so
-  primary is never clobbered (files that exist in both are preserved as
-  primary's version). Net: write-once artefacts (specs, plans, autonomo
-  logs) survive `wt remove`; diverged files in the worktree are dropped
-  on remove. Don't reintroduce per-path symlink hooks (the previous
-  `share-tmp` design) without explicit ask — keep this simple.
+  stages, both using `wt step copy-ignored`.** `[post-start] copy = "wt step copy-ignored"`
+  reflinks primary's gitignored content into a new worktree at
+  creation. `[pre-remove] save-shared = "wt -C {{ main_worktree_path }} step copy-ignored --from {{ branch }}"`
+  reflinks the worktree's gitignored content back to primary just
+  before `wt remove`. Default no-`--force` semantics on both: files
+  that already exist in the destination are never overwritten —
+  primary's specs/plans/logs are safe from a worktree's diverged
+  copies, and the worktree starts cold-free with primary's exact
+  state. Auto-discovers any new gitignored top-level dir (e.g.
+  `autonomo-workspace/`) — no per-path hook edits needed when a new
+  tool drops state. Caveat: `step.copy-ignored.exclude` is shared
+  across both directions, so derived-state dirs (`node_modules/`,
+  `target/`, `.next/`, `dist/`) carried in on post-start will also
+  flow back on pre-remove if a worktree mutated them via
+  `npm install` / `cargo build` / etc. Accepted trade-off — see
+  the design doc referenced from `config.toml`. Don't reintroduce
+  per-path symlink hooks (the previous `share-tmp` design) without
+  explicit ask — keep this simple.
 - **Worktree status segment** uses `git rev-parse --git-dir` vs
   `--git-common-dir` for detection (works for `.claude/worktrees/*`,
   worktrunk paths, sibling worktrees alike). Don't replace with

--- a/scripts/test-wt-pre-remove-save.sh
+++ b/scripts/test-wt-pre-remove-save.sh
@@ -1,23 +1,25 @@
 #!/opt/homebrew/bin/bash
 # Smoke test for the [pre-remove] save-shared hook in
 # .config/worktrunk/config.toml. Extracts the hook command from
-# config.toml, substitutes the {{ primary_worktree_path }} template,
-# and exercises it in a temp repo. Asserts:
+# config.toml, substitutes the {{ main_worktree_path }} and
+# {{ branch }} templates, and exercises it against a real worktree.
+# Asserts:
 #   - new files in worktree get copied to primary
-#   - primary's pre-existing files are NOT clobbered
-#   - missing dirs in worktree are skipped (not errors)
+#   - primary's pre-existing files are NOT clobbered (no overwrite)
+#   - new gitignored top-level dirs in worktree are created on primary
+#     with their contents (the case issue #94 is about — e.g.
+#     autonomo-workspace/ with no per-hook edit)
 
 set -euo pipefail
 
 DOTFILES="$(cd "$(dirname "$0")/.." && pwd)"
 CONFIG="$DOTFILES/.config/worktrunk/config.toml"
 
-command -v rsync >/dev/null || { echo "FAIL: rsync not installed" >&2; exit 1; }
+command -v wt >/dev/null || { echo "FAIL: wt not installed" >&2; exit 1; }
 
 # Extract the save-shared hook command from config.toml.
 # Strip the `save-shared = "…"` wrapper, then un-escape TOML's `\"` so
-# the bash-c invocation below sees real quote characters (not literal
-# backslash-quotes that would end up inside the path argument).
+# bash -c below sees real quote characters.
 hook_cmd=$(grep -E '^save-shared = ' "$CONFIG" | sed -E 's/^save-shared = "(.*)"$/\1/; s/\\"/"/g')
 if [ -z "$hook_cmd" ]; then
   echo "FAIL: save-shared hook not found in $CONFIG" >&2
@@ -25,26 +27,66 @@ if [ -z "$hook_cmd" ]; then
 fi
 
 TMPDIR=$(mktemp -d)
-trap 'rm -rf "$TMPDIR"' EXIT
+# Use realpath so paths match what `wt` and `git` report (macOS symlinks
+# /tmp → /private/tmp and /var/folders → /private/var/folders).
+TMPDIR=$(cd "$TMPDIR" && pwd -P)
+
+cleanup() {
+  # Best-effort cleanup. --no-hooks skips the user's [pre-remove] hook
+  # so cleanup doesn't re-run the very thing we just tested.
+  if [ -n "${PRIMARY:-}" ] && [ -d "$PRIMARY" ]; then
+    ( cd "$PRIMARY" && wt remove feature -y --no-hooks >/dev/null 2>&1 ) || true
+  fi
+  rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
 
 PRIMARY="$TMPDIR/primary"
-WORKTREE="$TMPDIR/worktree"
+git init -q "$PRIMARY"
+git -C "$PRIMARY" config user.email t@t.t
+git -C "$PRIMARY" config user.name t
+echo "tracked" > "$PRIMARY/tracked.txt"
+cat > "$PRIMARY/.gitignore" <<'EOF'
+.superpowers/
+.autonomo/
+autonomo-workspace/
+EOF
+git -C "$PRIMARY" add -A
+git -C "$PRIMARY" commit -qm init
 
-# Primary has an existing spec that must NOT be clobbered.
+# Primary fixture: existing spec that must NOT be clobbered.
 mkdir -p "$PRIMARY/.superpowers/specs"
 echo "ORIGINAL" > "$PRIMARY/.superpowers/specs/keep.md"
 
-# Worktree has: a diverged copy of keep.md (must be dropped),
-# a new spec (must land in primary), and a new autonomo log in
-# a dir that primary doesn't yet have.
+# Create a real feature worktree via wt. -y bypasses approval prompts;
+# --no-hooks suppresses the user's [post-start] (which would otherwise
+# race with the worktree fixture writes below).
+( cd "$PRIMARY" && wt switch --create feature -y --no-hooks >/dev/null 2>&1 )
+WORKTREE="$PRIMARY/.claude/worktrees/feature"
+[ -d "$WORKTREE" ] || { echo "FAIL: worktree not created at $WORKTREE" >&2; exit 1; }
+
+# Worktree fixtures:
+#   - diverged keep.md (must be DROPPED — primary's stays "ORIGINAL")
+#   - new spec new.md (must MIGRATE to primary)
+#   - new dir .autonomo/ with content (must MIGRATE — primary has no .autonomo/ yet)
+#   - new dir autonomo-workspace/ with content (must MIGRATE — issue #94's case)
 mkdir -p "$WORKTREE/.superpowers/specs"
 echo "DIVERGED" > "$WORKTREE/.superpowers/specs/keep.md"
 echo "NEW SPEC" > "$WORKTREE/.superpowers/specs/new.md"
 mkdir -p "$WORKTREE/.autonomo"
 echo "log line" > "$WORKTREE/.autonomo/run-1.log"
+mkdir -p "$WORKTREE/autonomo-workspace/iter-1"
+echo "trace" > "$WORKTREE/autonomo-workspace/iter-1/trace.json"
 
-# Substitute the template variable, then run the hook in worktree's cwd.
-substituted="${hook_cmd//\{\{ primary_worktree_path \}\}/$PRIMARY}"
+# Substitute template variables. Cover both old and new hook variable names
+# so the test infrastructure is forward-compatible across the hook change.
+substituted="$hook_cmd"
+substituted="${substituted//\{\{ primary_worktree_path \}\}/$PRIMARY}"
+substituted="${substituted//\{\{ main_worktree_path \}\}/$PRIMARY}"
+substituted="${substituted//\{\{ branch \}\}/feature}"
+
+# Run the hook from inside the worktree (matches wt's pre-remove behavior:
+# pre-remove "Runs in the worktree being removed").
 ( cd "$WORKTREE" && bash -c "$substituted" )
 
 fail=0
@@ -67,5 +109,8 @@ check "primary's new.md was created with worktree content" \
 check "primary's .autonomo/run-1.log was created" \
       "log line" \
       "$(cat "$PRIMARY/.autonomo/run-1.log" 2>/dev/null)"
+check "primary's autonomo-workspace/iter-1/trace.json was created" \
+      "trace" \
+      "$(cat "$PRIMARY/autonomo-workspace/iter-1/trace.json" 2>/dev/null)"
 
 [ $fail -eq 0 ] && { echo "PASS"; exit 0; } || exit 1


### PR DESCRIPTION
## Summary

- Replace the rsync for-loop in `[pre-remove] save-shared` with `wt -C {{ main_worktree_path }} step copy-ignored --from {{ branch }}`, mirroring the existing `[post-start]` hook.
- Auto-discovers new gitignored top-level dirs (`autonomo-workspace/` is the immediate motivator; future tools' state directories will flow without further hook edits).
- Default no-`--force` preserves the no-overwrite guarantee the rsync `--ignore-existing` flag gave.
- CLAUDE.md (project + user-global) bullets rewritten to describe the new mechanism plus the derived-state caveat (shared exclude config means bulky `node_modules/` / `target/` / `.next/` / `dist/` mutated in a worktree could flow back to primary on `wt remove` — accepted trade-off; design doc cited from `config.toml`).

## Test plan

- [x] `scripts/test-wt-pre-remove-save.sh` rewritten to use a real `wt switch --create` worktree (with `--no-hooks` to avoid background post-start racing the test fixtures) and adds an assertion for `autonomo-workspace/iter-1/trace.json` migrating from worktree → primary (the case issue #94 is fundamentally about). All four checks pass.
- [x] `scripts/test-helpers.sh` still passes (26/26).
- [ ] On first `wt remove` after merge, accept the one-time approval prompt for the new save-shared command (persists to `~/.config/worktrunk/approvals.toml`).

Closes #94