### PR TITLE
🎨 Apply Pastel Powerline preset to starship

### DIFF
--- a/.config/starship.toml
+++ b/.config/starship.toml
@@ -2,11 +2,10 @@
 
 palette = "solarized_dark"
 
-format = """
-[╭─](frame)$directory$git_branch$git_status
-[╰─](frame)$character"""
+format = """$directory[](fg:pastel_peach bg:pastel_rose)$git_branch[](fg:pastel_lblue bg:pastel_peach)$git_status[](fg:pastel_lblue)
+$character"""
 
-right_format = "$cmd_duration$jobs$status"
+right_format = "$status$cmd_duration"
 
 [palettes.solarized_dark]
 # Same hex codes already pinned in tmux/btop/lnav configs.
@@ -27,34 +26,41 @@ blue    = "#268bd2"
 cyan    = "#2aa198"
 green   = "#859900"
 frame   = "#586e75"   # base01 — matches p10k color 242 used today
+# Pastel powerline accents — scoped exception to "Solarized everywhere" (see CLAUDE.md).
+# Used only by the prompt; every other tool stays Solarized.
+pastel_rose  = "#DA627D"
+pastel_peach = "#FCA17D"
+pastel_lblue = "#86BBD8"
 
 [directory]
-format = "[$path]($style)[$read_only]($read_only_style) "
-style  = "blue"
+format = "[](fg:pastel_rose)[ $path ]($style)"
+style  = "fg:base3 bg:pastel_rose"
+truncation_length = 3
+truncation_symbol = "…/"
 
 [git_branch]
-format = "on [$symbol$branch]($style) "
-style  = "violet"
+format = "[ $symbol$branch ]($style)"
+style  = "fg:base3 bg:pastel_peach"
+symbol = " "
 
 [git_status]
-format = "[$all_status$ahead_behind]($style) "
-style  = "yellow"
+format = "([ $all_status$ahead_behind ]($style))"
+style  = "fg:base3 bg:pastel_lblue"
 
 [character]
-success_symbol = "[❯](green)"
-error_symbol   = "[❯](red)"
-vicmd_symbol   = "[❮](green)"
+success_symbol = "[❯](bold fg:pastel_lblue)"
+error_symbol   = "[❯](bold fg:pastel_rose)"
+vicmd_symbol   = "[❮](bold fg:pastel_lblue)"
 
 [cmd_duration]
 min_time = 2000
-format   = "took [$duration]($style) "
-style    = "yellow"
-
-[jobs]
-format = "[$symbol$number]($style) "
-style  = "cyan"
+format   = "[ $duration]($style) "
+style    = "fg:pastel_peach"
 
 [status]
 disabled = false
-format   = "[$status]($style) "
-style    = "red"
+format   = "[✘ $status]($style) "
+style    = "fg:pastel_rose"
+
+[jobs]
+disabled = true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -299,8 +299,19 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
   upgrades to latest then snapshots — use the latter to bump versions.
 - **`lazy-lock.json` and `mason-lock.json` are committed** for
   reproducibility across machines.
-- **Solarized + JetBrainsMono Nerd Font everywhere.** No alternatives without
-  asking.
+- **Solarized + JetBrainsMono Nerd Font everywhere — except the starship
+  prompt.** Every other tool (tmux, btop, lnav, bat, delta, glow, eza, vivid,
+  fzf, procs, tailspin, xh, syntax-highlighting plugins, …) stays Solarized
+  Dark. The starship prompt is the documented exception: it uses a pastel
+  powerline palette (`#DA627D` rose, `#FCA17D` peach, `#86BBD8` light blue)
+  named alongside the Solarized hex codes inside `[palettes.solarized_dark]`
+  in `.config/starship.toml`. Why: connected-gradient powerline chips earn
+  the palette break at the most-looked-at part of the terminal. How to
+  apply: don't extend the pastel palette to other tools without an explicit
+  ask, and don't revert the prompt to Solarized chips without an ask either
+  — see `.superpowers/specs/2026-05-06-pastel-powerline-design.md` for the
+  trade-offs (in particular the small artifact slivers that pure-α
+  continuous-flow rendering produces when conditional chips are absent).
 - **wt user config is symlinked from `.config/worktrunk/config.toml`.**
   Per-project hook approvals (`approvals.toml`) are machine-local and
   gitignored.


### PR DESCRIPTION
## ✨ Summary

- Replace the existing Solarized chips + `╭─ ╰─❯` two-line frame with a Pastel Powerline-style prompt: rose → peach → light blue chips with rounded `` (U+E0B4) separators, no corner glyphs.
- Right side keeps `$status$cmd_duration` (status first), recoloured to match — `[✘ $status]` rose, `[ $duration]` peach, `min_time = 2000` unchanged.
- Pastel palette (`#DA627D` rose, `#FCA17D` peach, `#86BBD8` light blue) is added as named entries inside the existing `[palettes.solarized_dark]` block — every other tool stays Solarized Dark.
- `CLAUDE.md` is updated to document the scoped exception to the "Solarized everywhere" rule.

## 🎯 Why

Powerline-style chips give better at-a-glance scanning of `directory / branch / status` without changing the information density. The pastel palette is a deliberate, scoped break — applied only to the prompt — at the most-looked-at part of the terminal.

## ⚖️ Trade-offs (documented)

The α (continuous-flow) rendering strategy means the literal cross-chip transition caps still fire when conditional chips don't render — producing 1–2 small color-sliver glyphs trailing the last visible chip outside git or in a clean repo. Inside a dirty repo (the most common engineering workflow) the gradient renders perfectly. See `.superpowers/specs/2026-05-06-pastel-powerline-design.md` for the full alternatives analysis.

## 🧪 Test plan

- 📁 [x] `cd /tmp` (outside git) — single rose chip + accepted artifact slivers.
- 🌱 [x] Inside a fresh `git init` clean repo — rose + peach chips + accepted artifact slivers, no empty `[ ]` lblue rectangle.
- 🚧 [x] Inside `~/code/dotfiles` (dirty repo) — full clean rose → peach → lblue gradient with `! ` git-status indicator.
- ⏱️ [x] Slow successful command — ` 3s` peach appears on right.
- ❌ [x] Slow failed command (`false`) — `✘ 1` rose appears on right and line-2 `❯` turns rose.
- 🔍 [x] No-regression scoping — pastel hex codes (`DA627D`, `FCA17D`, `86BBD8`) only appear in `.config/starship.toml` and the CLAUDE.md note; not in tmux/btop/lnav/etc.

## 📄 Spec

`.superpowers/specs/2026-05-06-pastel-powerline-design.md` (gitignored — local only).