### PR TITLE
nvim: disable markdownlint diagnostics globally

### DIFF
--- a/.config/nvim/lua/plugins/markdown-lint-off.lua
+++ b/.config/nvim/lua/plugins/markdown-lint-off.lua
@@ -1,0 +1,9 @@
+return {
+  {
+    "mfussenegger/nvim-lint",
+    opts = function(_, opts)
+      opts.linters_by_ft = opts.linters_by_ft or {}
+      opts.linters_by_ft.markdown = {}
+    end,
+  },
+}


### PR DESCRIPTION
## Summary
- Empty `nvim-lint`'s `linters_by_ft.markdown` so `markdownlint-cli2` style hints stop painting diagnostics on every Markdown buffer.
- Marksman LSP diagnostics (link/anchor checks) are intentionally left on — those catch real broken references.

## Test plan
- [ ] Open any `*.md` file — no markdownlint diagnostics in the gutter or virtual text
- [ ] `:Lint` on a markdown buffer is a no-op (empty linter list)
- [ ] Marksman still reports broken `[link](#anchor)` refs as expected