### PR TITLE
nvim: block schemastore catalog injection for jsonls/yamlls

### DIFF
--- a/.config/nvim/lua/plugins/lsp-no-schema-fetch.lua
+++ b/.config/nvim/lua/plugins/lsp-no-schema-fetch.lua
@@ -1,0 +1,26 @@
+-- Block schemastore catalog injection for jsonls and yamlls. LazyVim's
+-- lang.json and lang.yaml extras populate `settings.{json,yaml}.schemas`
+-- with the full schemastore.org catalog (~700 fileMatch → URL pairs) via
+-- a `before_init` hook. Each match triggers an HTTP fetch on first
+-- validation — fine when offline-tolerant, but a freeze risk on flaky
+-- networks and unwanted noise on every `:LspOn jsonls` for ad-hoc work.
+--
+-- Override `before_init` with a no-op so the schemas array stays empty.
+-- Inline `$schema` URLs still resolve normally; per-project always-on
+-- with full catalog stays available via `.nvim.lua` that overrides
+-- `before_init` back to LazyVim's injector.
+return {
+  {
+    "neovim/nvim-lspconfig",
+    opts = {
+      servers = {
+        jsonls = {
+          before_init = function() end,
+        },
+        yamlls = {
+          before_init = function() end,
+        },
+      },
+    },
+  },
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,6 +257,21 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
 - **`lsp-lua-off.lua` was deleted** when the broader
   `lsp-disable-all.lua` landed. Don't reintroduce per-server opt-out
   files; add to the unified server list instead.
+- **No schemastore catalog injection for jsonls/yamlls.**
+  `lua/plugins/lsp-no-schema-fetch.lua` overrides LazyVim's
+  `before_init` hook (from `lang.json` and `lang.yaml` extras) with
+  a no-op so the ~700-entry schemastore.org catalog is never written
+  into `settings.{json,yaml}.schemas`. Why: each pattern match
+  triggers an HTTP fetch on first validation — fine when online and
+  fast, but a freeze risk on flaky networks and unwanted noise on
+  every `:LspOn jsonls` for ad-hoc work. Inline `$schema` URLs in
+  files still resolve normally. For projects that genuinely want
+  the full catalog, drop a `.nvim.lua` at the repo root that
+  restores LazyVim's injector — same `vim.o.exrc = true` caveat as
+  the per-project always-on path. Don't fold this into
+  `lsp-disable-all.lua`; that file's per-server `enabled/mason`
+  loop stays pure, and the schema-fetch override is conceptually
+  separate (different problem, different remediation).
 - **Mason-managed LSPs are pinned** via `mason-lock.json`. The lockfile
   is committed. `:MasonLock` snapshots the current state; `:MasonLockUpdate`
   upgrades to latest then snapshots — use the latter to bump versions.

--- a/docs/nvim-cheatsheet.html
+++ b/docs/nvim-cheatsheet.html
@@ -320,6 +320,8 @@
 
 <p class="note">LSPs are <strong>off by default</strong>. Run <code>:LspOn &lt;name&gt;</code> once per session to enable a server (e.g. <code>:LspOn vtsls</code>); every matching buffer in that session auto-attaches from then on. Mason packages stay installed — opt-in is instant.</p>
 
+<p class="note">For <code>jsonls</code> / <code>yamlls</code>: the schemastore.org catalog injection is also <strong>off by default</strong>. Inline <code>$schema</code> URLs still resolve; the full ~700-pattern catalog stays out of <code>settings.{json,yaml}.schemas</code> so no HTTP fetches fan out on every recognized file. Restore via a per-project <code>.nvim.lua</code> when catalog validation is genuinely wanted.</p>
+
 <div class="grid">
 
   <div class="card">


### PR DESCRIPTION
## Summary

- Add `lua/plugins/lsp-no-schema-fetch.lua` overriding `before_init` for `jsonls` and `yamlls` with a no-op. LazyVim's `lang.json` / `lang.yaml` extras inject the full schemastore.org catalog (~700 fileMatch → URL pairs) into `settings.{json,yaml}.schemas`; each match triggers an HTTP fetch on first validation. With LSP off by default this rarely fires, but `:LspOn jsonls` for ad-hoc work shouldn't fan out to network on every recognized file.
- Inline `\$schema` URLs in JSON files still resolve normally — only the catalog injection is blocked.
- Per-project opt-in still available via `.nvim.lua` that restores the injector (for projects where catalog validation is genuinely wanted).
- Document the convention in `CLAUDE.md` and add a sister note in the LSP section of `docs/nvim-cheatsheet.html`.

## Why

A separate file from `lsp-disable-all.lua` because the concerns are different: that file's per-server `enabled/mason` loop stays clean, while this one's two-server before_init override is a different kind of remediation (network-fetch behavior, not auto-attach behavior).

## Test plan

- [ ] After merge, on primary checkout: `nvim some-package.json` — opens instantly even on slow/no network
- [ ] `:LspOn jsonls` then `:lua =vim.lsp.get_clients()[1].config.settings.json.schemas` — should be `nil` or `{}` (catalog empty)
- [ ] A file with inline `"\$schema": "https://json.schemastore.org/package.json"` — diagnostics still appear (URL resolves on first validation)
- [ ] `scripts/test-nvim.sh` passes