### PR TITLE
tmux: recolor active window pin from yellow to magenta

### DIFF
--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -185,7 +185,7 @@ set -g status-left-length 80
 
 # Windows
 setw -g window-status-format         "#[fg=#586e75,bg=#073642] #I:#W "
-setw -g window-status-current-format "#[fg=#b58900,bg=#073642]#[fg=#073642,bg=#b58900,bold] #I:#W #[fg=#b58900,bg=#073642]"
+setw -g window-status-current-format "#[fg=#d33682,bg=#073642]#[fg=#fdf6e3,bg=#d33682,bold] #I:#W #[fg=#d33682,bg=#073642]"
 
 # Right: branch chip from tmux-git-status (violet on main, yellow on worktree)
 set -g status-right "#(~/.config/tmux/bin/tmux-git-status #{pane_current_path} '#073642' '#073642')"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,18 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
 - **tmux status bar is hand-rolled** in `.config/tmux/tmux.conf` with
   Solarized base16 colors. Don't suggest theme plugins (catppuccin,
   tmux-powerline, etc.) — we deliberately avoid them.
+  Each status-bar **pin** uses a unique Solarized accent — never
+  duplicated across pins. Currently: blue (session chip, left),
+  magenta (active window pin, center), violet (main-checkout git
+  chip, right), yellow (worktree git chip, right). Why: shared
+  color visually merges two unrelated signals — the active-pin
+  yellow and worktree-chip yellow collision is what drove the
+  magenta switch. How to apply: when adding a new pin/chip on the
+  status line, pick from the currently-unused accents (orange, red,
+  green, cyan); if all are taken, reconsider whether a new pin is
+  warranted before reusing one. Mode-style, message-style,
+  pane-borders, and inline text colors (e.g. ins/del markers in
+  `tmux-git-status`) are not pins and are exempt from this rule.
 - **SSH indicator on the session chip** is wired into `status-left` via
   `#(~/.config/tmux/bin/tmux-ssh-indicator)`. The helper walks each
   attached client's parent-process chain on macOS using

--- a/docs/tmux-cheatsheet.html
+++ b/docs/tmux-cheatsheet.html
@@ -312,7 +312,7 @@
     <p>Bottom bar, <code>bg=base02</code> / <code>fg=base0</code>. Three segments:</p>
     <ul class="compact">
       <li><strong>Left:</strong> session name on a blue chip with a powerline arrow. Gains a leading globe glyph (<code></code> <code>nf-fa-globe</code>) when any attached tmux client is SSH-rooted (drives <code>tmux-ssh-indicator</code>).</li>
-      <li><strong>Center (absolute-centered on the full bar):</strong> windows. Inactive = <code>base01</code> on <code>base02</code>; active = <code>yellow</code>-on-<code>base02</code> chip.</li>
+      <li><strong>Center (absolute-centered on the full bar):</strong> windows. Inactive = <code>base01</code> on <code>base02</code>; active = <code>magenta</code>-on-<code>base3</code> chip with rounded powerline caps.</li>
       <li><strong>Right:</strong> branch chip — violet for main checkout, yellow for worktree (drives <code>tmux-git-status</code>).</li>
     </ul>
   </div>
@@ -329,7 +329,8 @@
     </div>
     <div class="swatch-row">
       <span class="swatch"><i style="background:#268bd2"></i> blue (session)</span>
-      <span class="swatch"><i style="background:#b58900"></i> yellow (active win)</span>
+      <span class="swatch"><i style="background:#d33682"></i> magenta (active win)</span>
+      <span class="swatch"><i style="background:#b58900"></i> yellow (worktree branch)</span>
       <span class="swatch"><i style="background:#6c71c4"></i> violet (main branch)</span>
       <span class="swatch"><i style="background:#2aa198"></i> cyan (selection)</span>
       <span class="swatch"><i style="background:#dc322f"></i> red</span>


### PR DESCRIPTION
## Summary

- Active window pin and the worktree git chip both rendered as Solarized **yellow** (`#b58900`) — same accent for two unrelated signals. Inside any worktree the bar showed two yellow pills that visually merged.
- Recolored the active window pin to **magenta** `#d33682` (the only unused Solarized accent that stays distinct from blue/yellow/violet) and switched the inner-pill text to base3 `#fdf6e3` for contrast on the darker background. Powerline rounded caps were already on the pin (the cheatsheet just never mentioned them); they stay.
- Codified a "one Solarized accent per status-bar pin" rule in `CLAUDE.md` under the existing "tmux status bar is hand-rolled" entry, with a list of the currently-used accents (blue / magenta / violet / yellow) and the unused ones available for future pins (orange / red / green / cyan). Mode-style, message-style, pane borders, and inline text colors are explicitly called out as non-pins so the rule's scope stays narrow.
- Cheatsheet (`docs/tmux-cheatsheet.html`) updated to match: layout description swaps "yellow-on-base02" → "magenta-on-base3 chip with rounded powerline caps", swatch row swaps the active-win swatch from yellow to magenta and adds a separate yellow "worktree branch" swatch so the palette key stays accurate.

## Test plan

- [ ] `bash scripts/test-helpers.sh` passes (regression check on `tmux-git-status`).
- [ ] `<prefix> r` reloads tmux without errors and the active window pin renders magenta with light text and rounded caps.
- [ ] On a worktree checkout, active pin (magenta) and right-side git chip (yellow) are visually distinct.
- [ ] On a main checkout, active pin (magenta) and right-side git chip (violet) are visually distinct.
- [ ] `open docs/tmux-cheatsheet.html` — swatch row matches the live bar; layout description reads "magenta-on-base3 chip with rounded powerline caps".