### PR TITLE
✂️ starship: simplify to a single flush-left rose chip

### DIFF
--- a/.config/starship.toml
+++ b/.config/starship.toml
@@ -31,7 +31,7 @@ frame   = "#586e75"   # base01 — matches p10k color 242 used today
 pastel_rose  = "#DA627D"
 
 [directory]
-format = "[](fg:pastel_rose)[ $path ]($style)"
+format = "[ $path ]($style)"
 style  = "fg:base3 bg:pastel_rose"
 truncation_length = 3
 truncation_symbol = "…/"

--- a/.config/starship.toml
+++ b/.config/starship.toml
@@ -2,7 +2,7 @@
 
 palette = "solarized_dark"
 
-format = """$directory[](fg:pastel_peach bg:pastel_rose)$git_branch[](fg:pastel_lblue bg:pastel_peach)$git_status[](fg:pastel_lblue)
+format = """$directory[](fg:pastel_rose)
 $character"""
 
 right_format = "$status$cmd_duration"
@@ -29,8 +29,6 @@ frame   = "#586e75"   # base01 — matches p10k color 242 used today
 # Pastel powerline accents — scoped exception to "Solarized everywhere" (see CLAUDE.md).
 # Used only by the prompt; every other tool stays Solarized.
 pastel_rose  = "#DA627D"
-pastel_peach = "#FCA17D"
-pastel_lblue = "#86BBD8"
 
 [directory]
 format = "[](fg:pastel_rose)[ $path ]($style)"
@@ -38,24 +36,15 @@ style  = "fg:base3 bg:pastel_rose"
 truncation_length = 3
 truncation_symbol = "…/"
 
-[git_branch]
-format = "[ $symbol$branch ]($style)"
-style  = "fg:base3 bg:pastel_peach"
-symbol = " "
-
-[git_status]
-format = "([ $all_status$ahead_behind ]($style))"
-style  = "fg:base3 bg:pastel_lblue"
-
 [character]
-success_symbol = "[❯](bold fg:pastel_lblue)"
+success_symbol = "[❯](bold fg:pastel_rose)"
 error_symbol   = "[❯](bold fg:pastel_rose)"
-vicmd_symbol   = "[❮](bold fg:pastel_lblue)"
+vicmd_symbol   = "[❮](bold fg:pastel_rose)"
 
 [cmd_duration]
 min_time = 2000
 format   = "[ $duration]($style) "
-style    = "fg:pastel_peach"
+style    = "fg:pastel_rose"
 
 [status]
 disabled = false

--- a/.config/starship.toml
+++ b/.config/starship.toml
@@ -2,7 +2,7 @@
 
 palette = "solarized_dark"
 
-format = """$directory[](fg:pastel_peach bg:pastel_rose)$git_branch[](fg:pastel_lblue bg:pastel_peach)$git_status[](fg:pastel_lblue)
+format = """$directory[](fg:pastel_peach bg:pastel_rose)$git_branch[](fg:pastel_lblue bg:pastel_peach)$git_status[](fg:pastel_lblue)
 $character"""
 
 right_format = "$status$cmd_duration"
@@ -33,7 +33,7 @@ pastel_peach = "#FCA17D"
 pastel_lblue = "#86BBD8"
 
 [directory]
-format = "[](fg:pastel_rose)[ $path ]($style)"
+format = "[](fg:pastel_rose)[ $path ]($style)"
 style  = "fg:base3 bg:pastel_rose"
 truncation_length = 3
 truncation_symbol = "…/"
@@ -41,7 +41,7 @@ truncation_symbol = "…/"
 [git_branch]
 format = "[ $symbol$branch ]($style)"
 style  = "fg:base3 bg:pastel_peach"
-symbol = " "
+symbol = " "
 
 [git_status]
 format = "([ $all_status$ahead_behind ]($style))"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -302,16 +302,18 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
 - **Solarized + JetBrainsMono Nerd Font everywhere — except the starship
   prompt.** Every other tool (tmux, btop, lnav, bat, delta, glow, eza, vivid,
   fzf, procs, tailspin, xh, syntax-highlighting plugins, …) stays Solarized
