### PR TITLE
mise: drop yarn — corepack manages it per project

### DIFF
--- a/mise.global.toml
+++ b/mise.global.toml
@@ -1,7 +1,6 @@
 [tools]
 node = "lts"
 ruby = "3.4.8"
-yarn = "1"
 
 [settings]
 legacy_version_file = true


### PR DESCRIPTION
## Summary

- Remove `yarn = "1"` from `mise.global.toml`

## Why

mise's yarn shim lands earlier in PATH than corepack's shim, so `yarn` resolves to mise's 1.22.22 even when `package.json` defines `packageManager: yarn@4.x`. Removing yarn from mise lets corepack own the `yarn` binary and dispatch the correct version per project.

## Test plan

- [ ] `yarn install` in a project with `"packageManager": "yarn@4.x"` uses the correct version