### PR TITLE
Show outbound SSH target on Ghostty tab title

### DIFF
--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -49,6 +49,20 @@ set -g allow-rename off
 set -g automatic-rename on
 set -g automatic-rename-format '#{?#{!=:#{@claude_session_name},},claude[#{@claude_session_name}],#{?#{==:#{@last_cmd},},#{pane_current_command},#{@last_cmd}}}'
 
+# ─── Outer-terminal title (Ghostty tab) ────────
+# Drive the Ghostty tab title from the active pane. While an `ssh` command is
+# foreground in the active pane, render " user@host" — Nerd Font globe (U+F0AC,
+# nf-fa-globe) plus the canonical destination, matching tmux-ssh-indicator's
+# glyph. Otherwise render "<session>:<window>".
+#
+# @ssh_target is set/cleared by the _tmux_record_ssh_target /
+# _tmux_clear_ssh_target zsh hooks (.zshrc); refresh-client -S in those hooks
+# pushes the update instantly rather than waiting for the 5s status-interval
+# tick. The literal globe is embedded as raw UTF-8, same pattern as the glyphs
+# already in status-left.
+set -g set-titles on
+set -g set-titles-string "#{?#{!=:#{@ssh_target},},  #{@ssh_target},#S:#W}"
+
 # ─── Splits keep cwd, mirror Ghostty's bindings ──
 bind | split-window -h -c "#{pane_current_path}"
 bind - split-window -v -c "#{pane_current_path}"

--- a/.zshrc
+++ b/.zshrc
@@ -106,6 +106,36 @@ _tmux_record_last_cmd() {
 }
 add-zsh-hook preexec _tmux_record_last_cmd
 