-  Dark. The starship prompt is the documented exception: it uses a pastel
-  powerline palette (`#DA627D` rose, `#FCA17D` peach, `#86BBD8` light blue)
-  named alongside the Solarized hex codes inside `[palettes.solarized_dark]`
-  in `.config/starship.toml`. Why: connected-gradient powerline chips earn
-  the palette break at the most-looked-at part of the terminal. How to
-  apply: don't extend the pastel palette to other tools without an explicit
-  ask, and don't revert the prompt to Solarized chips without an ask either
-  — see `.superpowers/specs/2026-05-06-pastel-powerline-design.md` for the
-  trade-offs (in particular the small artifact slivers that pure-α
-  continuous-flow rendering produces when conditional chips are absent).
+  Dark. The starship prompt is the documented exception: it uses a single
+  pastel rose accent (`#DA627D`) named alongside the Solarized hex codes
+  inside `[palettes.solarized_dark]` in `.config/starship.toml`. The chip
+  is flush-left (no leading cap) and ends with a U+E0B4 `` rounded right
+  cap; the prompt character drops to line 2. Why: a single-chip flush-left
+  directory + rounded-right cap reads cleanly without committing to a
+  multi-color powerline (which hits a starship parsing limitation where
+  `bg:` is silently dropped when both `fg:` and `bg:` reference custom
+  palette names in the top-level format string). How to apply: don't
+  extend the pastel palette to other tools without an explicit ask, and
+  don't add chips with `(fg:custom_a bg:custom_b)` styles in the format
+  string — they will render with `bg` missing.
 - **wt user config is symlinked from `.config/worktrunk/config.toml`.**
   Per-project hook approvals (`approvals.toml`) are machine-local and
   gitignored.


### PR DESCRIPTION
## ✨ Summary

What started as a glyph-restoration follow-up to #127 turned into a simplification: drop the multi-chip rose → peach → lblue layout entirely and ship a single flush-left rose directory chip with a U+E0B4 `` rounded right cap.

## 🐛 What was wrong on `main`

#127 merged with two latent bugs:

1. 🪲 The Nerd Font powerline glyphs (U+E0B4, U+E0B6) and the git-branch glyph (U+E0A0) were silently stripped from `.config/starship.toml` during the original write — every `[…]` cap segment was empty, and `git_branch.symbol` was just two literal spaces.
2. 🪲 Even after restoring the glyphs, the multi-chip transitions still rendered with hard dark gaps between chips because starship silently drops `bg:` from format-string styles like `(fg:custom_a bg:custom_b)` when both slots reference custom palette entries.

## 🔧 What this PR does

- 🎨 Restore the missing U+E0B4 / U+E0B6 / U+E0A0 bytes (commit 1).
- ✂️ Drop `git_branch` and `git_status` from the prompt; trim the unused `pastel_peach` / `pastel_lblue` palette entries (commit 2).
- 📐 Make the directory chip flush-left — drop the leading U+E0B6 cap, keep only the trailing U+E0B4 rounded cap (commit 3).
- 📝 Update the CLAUDE.md "scoped exception" note to describe the simpler shape and document the starship `bg:` parsing limitation.

## 🧪 Test plan

- 🌹 [x] `starship prompt …` against the dotfiles repo — single rose `…/dotfiles ` chip flush against the left edge, with a clean rounded right cap; rose `❯` on line 2.
- 🔬 [x] `xxd .config/starship.toml | grep 'ee 82'` — confirms 1× U+E0B4 (right cap) present in the file; no leftover U+E0B6 or U+E0A0.
- 🧯 [x] `--status 1 --cmd-duration 2300` — `✘ 1` rose + ` 2s` rose appear on the right side; line-2 `❯` stays rose (success/error/vicmd all rose now since peach/lblue were removed).

## 🔬 Why the multi-chip layout was abandoned

I bisected the rendering with combinations of palette + named + literal-hex colors as `fg:` and `bg:` in `(fg:X bg:Y)`. The result:

| `fg:` | `bg:` | Both emitted? |
|---|---|---|
| `red` | `green` | ✅ |
| `pastel_peach` | `red` | ✅ |
| `pastel_peach` | `pastel_rose` | ❌ (bg dropped) |
| `red` | `pastel_rose` | ❌ (bg dropped) |
| (none) | `pastel_rose` | ✅ |

Whenever the `bg:` slot references a custom palette entry **and** any `fg:` is also set, starship emits only the `fg:` ANSI escape — the cap renders on terminal-default background instead of the previous chip's color, leaving a dark gap. The `[directory]` style line works fine because that's a module-level `style` field, not a top-level format-string segment.

A single chip avoids the issue entirely.