### PR TITLE
tmux: add orange PR pin to status bar (left of git chip)

### DIFF
--- a/.config/tmux/bin/tmux-git-status
+++ b/.config/tmux/bin/tmux-git-status
@@ -23,7 +23,7 @@
 set -e
 pwd_in="${1:-$PWD}"
 prev_bg="${2:-#073642}"
-next_bg="${3:-#073642}"
+next_bg="${3-#073642}"
 
 # Solarized base16
 fg_text_wt="#073642"       # base02 — dark text on yellow chip
@@ -127,9 +127,20 @@ if [ "$ahead"     -gt 0 ]; then extras="$extras ${g_up}${ahead}"; fi
 if [ "$behind"    -gt 0 ]; then extras="$extras ${g_dn}${behind}"; fi
 label="$label$extras"
 
-# Both states render as a rounded chip with both caps.
-printf '#[fg=%s,bg=%s]%s#[fg=%s,bg=%s] %s #[fg=%s,bg=%s]%s' \
-  "$bg" "$prev_bg" "$tri_l" \
-  "$branch_fg" "$bg" \
-  "$label" \
-  "$bg" "$next_bg" "$tri_r"
+# Render the chip. With a non-empty next_bg, close with the rounded right
+# cap (tri_r) drawn fg=chip-bg, bg=next_bg — the cap visually transitions
+# into whatever follows. With an empty next_bg, suppress the closing cap
+# so the chip body extends flush against whatever follows (typically the
+# screen edge, mirroring the session chip's flush-left anchor).
+if [ -z "$next_bg" ]; then
+  printf '#[fg=%s,bg=%s]%s#[fg=%s,bg=%s] %s ' \
+    "$bg" "$prev_bg" "$tri_l" \
+    "$branch_fg" "$bg" \
+    "$label"
+else
+  printf '#[fg=%s,bg=%s]%s#[fg=%s,bg=%s] %s #[fg=%s,bg=%s]%s' \
+    "$bg" "$prev_bg" "$tri_l" \
+    "$branch_fg" "$bg" \
+    "$label" \
+    "$bg" "$next_bg" "$tri_r"
+fi

--- a/.config/tmux/bin/tmux-pr-detect
+++ b/.config/tmux/bin/tmux-pr-detect
@@ -1,0 +1,50 @@
+#!/opt/homebrew/bin/bash
+# Echoes the PR number for the current branch (state OPEN or DRAFT), or
+# nothing. File-backed stale-while-revalidate cache, TTL 60s, never blocks
+# tmux on a slow gh call.
+#
+# Usage: tmux-pr-detect <pwd>
+#
+# Cache layout:
+#   ${XDG_CACHE_HOME:-$HOME/.cache}/tmux-pr-pin/<repo-hash>-<branch>
+# repo-hash is shasum of git-common-dir (worktrees of the same repo share
+# entries per branch). Branch is sanitized for filesystem safety.
+
+set -e
+pwd_in="${1:-$PWD}"
+ttl=60
+
+cd "$pwd_in" 2>/dev/null || exit 0
+command -v gh >/dev/null 2>&1 || exit 0
+
+branch=$(git symbolic-ref --short HEAD 2>/dev/null) || exit 0
+common_dir=$(git rev-parse --git-common-dir 2>/dev/null) || exit 0
+common_dir_abs=$(cd "$common_dir" 2>/dev/null && pwd) || exit 0
+
+repo_hash=$(printf '%s' "$common_dir_abs" | shasum | cut -c1-12)
+cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/tmux-pr-pin"
+mkdir -p "$cache_dir"
+
+safe_branch="${branch//[^a-zA-Z0-9._-]/_}"
+cache_file="$cache_dir/${repo_hash}-${safe_branch}"
+
+now=$(date +%s)
+fresh=0
+if [ -f "$cache_file" ]; then
+  cat "$cache_file"
+  mtime=$(stat -f '%m' "$cache_file" 2>/dev/null || echo 0)
+  age=$((now - mtime))
+  [ "$age" -lt "$ttl" ] && fresh=1
+fi
+
+if [ "$fresh" = "0" ]; then
+  (
+    num=$(gh pr view --json state,number \
+      --jq 'select(.state == "OPEN" or .state == "DRAFT") | .number' \
+      2>/dev/null || true)
+    tmp="$cache_file.tmp.$$"
+    printf '%s' "$num" > "$tmp" && mv "$tmp" "$cache_file"
+  ) >/dev/null 2>&1 &
+fi
+
+exit 0

