### PR TITLE
[#112] Replace rbenv with mise for Ruby

### DIFF
--- a/.config/zsh/mise.zsh
+++ b/.config/zsh/mise.zsh
@@ -1,6 +1,6 @@
-# Polyglot runtime version manager (Node here; Ruby still on rbenv pending
-# its own migration). mise's `activate` registers a chpwd hook that
-# auto-switches versions per .nvmrc / .tool-versions in Rust.
+# Polyglot runtime version manager (Node + Ruby). mise's `activate`
+# registers a chpwd hook that auto-switches versions per .nvmrc /
+# .ruby-version / .tool-versions.
 
 [[ -n ${ZSH_DOTFILES_TEST:-} ]] && return
 

--- a/.zshrc
+++ b/.zshrc
@@ -8,7 +8,7 @@ fi
 # Oh-My-Zsh bootstrap — plugins=() must precede `source $ZSH/oh-my-zsh.sh`.
 export ZSH="$HOME/.oh-my-zsh"
 ZSH_THEME="powerlevel10k/powerlevel10k"
-plugins=(git brew rbenv)
+plugins=(git brew)
 source "$ZSH/oh-my-zsh.sh"
 
 # Split modules — load order matters; see plugins.zsh header for plugin order.

--- a/Brewfile
+++ b/Brewfile
@@ -18,7 +18,7 @@ brew "zoxide"  # frecency-ranked dir jumping; sesh picker source
 # Worktree manager
 brew "worktrunk"
 
-# Runtime version manager (Node; Ruby still on rbenv pending its own migration)
+# Runtime version manager (Node + Ruby)
 brew "mise"
 
 # Editor — neovim IDE (LazyVim)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,8 +33,7 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
   `env.zsh` (locale, EDITOR, PATH, MANPAGER, no-bells), `colors.zsh`
   (vivid `LS_COLORS`, fzf palette, autosuggest highlight), `mise.zsh`
   (`mise activate zsh` registers a polyglot chpwd hook for `.nvmrc` /
-  `.tool-versions`; replaces the old `load-nvmrc` shell function. Ruby is
-  still on rbenv pending its own migration — see issue #110), `tmux-hooks.zsh` (window-label,
+  `.ruby-version` / `.tool-versions`), `tmux-hooks.zsh` (window-label,
   ssh-target, `CLAUDE_CODE_TMUX_TRUECOLOR`), `modern-reminder.zsh`
   (default→modern tool nudge), `prompt.zsh` (p10k source +
   `_p9k_project_context`), `aliases.zsh` (color-aware tool aliases +


### PR DESCRIPTION
## Summary

- Drop `rbenv` from OMZ `plugins=()` so rbenv stops loading (shims no longer shadow mise)
- Update comments in `mise.zsh`, `Brewfile`, and `CLAUDE.md` to reflect mise now covers both Node and Ruby
- rbenv stays installed and `~/.rbenv/` stays on disk — dormant but available for rollback

Closes #112

## Test plan

- [ ] Open a new shell, verify `which ruby` resolves via mise (not `~/.rbenv/shims/ruby`)
- [ ] `cd` into a project with `.ruby-version`, verify mise picks up the version
- [ ] `command rbenv versions` still works (rbenv installed, just not loaded)