### PR TITLE
nvim: drop lua-language-server from mason-lock

### DIFF
--- a/.config/nvim/mason-lock.json
+++ b/.config/nvim/mason-lock.json
@@ -3,7 +3,6 @@
   "erb-lint": "0.9.0",
   "eslint-lsp": "4.10.0",
   "json-lsp": "4.10.0",
-  "lua-language-server": "3.18.2",
   "markdown-toc": "1.2.0",
   "markdownlint-cli2": "0.22.1",
   "marksman": "2026-02-08",


### PR DESCRIPTION
## Summary
- Uninstalled `lua-language-server` via `:MasonUninstall` and refreshed `mason-lock.json`.
- Without the `lang.lua` LazyVim extra, `lua_ls` was running without lazydev's tuning, scanning the cwd as workspace and indexing into `~/.local/share/nvim/lazy/` (~190 MB of plugin Lua) when opening Lua files outside an nvim config root (e.g. `~/.claude/` skills/hooks). That was the most likely cause of recent runtime slowness.

## Test plan
- [ ] `:Mason` — `lua-language-server` no longer listed as installed
- [ ] Open a Lua file outside `~/.config/nvim/` — no `lua_ls` client in `:LspInfo`
- [ ] `ps aux | grep lua-language-server` returns nothing
- [ ] `bootstrap.sh` re-run on a fresh machine produces the same Mason set as the lockfile (no `lua_ls`)