--- a/.config/tmux/bin/tmux-status-right
+++ b/.config/tmux/bin/tmux-status-right
@@ -1,0 +1,44 @@
+#!/opt/homebrew/bin/bash
+# Renders the right-side tmux status segment.
+#
+# Usage: tmux-status-right <pwd>
+#
+# Layout:
+#   With PR  : [orange ◖][orange body: <pr-glyph> #<num>][git chip flush-right
+#              with prev_bg=orange — tmux-git-status's tri_l renders as the
+#              yellow-on-orange separator]
+#   Without PR: [git chip flush-right, prev_bg=bar-bg]
+#
+# Both branches end without a closing cap — the git chip body extends to
+# the screen edge, mirroring the session chip's flush-left anchor.
+
+set -e
+pwd_in="${1:-$PWD}"
+
+bar_bg='#073642'   # base02 — status bar background
+pr_bg='#cb4b16'    # orange — PR pin
+pr_fg='#fdf6e3'    # base3  — PR pin foreground
+helper_dir="$(dirname "${BASH_SOURCE[0]}")"
+
+# Powerline rounded left cap (U+E0B6) and nf-oct-git_pull_request (U+F407)
+# as raw UTF-8 byte sequences (avoids editor-dependent literal embedding;
+# matches the pattern in tmux-git-status).
+tri_l=$(printf '\xee\x82\xb6')
+pr_glyph=$(printf '\xef\x90\x87')
+
+pr_num=$("$helper_dir/tmux-pr-detect" "$pwd_in" 2>/dev/null || true)
+
+if [ -n "$pr_num" ]; then
+  # Orange PR chip: rounded left cap on bar bg, then bold body. No right
+  # cap — the next chip's tri_l serves as the visual transition.
+  printf '#[fg=%s,bg=%s]%s#[fg=%s,bg=%s,bold] %s #%s ' \
+    "$pr_bg" "$bar_bg" "$tri_l" \
+    "$pr_fg" "$pr_bg" \
+    "$pr_glyph" "$pr_num"
+  # Git chip with prev_bg=orange (so its tri_l becomes the yellow-on-orange
+  # separator) and next_bg='' (flush-right).
+  "$helper_dir/tmux-git-status" "$pwd_in" "$pr_bg" ''
+else
+  # No PR — git chip alone, flush-right.
+  "$helper_dir/tmux-git-status" "$pwd_in" "$bar_bg" ''
+fi

--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -88,6 +88,13 @@ bind l select-pane -R
 # ─── Reload ─────────────────────────────────
 bind r source-file ~/.config/tmux/tmux.conf \; display "config reloaded"
 
+# ─── PR pin: open in browser ────────────────
+# `<prefix> P` opens the current branch's PR in the default browser via
+# `gh pr view --web`. When no PR exists, gh exits non-zero and run-shell
+# swallows the error silently. Visible counterpart in the status bar is
+# the orange PR pin (drives tmux-status-right + tmux-pr-detect).
+bind P run-shell "cd '#{pane_current_path}' && gh pr view --web 2>/dev/null"
+
 # ─── sessionx popup ─────────────────────────
 # Session picker is `omerxx/tmux-sessionx` (TPM plugin loaded below).
 # The plugin claims <prefix> t via `@sessionx-bind 't'` set in the TPM
@@ -187,8 +194,11 @@ set -g status-left-length 80
 setw -g window-status-format         "#[fg=#586e75,bg=#073642] #I:#W "
 setw -g window-status-current-format "#[fg=#859900,bg=#073642]#[fg=#fdf6e3,bg=#859900,bold] #I:#W #[fg=#859900,bg=#073642]"
 
-# Right: branch chip from tmux-git-status (violet on main, yellow on worktree)
-set -g status-right "#(~/.config/tmux/bin/tmux-git-status #{pane_current_path} '#073642' '#073642')"
+# Right: orchestrator that composes the PR pin (when a PR exists for the
+# current branch) and the branch chip. Git chip is always flush-right —
+# mirrors the session chip's flush-left anchor on the left of the bar.
+# Helpers: tmux-status-right → tmux-pr-detect (cache + gh) + tmux-git-status.
+set -g status-right "#(~/.config/tmux/bin/tmux-status-right #{pane_current_path})"
 set -g status-right-length 80
 
 # ─── Selection, messages, and pane borders ──

