### PR TITLE
[#114] Audit OMZ plugins, empty plugins=()

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -8,7 +8,7 @@ fi
 # Oh-My-Zsh bootstrap — plugins=() must precede `source $ZSH/oh-my-zsh.sh`.
 export ZSH="$HOME/.oh-my-zsh"
 ZSH_THEME="powerlevel10k/powerlevel10k"
-plugins=(git brew)
+plugins=()
 source "$ZSH/oh-my-zsh.sh"
 
 # Split modules — load order matters; see plugins.zsh header for plugin order.


### PR DESCRIPTION
## Summary

- Audited OMZ `git` and `brew` plugins against shell history (7,227 entries)
- Zero OMZ-provided aliases used — all git/brew interactions use full commands
- `brew` plugin's `fpath+=` is redundant with `brew shellenv` in `.zprofile`
- Set `plugins=()` empty — prerequisite for eventual OMZ removal

## Audit evidence

| Command | History count |
|---|---|
| `git status` | 539 |
| `git pull` | 493 |
| `git checkout` | 474 |
| `git stash` | 192 |
| `git push` | 91 |
| OMZ git aliases (`gst`, `gco`, etc.) | 0 |
| `brew bundle` / `brew install` / etc. | 42 |
| OMZ brew aliases (`bubo`, `bcubc`, etc.) | 0 |

## Startup timing

| | Mean ± σ |
|---|---|
| Before (`plugins=(git brew)`) | 256.8 ms ± 13.3 ms |
| After (`plugins=()`) | 247.7 ms ± 18.0 ms |
| Delta | ~9 ms (~3.5%) |

Modest delta — the `git` and `brew` plugins are alias-only, so the loader cost is small. The real speedup comes when OMZ itself is removed (next step).

## Verification

- [x] `_git` and `_brew` completions backed by brew `site-functions` (independent of OMZ)
- [x] `fpath` includes `/opt/homebrew/share/zsh/site-functions` via `brew shellenv`
- [x] Test suite passes (helpers, prompt-context, window-label, modern-reminder, ssh-target)
- [x] No `zstyle`/`autoload` dependencies on OMZ plugins in `.config/zsh/` modules

Closes #114