### PR TITLE
gitignore_global: add Python __pycache__/

### DIFF
--- a/.gitignore_global
+++ b/.gitignore_global
@@ -10,3 +10,6 @@
 # (per ~/.claude/CLAUDE.md — never committed in any repo)
 .superpowers/
 .autonomo/
+
+# Python
+__pycache__/


### PR DESCRIPTION
## Summary
- Add `__pycache__/` to the global gitignore so Python bytecode caches are never committed in any repo on this machine.

## Test plan
- [ ] `git check-ignore -v __pycache__/` resolves to `~/.gitignore_global`