--- a/Brewfile
+++ b/Brewfile
@@ -5,6 +5,7 @@
 brew "git"
 brew "tmux"
 brew "jq"   # JSON parsing in shell helpers
+brew "gh"   # GitHub CLI — drives tmux-pr-detect + <prefix> P (gh pr view --web)
 brew "watch"  # procps watch — used by `dashboard` for live tile polling (-c ANSI passthrough)
 brew "bash"   # bash 5; pinned-shebang scripts target /opt/homebrew/bin/bash
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,13 +47,14 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
   Each status-bar **pin** uses a unique Solarized accent — never
   duplicated across pins. Currently: blue (session chip, left),
   green (active window pin, center), violet (main-checkout git
-  chip, right), yellow (worktree git chip, right). Why: shared
-  color visually merges two unrelated signals — the active-pin
-  yellow and worktree-chip yellow collision is what drove the
-  active pin off yellow. How to apply: when adding a new pin/chip
-  on the status line, pick from the currently-unused accents
-  (orange, red, magenta, cyan); if all are taken, reconsider
-  whether a new pin is warranted before reusing one. Mode-style,
+  chip, right), yellow (worktree git chip, right), orange (PR pin,
+  right — left of git chip). Why: shared color visually merges two
+  unrelated signals — the active-pin yellow and worktree-chip
+  yellow collision is what drove the active pin off yellow. How
+  to apply: when adding a new pin/chip on the status line, pick
+  from the currently-unused accents (red, magenta, cyan); if all
+  are taken, reconsider whether a new pin is warranted before
+  reusing one. Mode-style,
   message-style, pane-borders, and inline text colors (e.g. ins/del
   markers in `tmux-git-status`) are not pins and are exempt from
   this rule.
@@ -81,6 +82,28 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
   detection (`$SSH_CONNECTION`) intentionally not used — it's set in
   the SSH-spawned shell's env, not the tmux server's, so `#(...)` calls
   never see it.
+- **tmux PR pin** is wired into `status-right` via
+  `#(~/.config/tmux/bin/tmux-status-right #{pane_current_path})`. The
+  orchestrator calls `tmux-pr-detect` (a stale-while-revalidate file cache
+  around `gh pr view --json state,number --jq ...` with TTL 60s, cache at
+  `${XDG_CACHE_HOME:-$HOME/.cache}/tmux-pr-pin/<repo-hash>-<branch>`).
+  When a PR exists for the current branch (state OPEN or DRAFT — single
+  visual, no draft distinction), the orange chip (`#cb4b16`, fg `#fdf6e3`
+  bold) rendering ` #<num>` (Nerd Font U+F407 `nf-oct-git_pull_request`)
+  is emitted, then `tmux-git-status` is called with `prev_bg=#cb4b16` so
+  its existing `tri_l` (U+E0B6) becomes the yellow-on-orange rounded
+  separator — falls out of the existing helper for free. Both states
+  (with PR / without PR) call `tmux-git-status` with `next_bg=''` so the
+  git chip is flush-right (no closing cap), mirroring the session chip's
+  flush-left anchor on the opposite side. `<prefix> P` opens the current
+  branch's PR in the browser via `gh pr view --web` (silent when no PR
+  exists). Cache key uses `git-common-dir` so all worktrees of the same
+  upstream repo share entries per-branch. First call after branch switch
+  shows nothing; the next 5s status-interval tick (after the background
+  refresh completes) renders the pin — acceptable trade-off for never
+  blocking the bar on a slow `gh` call. Why orange specifically: it was
+  the first unused accent (per the "unique accent per pin" rule); after
+  this change red/magenta/cyan remain available.
 - **Outbound SSH overlay on the Ghostty tab title.** Distinct from the
   inbound `tmux-ssh-indicator` above: this surfaces *outgoing* `ssh`
   sessions on the local client's Ghostty tab. While an `ssh` command is

