### PR TITLE
nvim: disable lua_ls (server + mason auto-install)

### DIFF
--- a/.config/nvim/lua/plugins/lsp-lua-off.lua
+++ b/.config/nvim/lua/plugins/lsp-lua-off.lua
@@ -1,0 +1,18 @@
+-- Disable lua_ls entirely. LazyVim core declares it in its default server set
+-- (lazy/LazyVim/lua/lazyvim/plugins/lsp/init.lua), so :MasonUninstall alone
+-- doesn't stick — mason-lspconfig auto-reinstalls on next startup.
+--
+-- We don't enable LazyVim's lang.lua extra, so lazydev's workspace tuning
+-- isn't wired up. Without it, lua_ls scans the cwd as workspace and can
+-- wander into ~/.local/share/nvim/lazy/ (~190 MB of plugin Lua) when opening
+-- Lua files outside an nvim config root — the slowness root cause.
+return {
+  {
+    "neovim/nvim-lspconfig",
+    opts = {
+      servers = {
+        lua_ls = { enabled = false, mason = false },
+      },
+    },
+  },
+}


### PR DESCRIPTION
## Summary
- Override LazyVim core's default `lua_ls` server entry with `enabled = false, mason = false` so the server neither attaches nor auto-reinstalls.
- Follow-up to #101: removing the package and lockfile entry alone wasn't enough — mason-lspconfig reinstalled on next startup because LazyVim core's default server set includes `lua_ls` (`lazy/LazyVim/lua/lazyvim/plugins/lsp/init.lua:117`). The opt-out hook documented at line 118 (`mason = false`) is the supported way to bow out.
- Without `lang.lua` extra (we don't enable it), lazydev's workspace tuning isn't wired up — `lua_ls` would scan cwd and wander into `~/.local/share/nvim/lazy/` (~190 MB of Lua) when opening Lua files outside an nvim config root. That was the runtime slowness.

## Test plan
- [x] `:MasonUninstall lua-language-server` → restart nvim → package stays uninstalled (verified locally across two `nvim --headless` invocations)
- [x] `:MasonLock` produces a lockfile with no `lua-language-server` entry (verified locally)
- [ ] Open a Lua file (e.g. `lua/config/options.lua`) — `:LspInfo` shows no `lua_ls` client attached
- [ ] `ps aux | grep lua-language-server` returns nothing