### PR TITLE
bootstrap: emoji-prefixed output (visual-only)

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -66,7 +66,7 @@ LNAV_REPO=".config/lnav"
 # 1. Old whole-dir symlink → tear down so we can rebuild as a real dir
 if [ -L "$LNAV_HOME" ]; then
   rm "$LNAV_HOME"
-  echo "removed: $LNAV_HOME (legacy whole-dir symlink)"
+  echo "🗑️  $LNAV_HOME (legacy whole-dir symlink)"
 fi
 # 2. Stale runtime artifacts inside the repo (from pre-migration lnav runs).
 #    Only the known set lnav itself emits — never touch installed/.
@@ -87,7 +87,7 @@ unset LNAV_HOME LNAV_REPO
 link ".config/sesh/sesh.toml" "$HOME/.config/sesh/sesh.toml"
 if [ ! -f "$HOME/.config/sesh/sesh.local.toml" ]; then
   cp "$DOTFILES/.config/sesh/sesh.local.toml.template" "$HOME/.config/sesh/sesh.local.toml"
-  echo "created: ~/.config/sesh/sesh.local.toml (edit to add machine-local sessions)"
+  echo "✨  ~/.config/sesh/sesh.local.toml (edit to add machine-local sessions)"
 fi
 
 # --- nvim
@@ -122,12 +122,12 @@ done
 # --- TPM (clone if missing; warn but don't abort if offline)
 TPM_DIR="$HOME/.config/tmux/plugins/tpm"
 if [ ! -d "$TPM_DIR/.git" ]; then
-  echo "cloning TPM..."
+  echo "⬇️  cloning TPM..."
   if ! git clone --depth=1 https://github.com/tmux-plugins/tpm "$TPM_DIR" 2>&1; then
-    echo "WARN:   TPM clone failed (offline?) — re-run bootstrap when online"
+    echo "⚠️  TPM clone failed (offline?) — re-run bootstrap when online"
   fi
 else
-  echo "ok:     $TPM_DIR (TPM present)"
+  echo "✅  $TPM_DIR (TPM present)"
 fi
 
 # --- brew check (don't install — just report)

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -138,11 +138,11 @@ brew bundle check --file="$DOTFILES/Brewfile" --verbose || \
 
 echo
 echo "🎯 next steps:"
-echo "  1. start tmux:               tmux"
-echo "  2. install plugins:          <prefix> I  (capital I, prefix = C-a)"
-echo "  3. test session picker:      <prefix> t"
-echo "  4. create machine config:    cp \$DOTFILES/.zshrc.local.template ~/.zshrc.local && \$EDITOR ~/.zshrc.local"
-echo "  5. login-shell machine cfg:  cp \$DOTFILES/.zprofile.local.template ~/.zprofile.local && \$EDITOR ~/.zprofile.local"
-echo "  6. delta + Claude hooks:     see README.md → \"Setup (new machine)\" → Manual extras"
+echo "  🪟 start tmux:               tmux"
+echo "  🧩 install plugins:          <prefix> I  (capital I, prefix = C-a)"
+echo "  🔍 test session picker:      <prefix> t"
+echo "  🏠 create machine config:    cp \$DOTFILES/.zshrc.local.template ~/.zshrc.local && \$EDITOR ~/.zshrc.local"
+echo "  🔐 login-shell machine cfg:  cp \$DOTFILES/.zprofile.local.template ~/.zprofile.local && \$EDITOR ~/.zprofile.local"
+echo "  🪝 delta + Claude hooks:     see README.md → \"Setup (new machine)\" → Manual extras"
 
 echo "🎉 dotfiles linked — finish with the next steps above"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -12,21 +12,21 @@ link() {
   local src="$DOTFILES/$1"
   local dst="$2"
   if [ ! -e "$src" ]; then
-    echo "missing: $src (skipping)"
+    echo "❓  $src (skipping)"
     return 0
   fi
   if [ -L "$dst" ] && [ "$(readlink "$dst")" = "$src" ]; then
-    echo "ok:     $dst"
+    echo "✅  $dst"
     return 0
   fi
   if [ -e "$dst" ] && [ ! -L "$dst" ]; then
     local backup="$dst.bak.$(date +%s)"
-    echo "BACKUP: $dst -> $backup"
+    echo "📦  $dst → $backup"
     mv "$dst" "$backup"
   fi
   mkdir -p "$(dirname "$dst")"
   ln -sfn "$src" "$dst"
-  echo "linked: $dst -> $src"
+  echo "🔗  $dst → $src"
 }
 
 # --- ghostty (already done; idempotent re-link)

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -5,6 +5,8 @@ set -euo pipefail
 
 DOTFILES="$PROJECTS_HOME/dotfiles"
 
+echo "🚀 dotfiles bootstrap"
+
 # link <source-relative-to-DOTFILES> <target-absolute>
 link() {
   local src="$DOTFILES/$1"
@@ -130,15 +132,17 @@ fi
 
 # --- brew check (don't install — just report)
 echo
-echo "brew bundle check:"
+echo "🍺 brew bundle check:"
 brew bundle check --file="$DOTFILES/Brewfile" --verbose || \
-  echo "-> run: brew bundle --file=$DOTFILES/Brewfile"
+  echo "→ run: brew bundle --file=$DOTFILES/Brewfile"
 
 echo
-echo "next steps:"
+echo "🎯 next steps:"
 echo "  1. start tmux:               tmux"
 echo "  2. install plugins:          <prefix> I  (capital I, prefix = C-a)"
 echo "  3. test session picker:      <prefix> t"
 echo "  4. create machine config:    cp \$DOTFILES/.zshrc.local.template ~/.zshrc.local && \$EDITOR ~/.zshrc.local"
 echo "  5. login-shell machine cfg:  cp \$DOTFILES/.zprofile.local.template ~/.zprofile.local && \$EDITOR ~/.zprofile.local"
 echo "  6. delta + Claude hooks:     see README.md → \"Setup (new machine)\" → Manual extras"
+
+echo "🎉 dotfiles linked — finish with the next steps above"


### PR DESCRIPTION
## Summary
- Replace `bootstrap.sh`'s grey text-only output with Solarized-friendly Unicode emoji prefixes — one emoji per status category (✅ ok, 🔗 linked, 📦 backup, ❓ missing, 🗑️ removed, ✨ created, ⬇️ cloning, ⚠️ warn).
- Frame the run with bookend banners: `🚀 dotfiles bootstrap` at the top, `🎉 dotfiles linked — finish with the next steps above` at the bottom; section headers gain 🍺 (brew) and 🎯 (next steps).
- Drop `1.`–`6.` numbering on the next-steps list; use thematic emoji per step (🪟 🧩 🔍 🏠 🔐 🪝). Right-hand command-sample column preserved (3-cell prefix width matches).
- ASCII `->` arrows inside echo strings become Unicode `→`.
- No functional changes — `link()` logic, idempotency, exit codes, ordering all unchanged. Single-file diff.

## Test plan
- [ ] `./bootstrap.sh` exits 0 on first run; opens with 🚀 banner, closes with 🎉 banner.
- [ ] Re-run `./bootstrap.sh`: still exits 0; every line is `✅` (idempotent — nothing re-linked).
- [ ] `grep -nE '"(ok:|linked:|BACKUP:|WARN:|removed:|created:|missing:|cloning )' bootstrap.sh` returns no matches.
- [ ] `grep -nF -- '->' bootstrap.sh` returns no matches.
- [ ] `grep -nE '^echo "  [1-6]\. ' bootstrap.sh` returns no matches.
- [ ] `bash scripts/test-helpers.sh` still passes (29/29).