--- a/docs/tmux-cheatsheet.html
+++ b/docs/tmux-cheatsheet.html
@@ -77,6 +77,7 @@
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">T</span></td><td class="desc">clock-mode <span class="muted">(swapped from default <code>t</code>)</span></td></tr>
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">u</span></td><td class="desc">URL picker (fzf, current pane full 50k scrollback, latest occurrence of duplicates wins) — opens in default browser</td></tr>
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">o</span></td><td class="desc">file picker (fzf, current pane + 2000 lines scrollback) — opens in per-session nvim, falls back to new window</td></tr>
+      <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">P</span></td><td class="desc">open current branch's PR in browser via <code>gh pr view --web</code> (silent when no PR — counterpart to the orange status-bar PR pin)</td></tr>
       <tr><td class="key"><span class="k">⇧⌘ click</span></td><td class="desc">Claude Code file links → routes via macOS file-type defaults (OSC 8 passthrough enabled in <code>tmux.conf</code> via <code>terminal-features hyperlinks</code>)</td></tr>
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">?</span></td><td class="desc">list all keybindings</td></tr>
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">:</span></td><td class="desc">command prompt</td></tr>
@@ -313,7 +314,7 @@
     <ul class="compact">
       <li><strong>Left:</strong> session name on a blue chip with a powerline arrow. Gains a leading globe glyph (<code></code> <code>nf-fa-globe</code>) when any attached tmux client is SSH-rooted (drives <code>tmux-ssh-indicator</code>).</li>
       <li><strong>Center (absolute-centered on the full bar):</strong> windows. Inactive = <code>base01</code> on <code>base02</code>; active = <code>green</code>-on-<code>base3</code> chip with rounded powerline caps.</li>
