### PR TITLE
mise: track config.toml and wire bootstrap symlink

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -1,0 +1,11 @@
+[tools]
+node = "lts"
+ruby = "3.4.8"
+yarn = "1"
+
+[settings]
+legacy_version_file = true
+idiomatic_version_file_enable_tools = ["node", "ruby"]
+
+[settings.ruby]
+compile = false

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -90,6 +90,10 @@ if [ ! -f "$HOME/.config/sesh/sesh.local.toml" ]; then
   echo "✨  ~/.config/sesh/sesh.local.toml (edit to add machine-local sessions)"
 fi
 
+# --- mise (polyglot runtime version manager; only config.toml — mise writes
+# trustrc and other runtime state into the real ~/.config/mise/)
+link ".config/mise/config.toml" "$HOME/.config/mise/config.toml"
+
 # --- nvim
 link ".config/nvim"    "$HOME/.config/nvim"
 


### PR DESCRIPTION
## Summary

- Add `.config/mise/config.toml` to the repo — pins global tools (`node lts`, `ruby 3.4.8`, `yarn 1`) and the two settings needed for per-project version files to work
- Wire `bootstrap.sh` to symlink `config.toml` only (not the whole dir — mise writes `trustrc` and runtime state alongside it)

## Settings added

- `legacy_version_file = true` — enables reading of `.node-version` / `.nvmrc` / `.ruby-version`
- `idiomatic_version_file_enable_tools = ["node", "ruby"]` — per-tool opt-in required by mise; without this the legacy file setting is silently ignored

## Test plan

- [ ] `bootstrap.sh` on a fresh machine symlinks `~/.config/mise/config.toml` → repo file
- [ ] `mise current` in a project with `.node-version` picks up the correct version