### PR TITLE
[#115] Drop oh-my-zsh, load powerlevel10k directly

### DIFF
--- a/.config/zsh/colors.zsh
+++ b/.config/zsh/colors.zsh
@@ -2,7 +2,7 @@
 # All side-effect (env exports). Tests don't source this file.
 
 # ─── Colors & appearance ────────────────────
-# LS_COLORS for eza (and GNU ls if present); BSD `\ls` keeps OMZ default LSCOLORS.
+# LS_COLORS for eza (and GNU ls if present).
 command -v vivid >/dev/null 2>&1 && export LS_COLORS="$(vivid generate solarized-dark)"
 
 # zsh-autosuggestions: dim ghost text, readable on Solarized Dark.

--- a/.config/zsh/env.zsh
+++ b/.config/zsh/env.zsh
@@ -8,6 +8,31 @@ unsetopt BEEP        # shell errors
 unsetopt HIST_BEEP   # history expansion errors
 unsetopt LIST_BEEP   # ambiguous completion
 
+# ─── Key bindings ──────────────────────────────
+bindkey -e  # emacs mode (zsh defaults to vi when EDITOR contains 'vi')
+
+# ─── History ───────────────────────────────────
+HISTFILE="${HOME}/.zsh_history"
+HISTSIZE=50000
+SAVEHIST=10000
+setopt EXTENDED_HISTORY
+setopt HIST_EXPIRE_DUPS_FIRST
+setopt HIST_IGNORE_DUPS
+setopt HIST_IGNORE_SPACE
+setopt HIST_VERIFY
+setopt SHARE_HISTORY
+
+# ─── Shell behavior ───────────────────────────
+setopt ALWAYS_TO_END
+setopt AUTO_PUSHD
+setopt COMPLETE_IN_WORD
+setopt INTERACTIVE_COMMENTS
+setopt LONG_LIST_JOBS
+setopt NO_FLOW_CONTROL
+setopt PROMPT_SUBST
+setopt PUSHD_IGNORE_DUPS
+setopt PUSHD_MINUS
+
 export LANG=en_US.UTF-8
 export LC_ALL=en_US.UTF-8
 

--- a/.config/zsh/plugins.zsh
+++ b/.config/zsh/plugins.zsh
@@ -39,7 +39,7 @@ fi
 # BEFORE zsh-autosuggestions / zsh-syntax-highlighting (both wrap widgets).
 [[ -f /opt/homebrew/opt/fzf-tab/share/fzf-tab/fzf-tab.zsh ]] && \
   source /opt/homebrew/opt/fzf-tab/share/fzf-tab/fzf-tab.zsh
-# OMZ sets `menu select`; fzf-tab needs this disabled to capture completions.
+# fzf-tab needs `menu select` disabled to capture completions.
 zstyle ':completion:*' menu no
 # Group completions by tag with a labeled header.
 zstyle ':completion:*:descriptions' format '[%d]'

--- a/.zshrc
+++ b/.zshrc
@@ -5,11 +5,9 @@ if [[ -r "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh" ]]
   source "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh"
 fi
 
-# Oh-My-Zsh bootstrap — plugins=() must precede `source $ZSH/oh-my-zsh.sh`.
-export ZSH="$HOME/.oh-my-zsh"
-ZSH_THEME="powerlevel10k/powerlevel10k"
-plugins=()
-source "$ZSH/oh-my-zsh.sh"
+autoload -Uz compinit && compinit
+
+source /opt/homebrew/share/powerlevel10k/powerlevel10k.zsh-theme
 
 # Split modules — load order matters; see plugins.zsh header for plugin order.
 ZDOTFILES="${HOME}/.config/zsh"

--- a/Brewfile
+++ b/Brewfile
@@ -36,6 +36,7 @@ brew "difftastic"               # syntactic diff for ad-hoc compares (non-git)
 brew "glow"                     # render markdown to ANSI
 brew "tailspin"                 # syntax-highlighted log viewer (tspin)
 brew "vivid"                    # generates LS_COLORS palettes
+brew "powerlevel10k"            # p10k prompt theme (loaded directly, no OMZ)
 brew "procs"                    # modern ps replacement (Rust)
 brew "xh"                       # modern HTTP client (HTTPie-compatible CLI, Solarized-aware)
 brew "zsh-syntax-highlighting"  # live command-line highlighting

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,12 +25,14 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
   `~/.zprofile.local` (untracked; copy from `.zprofile.local.template`),
   mirroring the `.zshrc.local` pattern. Use `.zprofile.local` rather than
   `.zshrc.local` whenever a tool's init does `fpath+=` or otherwise needs
-  to run before `compinit` — `.zshrc.local` is sourced after `oh-my-zsh.sh`
-  (which runs `compinit`), so late `fpath+=` silently no-ops there.
+  to run before `compinit` — `.zshrc.local` is sourced after `compinit`
+  (which runs near the top of `.zshrc`), so late `fpath+=` silently
+  no-ops there.
 - **Zsh module layout.** `.zshrc` is a thin orchestrator (~30 lines: p10k
-  instant prompt, OMZ bootstrap, `~/.zshrc.local`, `~/.secrets`, and one
-  `source` per module). Concerns live in `.config/zsh/<concern>.zsh`:
-  `env.zsh` (locale, EDITOR, PATH, MANPAGER, no-bells), `colors.zsh`
+  instant prompt, `compinit`, p10k theme load, `~/.zshrc.local`,
+  `~/.secrets`, and one `source` per module). Concerns live in `.config/zsh/<concern>.zsh`:
+  `env.zsh` (locale, EDITOR, PATH, MANPAGER, no-bells, emacs keybindings,
+  history config, shell options), `colors.zsh`
   (vivid `LS_COLORS`, fzf palette, autosuggest highlight), `mise.zsh`
   (`mise activate zsh` registers a polyglot chpwd hook for `.nvmrc` /
   `.ruby-version` / `.tool-versions`), `tmux-hooks.zsh` (window-label,


### PR DESCRIPTION
## Summary

- Remove oh-my-zsh framework dependency — replace with direct `compinit` + `source powerlevel10k.zsh-theme`
- Explicitly set the 15 shell options OMZ was providing (history, emacs bindings, completion behavior) in `env.zsh`
- Add `brew "powerlevel10k"` to Brewfile for the direct theme install path

## Details

With `plugins=()` landed in #122, OMZ contributed only the theme loader, `compinit`, and opinionated shell options — ~30-80ms of startup for ~10 lines of equivalent config. This PR replaces the framework with those explicit lines.

p10k prompt, colors (`~/.p10k.zsh`), and all module functionality are unchanged. `auto_cd` intentionally dropped (redundant with zoxide).

Manual post-merge step: `rm -rf ~/.oh-my-zsh` after validating.

Closes #115

## Test plan

- [x] Shell options audit: `setopt | sort` before/after matches (only `autocd` removed)
- [x] All zsh module tests pass (44/44): prompt-context, window-label, modern-reminder, ssh-target, claude-window-name
- [x] All helper smoke tests pass (131/131): git-status, glow, bin/s, dashboard
- [ ] Interactive smoke test: new shell — p10k renders, tab completion, Ctrl-A/E/K/W, fzf Ctrl-R/T, zoxide, aliases
- [ ] Startup benchmark: `hyperfine 'zsh -ic exit'`