-      <li><strong>Right:</strong> branch chip — violet for main checkout, yellow for worktree (drives <code>tmux-git-status</code>).</li>
+      <li><strong>Right:</strong> orange PR pin (when the current branch has an open/draft PR) glued to the branch chip via a rounded yellow-on-orange separator. Branch chip is violet for main checkout, yellow for worktree, always flush-right (no closing cap — mirrors the session chip's flush-left anchor). Drives <code>tmux-status-right</code> → <code>tmux-pr-detect</code> + <code>tmux-git-status</code>.</li>
     </ul>
   </div>
 
@@ -332,6 +333,7 @@
       <span class="swatch"><i style="background:#859900"></i> green (active win)</span>
       <span class="swatch"><i style="background:#b58900"></i> yellow (worktree branch)</span>
       <span class="swatch"><i style="background:#6c71c4"></i> violet (main branch)</span>
+      <span class="swatch"><i style="background:#cb4b16"></i> orange (PR pin)</span>
       <span class="swatch"><i style="background:#2aa198"></i> cyan (selection)</span>
       <span class="swatch"><i style="background:#dc322f"></i> red</span>
     </div>
@@ -341,6 +343,8 @@
   <div class="card">
     <h3>Status helpers</h3>
     <table>
+      <tr><td class="key"><code>~/.config/tmux/bin/tmux-status-right</code></td><td class="desc">orchestrator for the right-side status segment — composes PR pin (when present) + git chip flush-right</td></tr>
+      <tr><td class="key"><code>~/.config/tmux/bin/tmux-pr-detect</code></td><td class="desc">stale-while-revalidate file cache around <code>gh pr view</code> (TTL 60s) — echoes PR number for current branch or empty</td></tr>
       <tr><td class="key"><code>~/.config/tmux/bin/tmux-git-status</code></td><td class="desc">git/worktree status segment, colors as args</td></tr>
       <tr><td class="key"><code>~/.config/tmux/bin/claude-tmux-window-name</code></td><td class="desc">sets/clears <code>@claude_session_name</code> from Claude Code hooks (drives <code>claude[&lt;name&gt;]</code> window title)</td></tr>
       <tr><td class="key"><code>~/.config/tmux/bin/tmux-fzf-file</code></td><td class="desc">scans pane + scrollback for paths, fzf picker — backs <span class="k prefix">C-a</span> <span class="k">o</span></td></tr>
@@ -348,6 +352,7 @@
       <tr><td class="key"><code>~/.config/tmux/bin/tmux-open-in-nvim</code></td><td class="desc">remote-sends <code>:edit</code> to the per-session nvim socket; falls back to a fresh nvim in a new window</td></tr>
       <tr><td class="key"><code>~/.config/tmux/bin/tmux-ssh-indicator</code></td><td class="desc">walks each attached client's <code>ps</code> ancestry; prints <code></code> + space when any ancestor is <code>sshd</code>/<code>sshd-session</code> — prepended inside the session chip</td></tr>
       <tr><td class="key"><code>scripts/test-helpers.sh</code></td><td class="desc">smoke-tests for the helpers</td></tr>
+      <tr><td class="key"><code>scripts/test-tmux-pr-status.sh</code></td><td class="desc">smoke tests for <code>tmux-pr-detect</code> + <code>tmux-status-right</code> (uses a PATH-shimmed <code>gh</code>)</td></tr>
     </table>
     <p class="note">Worktree detection uses <code>git rev-parse --git-dir</code> vs <code>--git-common-dir</code> so it works for <code>.claude/worktrees/*</code>, worktrunk paths, and sibling worktrees alike.</p>
   </div>
@@ -423,7 +428,7 @@
 </table>
 
 <footer>
-  Built from <code>~/.config/tmux/tmux.conf</code> on 2026-05-04. Refresh after meaningful config changes.
+  Built from <code>~/.config/tmux/tmux.conf</code> on 2026-05-05. Refresh after meaningful config changes.
   <br>
   When in doubt: <span class="k prefix">C-a</span> <span class="k">?</span> for the live keymap list.
 </footer>

--- a/scripts/test-helpers.sh
+++ b/scripts/test-helpers.sh
@@ -3,7 +3,7 @@
 # Run from the repo root or anywhere — paths are absolute.
 set -u
 
-REPO="$PROJECTS_HOME/dotfiles"
+REPO="${REPO:-$PROJECTS_HOME/dotfiles}"
 GIT_STATUS="$REPO/.config/tmux/bin/tmux-git-status"
 
 pass=0
@@ -81,6 +81,21 @@ else
   not_repo=$(mktemp -d)
   out=$("$GIT_STATUS" "$not_repo" "#073642" "#586e75")
   assert_eq "$out" "" "non-git dir -> empty output"
+
+  # ─── flush-right mode (empty next-bg) ──────────
+  # tri_r is U+E0B4 (\xee\x82\xb4) — must be ABSENT when next-bg is empty.
+  # tri_l is U+E0B6 (\xee\x82\xb6) — must still be present.
+  out=$("$GIT_STATUS" "$fixture" "#073642" "")
+  if printf '%s' "$out" | grep -q -F -- $'\xee\x82\xb4'; then
+    fail=$((fail+1))
+    fail_msgs+=("FAIL  flush-right mode should not emit tri_r"$'\n'"        got:  '$out'")
+    echo "  FAIL  flush-right mode should not emit tri_r"
+  else
+    pass=$((pass+1))
+    echo "  PASS  flush-right mode omits closing tri_r (U+E0B4)"
+  fi
+  assert_contains "$out" $'\xee\x82\xb6' "flush-right mode still emits opening tri_l (U+E0B6)"
+  assert_contains "$out" "main" "flush-right mode still shows branch label"
 
   rm -rf "$fixture" "$not_repo"
 

--- a/scripts/test-tmux-pr-status.sh
+++ b/scripts/test-tmux-pr-status.sh
@@ -1,0 +1,242 @@
+#!/opt/homebrew/bin/bash
+# Smoke tests for tmux-pr-detect and tmux-status-right.
+#
+# Strategy: run the helpers with HOME pointed at a throwaway dir and PATH
+# rewritten so a stub `gh` shim wins over the real one. The shim writes
+# its invocation to a counter file so we can assert "second call within
+# TTL doesn't re-invoke gh".
+set -u
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DETECT="$REPO/.config/tmux/bin/tmux-pr-detect"
+ORCHESTRATOR="$REPO/.config/tmux/bin/tmux-status-right"
+
+pass=0
+fail=0
+fail_msgs=()
+
+assert_eq() {
+  local got="$1" want="$2" desc="$3"
+  if [ "$got" = "$want" ]; then
+    pass=$((pass+1))
+    echo "  PASS  $desc"
+  else
+    fail=$((fail+1))
+    fail_msgs+=("FAIL  $desc"$'\n'"        got:  '$got'"$'\n'"        want: '$want'")
+    echo "  FAIL  $desc"
+  fi
+}
+
+assert_contains() {
+  local got="$1" needle="$2" desc="$3"
+  if printf '%s' "$got" | grep -q -F -- "$needle"; then
+    pass=$((pass+1))
+    echo "  PASS  $desc"
+  else
+    fail=$((fail+1))
+    fail_msgs+=("FAIL  $desc"$'\n'"        got:  '$got'"$'\n'"        needle: '$needle'")
+    echo "  FAIL  $desc"
+  fi
+}
+
+assert_not_contains() {
+  local got="$1" needle="$2" desc="$3"
+  if printf '%s' "$got" | grep -q -F -- "$needle"; then
+    fail=$((fail+1))
+    fail_msgs+=("FAIL  $desc"$'\n'"        got: '$got'"$'\n'"        unwanted: '$needle'")
+    echo "  FAIL  $desc"
+  else
+    pass=$((pass+1))
+    echo "  PASS  $desc"
+  fi
+}
+
+# Build a sandbox: TEST_HOME for $HOME, plus a bin/ holding our gh shim.
+setup_sandbox() {
+  local fixture="$1" gh_response="$2"
+  TEST_HOME=$(mktemp -d)
+  mkdir -p "$TEST_HOME/bin"
+  GH_CALLS="$TEST_HOME/gh-calls"
+  : > "$GH_CALLS"
+
+  cat > "$TEST_HOME/bin/gh" <<EOF
+#!/opt/homebrew/bin/bash
+# Test shim. Records each invocation; emits the same output that real
+# gh would produce after applying its server-side --jq filter
+# 'select(.state == "OPEN" or .state == "DRAFT") | .number' to a
+# {"state":"...","number":N} payload.
+echo "\$@" >> "$GH_CALLS"
+case "$gh_response" in
+  open)   printf '%s\n' '105' ;;
+  draft)  printf '%s\n' '106' ;;
+  closed) ;;  # state filter rejects → empty stdout
+  none)   exit 1 ;;
+esac
+EOF
+  chmod +x "$TEST_HOME/bin/gh"
+
+  # XDG_CACHE_HOME under TEST_HOME so cache files are isolated.
+  export XDG_CACHE_HOME="$TEST_HOME/cache"
+  export HOME="$TEST_HOME"
+  export PATH="$TEST_HOME/bin:$PATH"
+}
+
+teardown_sandbox() {
+  rm -rf "$TEST_HOME"
+  PATH="${PATH#$TEST_HOME/bin:}"
+  export PATH
+  unset TEST_HOME GH_CALLS XDG_CACHE_HOME
+}
+
+# Wait for a backgrounded refresh to finish writing its cache file.
+# tmux-pr-detect forks the gh shim into the background; without this wait,
+# follow-up assertions can race the file-write.
+wait_for_cache() {
+  local cache_dir="$1"
+  local i=0
+  while [ "$i" -lt 50 ]; do
+    if [ -n "$(ls "$cache_dir" 2>/dev/null)" ]; then
+      # Also wait for any tmp swap to finish (rename is atomic but the
+      # background subshell exit may lag the rename slightly).
+      sleep 0.05
+      return 0
+    fi
+    sleep 0.02
+    i=$((i+1))
+  done
+  return 1
+}
+
+count_gh_calls() {
+  wc -l < "$GH_CALLS" | tr -d ' '
+}
+
+echo
+echo "tmux-pr-detect"
+echo "──────────────"
+
+if [ ! -x "$DETECT" ]; then
+  echo "  SKIP — $DETECT not present yet"
+else
+  # Test 1: non-git dir → empty output, gh never invoked.
+  setup_sandbox "" open
+  not_repo=$(mktemp -d)
+  out=$("$DETECT" "$not_repo")
+  assert_eq "$out" "" "non-git dir -> empty output"
+  assert_eq "$(count_gh_calls)" "0" "non-git dir -> gh not invoked"
+  rm -rf "$not_repo"
+  teardown_sandbox
+
+  # Test 2: git dir + gh OPEN → empty on cold call, then number after refresh.
+  setup_sandbox "" open
+  fixture=$(mktemp -d)
+  ( cd "$fixture" && git init -q -b feat/x && \
+    git -c user.email=t@t -c user.name=t commit --allow-empty -q -m init )
+  out=$("$DETECT" "$fixture")
+  assert_eq "$out" "" "cold call -> empty (cache miss, refresh forked)"
+  wait_for_cache "$XDG_CACHE_HOME/tmux-pr-pin" || \
+    echo "  WARN  cache file did not appear within timeout"
+  out=$("$DETECT" "$fixture")
+  assert_eq "$out" "105" "after refresh -> cached PR number"
+  # Second call within TTL must not invoke gh again.
+  calls_before=$(count_gh_calls)
+  out=$("$DETECT" "$fixture")
+  calls_after=$(count_gh_calls)
+  assert_eq "$out" "105" "second call within TTL returns cached value"
+  assert_eq "$calls_before" "$calls_after" "second call within TTL does not invoke gh"
+  rm -rf "$fixture"
+  teardown_sandbox
+
+  # Test 3: gh DRAFT → number returned (drafts treated identically to open).
+  setup_sandbox "" draft
+  fixture=$(mktemp -d)
+  ( cd "$fixture" && git init -q -b feat/y && \
+    git -c user.email=t@t -c user.name=t commit --allow-empty -q -m init )
+  "$DETECT" "$fixture" >/dev/null
+  wait_for_cache "$XDG_CACHE_HOME/tmux-pr-pin" || true
+  out=$("$DETECT" "$fixture")
+  assert_eq "$out" "106" "draft PR -> number returned"
+  rm -rf "$fixture"
+  teardown_sandbox
+
+  # Test 4: gh CLOSED → empty (state filter rejects it).
+  setup_sandbox "" closed
+  fixture=$(mktemp -d)
+  ( cd "$fixture" && git init -q -b feat/z && \
+    git -c user.email=t@t -c user.name=t commit --allow-empty -q -m init )
+  "$DETECT" "$fixture" >/dev/null
+  wait_for_cache "$XDG_CACHE_HOME/tmux-pr-pin" || true
+  out=$("$DETECT" "$fixture")
+  assert_eq "$out" "" "closed PR -> empty"
+  rm -rf "$fixture"
+  teardown_sandbox
+
+  # Test 5: gh exits non-zero (no PR for branch) → empty.
+  setup_sandbox "" none
+  fixture=$(mktemp -d)
+  ( cd "$fixture" && git init -q -b feat/no-pr && \
+    git -c user.email=t@t -c user.name=t commit --allow-empty -q -m init )
+  "$DETECT" "$fixture" >/dev/null
+  wait_for_cache "$XDG_CACHE_HOME/tmux-pr-pin" || true
+  out=$("$DETECT" "$fixture")
+  assert_eq "$out" "" "no PR for branch -> empty"
+  rm -rf "$fixture"
+  teardown_sandbox
+fi
+
+echo
+echo "tmux-status-right"
+echo "─────────────────"
+
+if [ ! -x "$ORCHESTRATOR" ]; then
+  echo "  SKIP — $ORCHESTRATOR not present yet"
+else
+  # Test 6: no PR → output omits tri_r (flush-right git chip).
+  setup_sandbox "" none
+  fixture=$(mktemp -d)
+  ( cd "$fixture" && git init -q -b main && \
+    git -c user.email=t@t -c user.name=t commit --allow-empty -q -m init )
+  "$ORCHESTRATOR" "$fixture" >/dev/null  # warm cache
+  wait_for_cache "$XDG_CACHE_HOME/tmux-pr-pin" || true
+  out=$("$ORCHESTRATOR" "$fixture")
+  assert_not_contains "$out" $'\xee\x82\xb4' "no-PR path: tri_r absent (flush-right)"
+  assert_contains "$out" "main" "no-PR path: shows branch"
+  assert_not_contains "$out" "#cb4b16" "no-PR path: orange not in output"
+  rm -rf "$fixture"
+  teardown_sandbox
+
+  # Test 7: with PR → orange chip body precedes the git chip; tri_r still absent.
+  setup_sandbox "" open
+  fixture=$(mktemp -d)
+  ( cd "$fixture" && git init -q -b feat/x && \
+    git -c user.email=t@t -c user.name=t commit --allow-empty -q -m init )
+  "$ORCHESTRATOR" "$fixture" >/dev/null  # warm cache
+  wait_for_cache "$XDG_CACHE_HOME/tmux-pr-pin" || true
+  out=$("$ORCHESTRATOR" "$fixture")
+  assert_contains "$out" "#cb4b16" "with-PR path: orange in output"
+  assert_contains "$out" "#105" "with-PR path: PR number rendered"
+  assert_contains "$out" $'\xef\x90\x87' "with-PR path: PR glyph U+F407 in output"
+  assert_not_contains "$out" $'\xee\x82\xb4' "with-PR path: tri_r still absent (git flush-right)"
+  # Order check: orange chip body must appear before the yellow chip body.
+  orange_pos=$(printf '%s' "$out" | grep -b -o "#cb4b16" | head -1 | cut -d: -f1)
+  yellow_pos=$(printf '%s' "$out" | grep -b -o "#b58900" | head -1 | cut -d: -f1)
+  if [ -n "$orange_pos" ] && [ -n "$yellow_pos" ] && [ "$orange_pos" -lt "$yellow_pos" ]; then
+    pass=$((pass+1))
+    echo "  PASS  with-PR path: orange chip emitted before yellow chip"
+  else
+    fail=$((fail+1))
+    fail_msgs+=("FAIL  with-PR path: orange chip should precede yellow chip"$'\n'"        orange_pos=$orange_pos yellow_pos=$yellow_pos")
+    echo "  FAIL  with-PR path: orange chip should precede yellow chip"
+  fi
+  rm -rf "$fixture"
+  teardown_sandbox
+fi
+
+echo
+if [ "$fail" -gt 0 ]; then
+  echo "──────"
+  printf '%s\n\n' "${fail_msgs[@]}"
+  echo "$pass passed, $fail failed"
+  exit 1
+fi
+echo "$pass passed, $fail failed"

--- a/scripts/test-tmux-pr-status.sh
+++ b/scripts/test-tmux-pr-status.sh
@@ -217,16 +217,17 @@ else
   assert_contains "$out" "#105" "with-PR path: PR number rendered"
   assert_contains "$out" $'\xef\x90\x87' "with-PR path: PR glyph U+F407 in output"
   assert_not_contains "$out" $'\xee\x82\xb4' "with-PR path: tri_r still absent (git flush-right)"
-  # Order check: orange chip body must appear before the yellow chip body.
+  # Order check: orange chip body must appear before the git chip body.
+  # The fixture is a plain main checkout, so the git chip uses violet (#6c71c4).
   orange_pos=$(printf '%s' "$out" | grep -b -o "#cb4b16" | head -1 | cut -d: -f1)
-  yellow_pos=$(printf '%s' "$out" | grep -b -o "#b58900" | head -1 | cut -d: -f1)
-  if [ -n "$orange_pos" ] && [ -n "$yellow_pos" ] && [ "$orange_pos" -lt "$yellow_pos" ]; then
+  git_pos=$(printf '%s' "$out" | grep -b -o "#6c71c4" | head -1 | cut -d: -f1)
+  if [ -n "$orange_pos" ] && [ -n "$git_pos" ] && [ "$orange_pos" -lt "$git_pos" ]; then
     pass=$((pass+1))
-    echo "  PASS  with-PR path: orange chip emitted before yellow chip"
+    echo "  PASS  with-PR path: orange chip emitted before git chip"
   else
     fail=$((fail+1))
-    fail_msgs+=("FAIL  with-PR path: orange chip should precede yellow chip"$'\n'"        orange_pos=$orange_pos yellow_pos=$yellow_pos")
-    echo "  FAIL  with-PR path: orange chip should precede yellow chip"
+    fail_msgs+=("FAIL  with-PR path: orange chip should precede git chip"$'\n'"        orange_pos=$orange_pos git_pos=$git_pos")
+    echo "  FAIL  with-PR path: orange chip should precede git chip"
   fi
   rm -rf "$fixture"
   teardown_sandbox


### PR DESCRIPTION
## Summary

- New orange status-bar pin showing the PR number for the current branch (Nerd Font U+F407 + `#<num>`), placed left of the existing git chip with a yellow-on-orange rounded separator.
- Detection via `gh pr view` wrapped in a 60s stale-while-revalidate file cache (`tmux-pr-detect`); orchestrator (`tmux-status-right`) composes the orange PR chip + flush-right git chip.
- `<prefix> P` opens the current branch's PR via `gh pr view --web` (silent when no PR exists).

## Test Plan

- [x] `scripts/test-tmux-pr-status.sh` — 17/17 pass (5 detect scenarios + 2 orchestrator scenarios)
- [x] `scripts/test-helpers.sh` — flush-right mode assertions pass
- [ ] Reload tmux (`tmux source-file ~/.config/tmux/tmux.conf`) and visually verify: orange PR chip on branches with an open PR, plain git chip on branches without
- [ ] Press `<prefix> P` on a branch with a PR — opens in browser
- [ ] Press `<prefix> P` on a branch without a PR — silent no-op
- [ ] `ls "${XDG_CACHE_HOME:-$HOME/.cache}/tmux-pr-pin/"` — cache files appear with `<12-hex>-<branch>` naming