### PR TITLE
tmux: recolor active window pin from magenta to green

### DIFF
--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -185,7 +185,7 @@ set -g status-left-length 80
 
 # Windows
 setw -g window-status-format         "#[fg=#586e75,bg=#073642] #I:#W "
-setw -g window-status-current-format "#[fg=#d33682,bg=#073642]#[fg=#fdf6e3,bg=#d33682,bold] #I:#W #[fg=#d33682,bg=#073642]"
+setw -g window-status-current-format "#[fg=#859900,bg=#073642]#[fg=#fdf6e3,bg=#859900,bold] #I:#W #[fg=#859900,bg=#073642]"
 
 # Right: branch chip from tmux-git-status (violet on main, yellow on worktree)
 set -g status-right "#(~/.config/tmux/bin/tmux-git-status #{pane_current_path} '#073642' '#073642')"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,16 +46,17 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
   tmux-powerline, etc.) — we deliberately avoid them.
   Each status-bar **pin** uses a unique Solarized accent — never
   duplicated across pins. Currently: blue (session chip, left),
-  magenta (active window pin, center), violet (main-checkout git
+  green (active window pin, center), violet (main-checkout git
   chip, right), yellow (worktree git chip, right). Why: shared
   color visually merges two unrelated signals — the active-pin
   yellow and worktree-chip yellow collision is what drove the
-  magenta switch. How to apply: when adding a new pin/chip on the
-  status line, pick from the currently-unused accents (orange, red,
-  green, cyan); if all are taken, reconsider whether a new pin is
-  warranted before reusing one. Mode-style, message-style,
-  pane-borders, and inline text colors (e.g. ins/del markers in
-  `tmux-git-status`) are not pins and are exempt from this rule.
+  active pin off yellow. How to apply: when adding a new pin/chip
+  on the status line, pick from the currently-unused accents
+  (orange, red, magenta, cyan); if all are taken, reconsider
+  whether a new pin is warranted before reusing one. Mode-style,
+  message-style, pane-borders, and inline text colors (e.g. ins/del
+  markers in `tmux-git-status`) are not pins and are exempt from
+  this rule.
 - **SSH indicator on the session chip** is wired into `status-left` via
   `#(~/.config/tmux/bin/tmux-ssh-indicator)`. The helper walks each
   attached client's parent-process chain on macOS using

--- a/docs/tmux-cheatsheet.html
+++ b/docs/tmux-cheatsheet.html
@@ -312,7 +312,7 @@
     <p>Bottom bar, <code>bg=base02</code> / <code>fg=base0</code>. Three segments:</p>
     <ul class="compact">
       <li><strong>Left:</strong> session name on a blue chip with a powerline arrow. Gains a leading globe glyph (<code></code> <code>nf-fa-globe</code>) when any attached tmux client is SSH-rooted (drives <code>tmux-ssh-indicator</code>).</li>
-      <li><strong>Center (absolute-centered on the full bar):</strong> windows. Inactive = <code>base01</code> on <code>base02</code>; active = <code>magenta</code>-on-<code>base3</code> chip with rounded powerline caps.</li>
+      <li><strong>Center (absolute-centered on the full bar):</strong> windows. Inactive = <code>base01</code> on <code>base02</code>; active = <code>green</code>-on-<code>base3</code> chip with rounded powerline caps.</li>
       <li><strong>Right:</strong> branch chip — violet for main checkout, yellow for worktree (drives <code>tmux-git-status</code>).</li>
     </ul>
   </div>
@@ -329,7 +329,7 @@
     </div>
     <div class="swatch-row">
       <span class="swatch"><i style="background:#268bd2"></i> blue (session)</span>
-      <span class="swatch"><i style="background:#d33682"></i> magenta (active win)</span>
+      <span class="swatch"><i style="background:#859900"></i> green (active win)</span>
       <span class="swatch"><i style="background:#b58900"></i> yellow (worktree branch)</span>
       <span class="swatch"><i style="background:#6c71c4"></i> violet (main branch)</span>
       <span class="swatch"><i style="background:#2aa198"></i> cyan (selection)</span>


### PR DESCRIPTION
## Summary

- Recolor the tmux active-window pin from magenta `#d33682` to Solarized green `#859900` for a calmer aesthetic — magenta read as loud against the otherwise restrained Solarized palette (blue session chip, violet/yellow git chips).
- Update `docs/tmux-cheatsheet.html` (description on the layout card, swatch on the palette card) and `CLAUDE.md`'s one-accent-per-pin rule; magenta returns to the unused-accents list.
- Foreground (`#fdf6e3` base3) and the powerline cap glyphs (U+E0B6 / U+E0B4) are unchanged from the magenta state — only the accent hex shifts.

Follows up on #98 (the yellow → magenta change). The "no two pins share an accent" rule from #98 is satisfied by green just as it was by magenta.

## Test Plan

- [ ] \`tmux source-file ~/.config/tmux/tmux.conf\` — bar reloads cleanly; active window pin renders as a green pill with rounded caps and light text.
- [ ] In a worktree session: active pin (green) and worktree git chip (yellow) are visually distinct.
- [ ] In a main-checkout session: active pin (green) and main-checkout git chip (violet) are visually distinct.
- [ ] \`bash scripts/test-helpers.sh\` — all assertions pass (no regression in \`tmux-git-status\` or other helpers).
- [ ] Open \`docs/tmux-cheatsheet.html\` in a browser — center-windows description reads "green-on-base3 chip" and the palette swatch row shows green for "active win" (no remaining magenta swatch).