+# Per-pane SSH-target recorder (Ghostty tab title overlay). preexec stamps
+# @ssh_target with the canonical user@hostname while an `ssh` command is
+# foreground; precmd clears it on the next prompt. tmux.conf's set-titles-string
+# reads @ssh_target so the Ghostty tab shows " user@host" during ssh and
+# falls back to <session>:<window> otherwise. Resolution uses `ssh -G` so
+# ~/.ssh/config Host aliases / default Users canonicalize correctly.
+# Keep in sync with scripts/test-tmux-ssh-target.zsh.
+_tmux_record_ssh_target() {
+  [[ -z ${TMUX:-} ]] && return
+  local -a tokens=(${=1})
+  [[ ${tokens[1]:-} == ssh ]] || return
+  local resolved
+  resolved=$(eval "ssh -G ${1#ssh}" 2>/dev/null) || return
+  local host user
+  host=${${(M)${(f)resolved}:#hostname *}#hostname }
+  user=${${(M)${(f)resolved}:#user *}#user }
+  [[ -n $user && -n $host ]] || return
+  tmux set -p @ssh_target "$user@$host"
+  tmux refresh-client -S
+}
+add-zsh-hook preexec _tmux_record_ssh_target
+
+_tmux_clear_ssh_target() {
+  [[ -z ${TMUX:-} ]] && return
+  [[ -z $(tmux show -p -v @ssh_target 2>/dev/null) ]] && return
+  tmux set -p -u @ssh_target
+  tmux refresh-client -S
+}
+add-zsh-hook precmd _tmux_clear_ssh_target
+
 # modern-reminder (keep in sync with scripts/test-modern-reminder.zsh)
 # One-line nudge after running a default tool whose modern alternative is
 # installed and intentionally unaliased. Once per zsh process, per command.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,33 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
   detection (`$SSH_CONNECTION`) intentionally not used — it's set in
   the SSH-spawned shell's env, not the tmux server's, so `#(...)` calls
   never see it.
+- **Outbound SSH overlay on the Ghostty tab title.** Distinct from the
+  inbound `tmux-ssh-indicator` above: this surfaces *outgoing* `ssh`
+  sessions on the local client's Ghostty tab. While an `ssh` command is
+  foreground in the active pane, the tab renders ` user@host` (Nerd
+  Font globe U+F0AC + canonical destination); otherwise it renders
+  `<session>:<window>`. Wired in `tmux.conf` via `set -g set-titles on`
+  and a `set-titles-string` that branches on the per-pane
+  `@ssh_target` user variable. The pane variable is set/cleared by two
+  zsh hooks in `.zshrc`: `_tmux_record_ssh_target` (preexec) checks
+  whether the first whitespace token of the typed command equals `ssh`
+  (first-token equality, not prefix — excludes `ssh-add`/`ssh-keygen`),
+  resolves the destination via `ssh -G <args>` so `~/.ssh/config` Host
+  aliases and default Users canonicalize, and stamps
+  `@ssh_target=user@host`. `_tmux_clear_ssh_target` (precmd) unsets it
+  on the next prompt. Both hooks call `tmux refresh-client -S` so the
+  tab updates instantly rather than waiting for the 5 s
+  `status-interval` tick. The precmd hook short-circuits when
+  `@ssh_target` is already empty, so non-SSH prompts don't trigger
+  spurious refreshes. Per-pane (not server-global) — each Ghostty tab
+  shows its own SSH state. The function bodies in `.zshrc` are
+  duplicated inside `scripts/test-tmux-ssh-target.zsh` (mocked
+  `tmux`/`ssh`); keep both copies in sync. Edge cases: Ctrl-Z'd `ssh`
+  is a small known gap (overlay clears on the next prompt even though
+  ssh is technically backgrounded — acceptable); nested `ssh` is not
+  tracked (only the outer command counts). Don't replace `ssh -G` with
+  argv parsing — it would miss `~/.ssh/config` aliases and default
+  Users.
 - **tmux prefix is `C-a`** (screen-style; `C-Space` conflicts with macOS
   input-source switching). Pane nav: `<prefix> h/j/k/l` (Alt is reserved for
   Polish diacritics — never use `bind -n M-*`). Splits: `|` and `-`.
@@ -465,6 +492,7 @@ filename is the source of truth).
 - Claude tmux window-name tests: `scripts/test-claude-tmux-window-name.zsh`
 - URL-picker wrapper tests: `scripts/test-tmux-fzf-url-newest.sh`
 - tmux SSH-indicator tests: `scripts/test-tmux-ssh-indicator.sh`
+- tmux SSH-target (outbound overlay) tests: `scripts/test-tmux-ssh-target.zsh`
 - Session-root binding tests: `scripts/test-s-session-root.sh`
 - Dashboard smoke + integration tests: `scripts/test-dashboard.sh`
 - Reapply symlinks (idempotent): `$PROJECTS_HOME/dotfiles/bootstrap.sh`

--- a/scripts/test-tmux-ssh-target.zsh
+++ b/scripts/test-tmux-ssh-target.zsh
@@ -1,0 +1,191 @@
+#!/usr/bin/env zsh
+# Tests for _tmux_record_ssh_target and _tmux_clear_ssh_target.
+# Keep the inline function bodies in sync with .zshrc.
+# Run: zsh scripts/test-tmux-ssh-target.zsh
+set -u
+
+pass=0; fail=0; fail_msgs=()
+
+assert_eq() {
+  local got="$1" want="$2" desc="$3"
+  if [[ "$got" == "$want" ]]; then
+    pass=$((pass+1)); echo "  PASS  $desc"
+  else
+    fail=$((fail+1))
+    fail_msgs+=("FAIL  $desc"$'\n'"        got:  '$got'"$'\n'"        want: '$want'")
+    echo "  FAIL  $desc"
+  fi
+}
+
+assert_no_call() {
+  local -a haystack=("${(@P)1}")
+  local needle="$2" desc="$3"
+  local hit
+  for hit in "${haystack[@]}"; do
+    if [[ "$hit" == *"$needle"* ]]; then
+      fail=$((fail+1))
+      fail_msgs+=("FAIL  $desc"$'\n'"        unexpected call: '$hit'")
+      echo "  FAIL  $desc"
+      return
+    fi
+  done
+  pass=$((pass+1)); echo "  PASS  $desc"
+}
+
+# ── mocks ────────────────────────────────────────────────────────────────────
+# `tmux` is shadowed by a zsh function so the SUT's tmux invocations are
+# captured without touching a real tmux server. Pane-variable state is held
+# in _mock_pane_vars; refresh-client is a no-op recorder.
+typeset -ga _mock_tmux_calls=()
+typeset -gA _mock_pane_vars=()
+
+tmux() {
+  _mock_tmux_calls+=("$*")
+  case "$1" in
+    set)
+      shift
+      [[ "$1" == "-p" ]] && shift
+      if [[ "$1" == "-u" ]]; then
+        shift
+        unset "_mock_pane_vars[$1]"
+      else
+        local name="$1"; shift
+        _mock_pane_vars[$name]="$*"
+      fi
+      ;;
+    show)
+      shift
+      [[ "$1" == "-p" ]] && shift
+      [[ "$1" == "-v" ]] && shift
+      printf '%s' "${_mock_pane_vars[$1]:-}"
+      ;;
+    refresh-client) ;;  # recorded but otherwise a no-op
+  esac
+}
+
+# `ssh` is shadowed too. -G mode prints the canned response and exits with
+# the canned status. Other invocations are no-ops (we never run real ssh).
+typeset -ga _mock_ssh_calls=()
+typeset -g _mock_ssh_g_response=""
+typeset -g _mock_ssh_g_exit=0
+
+ssh() {
+  _mock_ssh_calls+=("$*")
+  if [[ "$1" == "-G" ]]; then
+    [[ -n "$_mock_ssh_g_response" ]] && printf '%s\n' "$_mock_ssh_g_response"
+    return $_mock_ssh_g_exit
+  fi
+  return 0
+}
+
+reset_state() {
+  _mock_tmux_calls=()
+  _mock_ssh_calls=()
+  _mock_pane_vars=()
+  _mock_ssh_g_response=""
+  _mock_ssh_g_exit=0
+}
+
+# ── functions under test (keep in sync with .zshrc) ──────────────────────────
+_tmux_record_ssh_target() {
+  [[ -z ${TMUX:-} ]] && return
+  local -a tokens=(${=1})
+  [[ ${tokens[1]:-} == ssh ]] || return
+  local resolved
+  resolved=$(eval "ssh -G ${1#ssh}" 2>/dev/null) || return
+  local host user
+  host=${${(M)${(f)resolved}:#hostname *}#hostname }
+  user=${${(M)${(f)resolved}:#user *}#user }
+  [[ -n $user && -n $host ]] || return
+  tmux set -p @ssh_target "$user@$host"
+  tmux refresh-client -S
+}
+
+_tmux_clear_ssh_target() {
+  return  # filled in in Task 2
+}
+
+# ── tests: _tmux_record_ssh_target (preexec) ─────────────────────────────────
+echo
+echo "_tmux_record_ssh_target"
+echo "──────────────────────"
+
+# 1. TMUX unset → no-op
+reset_state
+unset TMUX
+_tmux_record_ssh_target "ssh foo@bar"
+assert_no_call _mock_tmux_calls "set -p @ssh_target" \
+  "TMUX unset → no tmux set call"
+
+# Switch to "tmux running" mode for the remaining tests.
+export TMUX=fake
+
+# 2. Non-ssh command → no-op
+reset_state
+_tmux_record_ssh_target "ls -la"
+assert_no_call _mock_tmux_calls "set -p @ssh_target" \
+  "Non-ssh command → no tmux set call"
+
+# 3. ssh foo@bar → @ssh_target=foo@bar
+reset_state
+_mock_ssh_g_response=$'user foo\nhostname bar\nport 22'
+_tmux_record_ssh_target "ssh foo@bar"
+assert_eq "${_mock_pane_vars[@ssh_target]:-}" "foo@bar" \
+  "ssh foo@bar → @ssh_target = foo@bar"
+
+# 4. ssh studio (alias) → @ssh_target = canonical user@hostname
+reset_state
+_mock_ssh_g_response=$'hostname studio.local\nuser martinciu\nport 22'
+_tmux_record_ssh_target "ssh studio"
+assert_eq "${_mock_pane_vars[@ssh_target]:-}" "martinciu@studio.local" \
+  "ssh studio → canonical martinciu@studio.local"
+
+# 5. refresh-client -S is called after a successful ssh detection
+reset_state
+_mock_ssh_g_response=$'user foo\nhostname bar'
+_tmux_record_ssh_target "ssh foo@bar"
+refresh_seen=0
+for c in "${_mock_tmux_calls[@]}"; do
+  [[ "$c" == "refresh-client -S" ]] && refresh_seen=1
+done
+assert_eq "$refresh_seen" "1" \
+  "ssh detection triggers refresh-client -S"
+
+# 6. ssh-add → no-op (first-token equality, not prefix)
+reset_state
+_tmux_record_ssh_target "ssh-add ~/.ssh/id_ed25519"
+assert_no_call _mock_tmux_calls "set -p @ssh_target" \
+  "ssh-add → no tmux set call"
+
+# 7. ssh-keygen → no-op
+reset_state
+_tmux_record_ssh_target "ssh-keygen -t ed25519 -C foo"
+assert_no_call _mock_tmux_calls "set -p @ssh_target" \
+  "ssh-keygen → no tmux set call"
+
+# 8. ssh -G failure (resolver returns non-zero) → no @ssh_target set
+reset_state
+_mock_ssh_g_exit=255
+_mock_ssh_g_response=""
+_tmux_record_ssh_target "ssh garbledhost"
+assert_no_call _mock_tmux_calls "set -p @ssh_target" \
+  "ssh -G failure → no tmux set call"
+
+# 9. ssh -G returns no user/hostname (only port) → no @ssh_target set
+reset_state
+_mock_ssh_g_response=$'port 22'
+_tmux_record_ssh_target "ssh foo"
+assert_no_call _mock_tmux_calls "set -p @ssh_target" \
+  "ssh -G with no user/hostname → no tmux set call"
+
+# ── summary ──────────────────────────────────────────────────────────────────
+echo
+echo "──────────────────────"
+echo "passed: $pass"
+echo "failed: $fail"
+if (( fail > 0 )); then
+  echo
+  printf '%s\n' "${fail_msgs[@]}"
+  exit 1
+fi
+exit 0

--- a/scripts/test-tmux-ssh-target.zsh
+++ b/scripts/test-tmux-ssh-target.zsh
@@ -102,7 +102,10 @@ _tmux_record_ssh_target() {
 }
 
 _tmux_clear_ssh_target() {
-  return  # filled in in Task 2
+  [[ -z ${TMUX:-} ]] && return
+  [[ -z $(tmux show -p -v @ssh_target 2>/dev/null) ]] && return
+  tmux set -p -u @ssh_target
+  tmux refresh-client -S
 }
 
 # ── tests: _tmux_record_ssh_target (preexec) ─────────────────────────────────
@@ -177,6 +180,41 @@ _mock_ssh_g_response=$'port 22'
 _tmux_record_ssh_target "ssh foo"
 assert_no_call _mock_tmux_calls "set -p @ssh_target" \
   "ssh -G with no user/hostname → no tmux set call"
+
+# ── tests: _tmux_clear_ssh_target (precmd) ───────────────────────────────────
+echo
+echo "_tmux_clear_ssh_target"
+echo "─────────────────────"
+
+# 10. TMUX unset → no-op
+reset_state
+unset TMUX
+_tmux_clear_ssh_target
+assert_no_call _mock_tmux_calls "set -p -u @ssh_target" \
+  "TMUX unset → no tmux unset call"
+
+export TMUX=fake
+
+# 11. @ssh_target empty → no-op (early exit, no spurious refresh)
+reset_state
+_tmux_clear_ssh_target
+assert_no_call _mock_tmux_calls "set -p -u @ssh_target" \
+  "@ssh_target empty → no tmux unset call"
+assert_no_call _mock_tmux_calls "refresh-client -S" \
+  "@ssh_target empty → no refresh-client call"
+
+# 12. @ssh_target set → unset + refresh
+reset_state
+_mock_pane_vars[@ssh_target]="martinciu@studio.local"
+_tmux_clear_ssh_target
+assert_eq "${_mock_pane_vars[@ssh_target]:-EMPTY}" "EMPTY" \
+  "@ssh_target set → unset by clear hook"
+refresh_seen=0
+for c in "${_mock_tmux_calls[@]}"; do
+  [[ "$c" == "refresh-client -S" ]] && refresh_seen=1
+done
+assert_eq "$refresh_seen" "1" \
+  "clear hook triggers refresh-client -S"
 
 # ── summary ──────────────────────────────────────────────────────────────────
 echo


### PR DESCRIPTION
## Summary

- While an `ssh` command is foreground in the active tmux pane, the Ghostty tab title renders ` user@host` (Nerd Font globe U+F0AC + canonical destination); otherwise it renders `<session>:<window>`. Distinct from the existing inbound `tmux-ssh-indicator` (session chip) — that surfaces incoming sshd, this surfaces outgoing ssh.
- Wired in `tmux.conf` via `set -g set-titles on` and a `set-titles-string` that branches on the per-pane `@ssh_target` user variable. Two zsh hooks set/clear it: `_tmux_record_ssh_target` (preexec) checks first-token equality (`ssh`, not `ssh-add`/`ssh-keygen`), resolves via `ssh -G <args>` so `~/.ssh/config` aliases canonicalize, and stamps `@ssh_target=user@host`. `_tmux_clear_ssh_target` (precmd) unsets it on the next prompt. Both call `tmux refresh-client -S` for instant updates.
- Per-pane (each Ghostty tab shows its own SSH state). New test script `scripts/test-tmux-ssh-target.zsh` covers 14 scenarios with mocked `tmux`/`ssh`. CLAUDE.md updated with a convention bullet adjacent to the inbound-indicator entry.

## Test plan

- [ ] `zsh scripts/test-tmux-ssh-target.zsh` → 14/14 PASS
- [ ] `bash scripts/test-helpers.sh` → no regressions
- [ ] `zsh scripts/test-tmux-window-label.zsh` → no regressions
- [ ] Manual: `ssh studio` (or any `~/.ssh/config` alias) — Ghostty tab switches to ` user@host` instantly; on disconnect, returns to `<session>:<window>` on next prompt
- [ ] Manual: `ssh-add -l`, `ssh-keygen -y …` — no tab change (first-token equality excludes them)
- [ ] Manual: two Ghostty tabs, ssh in only one — only that tab shows the overlay (per-pane independence)