### PR TITLE
worktrunk: rename main_worktree_path to primary_worktree_path

### DIFF
--- a/.config/worktrunk/config.toml
+++ b/.config/worktrunk/config.toml
@@ -259,7 +259,7 @@ copy = "wt step copy-ignored"
 # worktree picked up during its lifetime) back to the primary
 # worktree. Mirrors the [post-start] hook above: same `wt step
 # copy-ignored`, same default-skip-existing semantics — files
-# present on primary are never overwritten. `-C {{ main_worktree_path }}`
+# present on primary are never overwritten. `-C {{ primary_worktree_path }}`
 # sets wt's cwd to primary so --to defaults to primary's worktree
 # without needing primary's branch name (no {{ primary_branch }}
 # template variable exists in pre-remove).
@@ -271,4 +271,4 @@ copy = "wt step copy-ignored"
 # operations inside worktrees are rare; if it bites, revisit
 # (see .superpowers/specs/2026-05-04-wt-pre-remove-symmetric-copy-ignored-design.md).
 [pre-remove]
-save-shared = "wt -C {{ main_worktree_path }} step copy-ignored --from {{ branch }}"
+save-shared = "wt -C {{ primary_worktree_path }} step copy-ignored --from {{ branch }}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,7 +207,7 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
 - **Gitignored content flows between primary and worktrees in two
   stages, both using `wt step copy-ignored`.** `[post-start] copy = "wt step copy-ignored"`
   reflinks primary's gitignored content into a new worktree at
-  creation. `[pre-remove] save-shared = "wt -C {{ main_worktree_path }} step copy-ignored --from {{ branch }}"`
+  creation. `[pre-remove] save-shared = "wt -C {{ primary_worktree_path }} step copy-ignored --from {{ branch }}"`
   reflinks the worktree's gitignored content back to primary just
   before `wt remove`. Default no-`--force` semantics on both: files
   that already exist in the destination are never overwritten —

--- a/scripts/test-wt-pre-remove-save.sh
+++ b/scripts/test-wt-pre-remove-save.sh
@@ -1,7 +1,7 @@
 #!/opt/homebrew/bin/bash
 # Smoke test for the [pre-remove] save-shared hook in
 # .config/worktrunk/config.toml. Extracts the hook command from
-# config.toml, substitutes the {{ main_worktree_path }} and
+# config.toml, substitutes the {{ primary_worktree_path }} and
 # {{ branch }} templates, and exercises it against a real worktree.
 # Asserts:
 #   - new files in worktree get copied to primary
@@ -78,11 +78,9 @@ echo "log line" > "$WORKTREE/.autonomo/run-1.log"
 mkdir -p "$WORKTREE/autonomo-workspace/iter-1"
 echo "trace" > "$WORKTREE/autonomo-workspace/iter-1/trace.json"
 
-# Substitute template variables. Cover both old and new hook variable names
-# so the test infrastructure is forward-compatible across the hook change.
+# Substitute template variables.
 substituted="$hook_cmd"
 substituted="${substituted//\{\{ primary_worktree_path \}\}/$PRIMARY}"
-substituted="${substituted//\{\{ main_worktree_path \}\}/$PRIMARY}"
 substituted="${substituted//\{\{ branch \}\}/feature}"
 
 # Run the hook from inside the worktree (matches wt's pre-remove behavior:


### PR DESCRIPTION
## Summary

- Migrate the `[pre-remove] save-shared` hook in `.config/worktrunk/config.toml` from the deprecated `{{ main_worktree_path }}` template variable to its replacement `{{ primary_worktree_path }}`. `wt 0.47.0` now warns on the old name.
- Drop the dual-substitution scaffold in `scripts/test-wt-pre-remove-save.sh` (it was added in advance of this rename to keep the test forward-compatible across the change).
- Update the `CLAUDE.md` reference to the hook string to match.

Spec: `.superpowers/specs/2026-05-04-wt-primary-worktree-path-rename-design.md`

## Test plan

- [x] `scripts/test-wt-pre-remove-save.sh` passes against installed `wt 0.47.0` after each commit.
- [x] `grep -rn 'main_worktree_path'` over `*.md`, `*.toml`, `*.sh`, `*.zsh` returns no matches in tracked source.