### PR TITLE
🐟 Add fish as alternative login shell with zsh feature parity

### DIFF
--- a/.config/fish/conf.d/00-env.fish
+++ b/.config/fish/conf.d/00-env.fish
@@ -1,0 +1,20 @@
+# brew shellenv — replaces .zprofile's role on the fish side. conf.d
+# runs for non-interactive shells too, so child processes inherit PATH.
+eval (/opt/homebrew/bin/brew shellenv)
+
+set -gx EDITOR vim
+set -gx LANG en_US.UTF-8
+set -gx LC_ALL en_US.UTF-8
+
+if command -q bat
+    set -gx MANPAGER 'sh -c "col -bx | bat -l man -p --paging=always"'
+    set -gx MANROFFOPT -c
+end
+
+fish_add_path -gP $HOME/.local/bin $HOME/.cargo/bin
+
+# Force Claude Code truecolor inside tmux. Single env line; the only tmux
+# integration that survives B-scope.
+if test -n "$TMUX"
+    set -gx CLAUDE_CODE_TMUX_TRUECOLOR 1
+end

--- a/.config/fish/conf.d/10-colors.fish
+++ b/.config/fish/conf.d/10-colors.fish
@@ -1,0 +1,25 @@
+if command -q vivid
+    set -gx LS_COLORS (vivid generate solarized-dark)
+end
+
+set -gx FZF_DEFAULT_OPTS '
+  --color=fg:#839496,bg:#002b36,hl:#268bd2
+  --color=fg+:#eee8d5,bg+:#073642,hl+:#268bd2
+  --color=info:#b58900,prompt:#dc322f,pointer:#d33682
+  --color=marker:#2aa198,spinner:#dc322f,header:#586e75'
+
+# Ghost-text autosuggestions — dim, readable on Solarized Dark.
+set -g fish_color_autosuggestion brblack
+
+# Solarized syntax-highlighting palette (replaces zsh-syntax-highlighting).
+set -g fish_color_command       blue
+set -g fish_color_param         normal
+set -g fish_color_quote         cyan
+set -g fish_color_redirection   magenta
+set -g fish_color_end           magenta
+set -g fish_color_error         red
+set -g fish_color_comment       brblack
+set -g fish_color_operator      magenta
+set -g fish_color_escape        yellow
+set -g fish_color_match         --background=brblack
+set -g fish_color_search_match  --background=brblack

--- a/.config/fish/conf.d/15-local.fish.template
+++ b/.config/fish/conf.d/15-local.fish.template
@@ -1,0 +1,7 @@
+# Per-machine fish config. Copied from .template by bootstrap.sh on first run.
+# Parallel to ~/.zshrc.local.
+
+set -gx PROJECTS_HOME $HOME/code
+
+# Add machine-local PATH entries here, e.g.:
+# fish_add_path -gP $HOME/some-tool/bin

--- a/.config/fish/conf.d/20-mise.fish
+++ b/.config/fish/conf.d/20-mise.fish
@@ -1,0 +1,3 @@
+if command -q mise
+    mise activate fish | source
+end

--- a/.config/fish/conf.d/25-prompt.fish
+++ b/.config/fish/conf.d/25-prompt.fish
@@ -1,0 +1,1 @@
+starship init fish | source

--- a/.config/fish/conf.d/30-aliases.fish
+++ b/.config/fish/conf.d/30-aliases.fish
@@ -1,0 +1,33 @@
+if command -q bat
+    alias cat='bat --paging=never'
+end
+
+if command -q eza
+    alias ls='eza --group-directories-first --icons'
+    alias ll='eza -lh --git --icons --group-directories-first'
+    alias la='ll -a'
+end
+
+if command -q glow
+    alias md='glow --style $HOME/.config/glow/glamour.json'
+    alias mdp='md -p'
+end
+
+if command -q procs
+    alias ps='procs'
+    alias psh='procs --load-config $HOME/.config/procs/procs-heavy.toml'
+end
+
+if command -q nvim
+    alias vim='nvim'
+    alias vi='command vim'
+    alias vimdiff='vim -d'
+end
+
+if command -q btop
+    alias top='btop'
+end
+
+if command -q difft
+    alias diff='difft'
+end

--- a/.config/fish/conf.d/40-plugins.fish
+++ b/.config/fish/conf.d/40-plugins.fish
@@ -1,0 +1,18 @@
+# fzf shell integration — Ctrl-R history, Ctrl-T file picker, Alt-C cd.
+if command -q fzf
+    fzf --fish | source
+end
+
+# Alt-C is reserved for Polish diacritics; remove fzf's cd-widget binding.
+bind -e \ec 2>/dev/null
+
+# zoxide — frecency-ranked cd. Same exclusions as the zsh side.
+if command -q zoxide
+    set -gx _ZO_EXCLUDE_DIRS "$HOME:$HOME/Downloads/*:$HOME/.config/*:$HOME/Library/*"
+    zoxide init fish | source
+end
+
+# worktrunk shell init.
+if command -q wt
+    wt config shell init fish | source
+end

--- a/.config/fish/conf.d/99-secrets.fish.template
+++ b/.config/fish/conf.d/99-secrets.fish.template
@@ -1,0 +1,7 @@
+# Per-machine secrets. Copied from .template by bootstrap.sh on first run.
+# Parallel to ~/.secrets. Last in the conf.d/ chain so it can override
+# anything earlier.
+
+# Add API keys etc. with: set -gx KEY value
+# Example:
+# set -gx ANTHROPIC_API_KEY sk-...

--- a/.config/fish/config.fish
+++ b/.config/fish/config.fish
@@ -1,0 +1,1 @@
+# fish loads conf.d/*.fish automatically. Nothing else needed here.

--- a/.config/fish/functions/less.fish
+++ b/.config/fish/functions/less.fish
@@ -1,0 +1,8 @@
+# bat-backed less wrapper. Direct port of the zsh function in aliases.zsh.
+function less
+    if isatty stdin
+        command bat --paging=always $argv
+    else
+        command bat --paging=always --plain $argv
+    end
+end

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,12 @@ tmp/
 # editor swap
 *.swp
 *~
+
+# fish machine-local config — copied from .template by bootstrap.sh
+.config/fish/conf.d/15-local.fish
+.config/fish/conf.d/99-secrets.fish
+
+# fish runtime state (universal vars, history, generated completions)
+.config/fish/fish_variables
+.config/fish/fish_history
+.config/fish/generated_completions/

--- a/Brewfile
+++ b/Brewfile
@@ -43,6 +43,7 @@ brew "zsh-syntax-highlighting"  # live command-line highlighting
 brew "zsh-autosuggestions"      # ghost-text completion from history
 brew "fzf-tab"                  # fzf-driven Tab completion menu
 brew "lnav"                     # TUI log file navigator
+brew "fish"                     # alternative interactive shell (trial)
 
 # System monitoring & benchmarking
 brew "btop"                     # modern top replacement (themed Solarized)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -586,6 +586,7 @@ filename is the source of truth).
 - tmux SSH-target (outbound overlay) tests: `scripts/test-tmux-ssh-target.zsh`
 - Session-root binding tests: `scripts/test-s-session-root.sh`
 - Dashboard smoke + integration tests: `scripts/test-dashboard.sh`
+- Fish config smoke test: `scripts/test-fish-loads.sh`
 - Reapply symlinks (idempotent): `$PROJECTS_HOME/dotfiles/bootstrap.sh`
 - Check brew deps without installing: `brew bundle check --file=$PROJECTS_HOME/dotfiles/Brewfile --verbose`
 - nvim plugin smoke test: `scripts/test-nvim.sh`

--- a/README.md
+++ b/README.md
@@ -88,6 +88,43 @@ so this is a one-time manual edit. Add (or merge into) the top-level
 These drive the `claude[<name>]` window title (tmux's
 `automatic-rename-format` reads `@claude_session_name`).
 
+**6. Try fish as the login shell (optional).** `bootstrap.sh` installs the
+fish config and copies `15-local.fish` / `99-secrets.fish` from templates,
+but it does *not* change your login shell. Enable and revert manually:
+
+```sh
+# One-time: register fish as a valid login shell
+echo /opt/homebrew/bin/fish | sudo tee -a /etc/shells
+
+# Edit the per-machine fish overlays (parallel to .zshrc.local + .secrets):
+$EDITOR ~/.config/fish/conf.d/15-local.fish    # PROJECTS_HOME, PATH overrides
+$EDITOR ~/.config/fish/conf.d/99-secrets.fish  # API keys etc.
+
+# Enable: switch login shell to fish
+chsh -s /opt/homebrew/bin/fish
+
+# Revert: switch back to zsh
+chsh -s /bin/zsh
+```
+
+After `chsh`, open a new Ghostty tab (or `exec /opt/homebrew/bin/fish` to
+hot-swap an existing pane). zsh stays installed and fully configured —
+reverting is one `chsh` call.
+
+**Parity status during the trial:**
+- ✅ Aliases (cat→bat, ls→eza, vim→nvim, ps→procs, top→btop, diff→difft,
+  md/mdp→glow, less wrapper)
+- ✅ Modern integrations (starship prompt, mise, zoxide, fzf bindings, wt)
+- ✅ Solarized syntax highlighting + autosuggestions (fish-native, no plugin)
+- ✅ Solarized fzf palette, LS_COLORS via vivid
+- ❌ Tmux window-name follow-last-cmd (`@last_cmd` hook is zsh-only for now)
+- ❌ Ghostty tab SSH-target overlay (`@ssh_target` hook is zsh-only for now)
+- ❌ `MODERN_REMINDER` discoverability nudge (zsh-only for now)
+- ❌ fzf-tab-style completion menu — fish's built-in completion pager
+  replaces it; the look-and-feel differs but the UX is on par.
+
+If you decide to keep fish, the deferred items can be ported in a follow-up.
+
 ## What's where
 
 | Tool         | Source path                          | Target              |
@@ -97,6 +134,7 @@ These drive the `claude[<name>]` window title (tmux's
 | [nvim](https://neovim.io/) | `.config/nvim/`                | `~/.config/nvim`    |
 | [vim](https://www.vim.org/) | `.vimrc`, `.vim/colors/`      | `~/.vimrc`, `~/.vim/colors` |
 | [zsh](https://www.zsh.org/) | `.zshrc`, `.zprofile`, `.config/starship.toml` | `~/.zshrc`, `~/.zprofile`, `~/.config/starship.toml` |
+| [fish](https://fishshell.com/) (alt shell) | `.config/fish/`              | `~/.config/fish/`   |
 | [sesh](https://github.com/joshmedeski/sesh) | `.config/sesh/sesh.toml` | `~/.config/sesh/sesh.toml` |
 | [worktrunk](https://worktrunk.dev/) | `.config/worktrunk/` | `~/.config/worktrunk` |
 | [glow](https://github.com/charmbracelet/glow) | `.config/glow/` | `~/.config/glow` |

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -109,6 +109,19 @@ link ".zshrc"      "$HOME/.zshrc"
 link ".zprofile"   "$HOME/.zprofile"
 link ".config/starship.toml" "$HOME/.config/starship.toml"
 
+# --- fish (alternative shell trial)
+link ".config/fish" "$HOME/.config/fish"
+if [ ! -f "$HOME/.config/fish/conf.d/15-local.fish" ]; then
+  cp "$DOTFILES/.config/fish/conf.d/15-local.fish.template" \
+     "$HOME/.config/fish/conf.d/15-local.fish"
+  echo "✨  ~/.config/fish/conf.d/15-local.fish (edit to set PROJECTS_HOME etc.)"
+fi
+if [ ! -f "$HOME/.config/fish/conf.d/99-secrets.fish" ]; then
+  cp "$DOTFILES/.config/fish/conf.d/99-secrets.fish.template" \
+     "$HOME/.config/fish/conf.d/99-secrets.fish"
+  echo "✨  ~/.config/fish/conf.d/99-secrets.fish (edit to add machine secrets)"
+fi
+
 # --- git (global ignore — paths excluded across every repo on this machine)
 link ".gitignore_global" "$HOME/.gitignore_global"
 

--- a/scripts/test-fish-loads.sh
+++ b/scripts/test-fish-loads.sh
@@ -33,7 +33,7 @@ fixture=$(mktemp -d)
 trap 'rm -rf "$fixture"' EXIT
 mkdir -p "$fixture/.config"
 ln -s "$FISH_DIR" "$fixture/.config/fish"
-if ! HOME="$fixture" fish -c 'type -q cat; and type -q ls; and type -q vim' \
+if ! HOME="$fixture" fish -c 'functions -q cat; and functions -q ls; and functions -q vim' \
     2>/tmp/fish-smoke-err; then
   echo "❌ fish session smoke failed:"
   cat /tmp/fish-smoke-err

--- a/scripts/test-fish-loads.sh
+++ b/scripts/test-fish-loads.sh
@@ -1,0 +1,44 @@
+#!/opt/homebrew/bin/bash
+# Smoke test: every fish config file parses, and a full fish session
+# starts without errors when the repo's .config/fish is loaded.
+set -euo pipefail
+
+DOTFILES="$(cd "$(dirname "$0")/.." && pwd)"
+FISH_DIR="$DOTFILES/.config/fish"
+
+if ! command -v fish >/dev/null 2>&1; then
+  echo "⏭️  fish not installed — skipping (brew install fish)"
+  exit 0
+fi
+
+if [ ! -d "$FISH_DIR" ]; then
+  echo "⏭️  $FISH_DIR not present yet — skipping"
+  exit 0
+fi
+
+# 1. Parse-check every tracked .fish file (no execution).
+fail=0
+while IFS= read -r -d '' f; do
+  if ! fish -n < "$f" 2>/tmp/fish-parse-err; then
+    echo "❌ parse error in $f:"
+    cat /tmp/fish-parse-err
+    fail=1
+  fi
+done < <(find "$FISH_DIR" -name '*.fish' -print0)
+
+# 2. Full-session smoke: spawn fish with HOME pointing at a fixture that
+#    symlinks our config in. Verify exit code and a representative alias
+#    is defined.
+fixture=$(mktemp -d)
+trap 'rm -rf "$fixture"' EXIT
+mkdir -p "$fixture/.config"
+ln -s "$FISH_DIR" "$fixture/.config/fish"
+if ! HOME="$fixture" fish -c 'type -q cat; and type -q ls; and type -q vim' \
+    2>/tmp/fish-smoke-err; then
+  echo "❌ fish session smoke failed:"
+  cat /tmp/fish-smoke-err
+  fail=1
+fi
+
+[ $fail -eq 0 ] && echo "✅ fish config loads clean"
+exit $fail


### PR DESCRIPTION
## 📝 Summary

- 🐟 Adds `fish` (homebrew, ~stable) as an opt-in alternative login shell, with config layout mirroring `.config/zsh/`. `conf.d/*.fish` files auto-load (numeric prefixes preserve order); `config.fish` is a near-empty orchestrator.
- 🎯 Ports the high-value zsh surface: aliases (cat→bat, ls→eza, ll/la, md/mdp, ps/psh, vim/vi/vimdiff, top→btop, diff→difft, less wrapper), modern integrations (starship, mise, zoxide, fzf bindings, wt), Solarized fzf palette + LS_COLORS via vivid, fish-native syntax highlighting + autosuggestions in Solarized colors.
- 🔁 Reversible by design: the user runs `chsh -s /opt/homebrew/bin/fish` to enable and `chsh -s /bin/zsh` to revert — `bootstrap.sh` never touches `/etc/shells` or the login shell. zsh stays installed and fully configured the whole time.
- 🛠 Per-machine overlay via `15-local.fish` + `99-secrets.fish` (gitignored, copied from `.template` siblings on first bootstrap — same shape as `sesh.local.toml`).
- 🚫 Explicitly **deferred** for the trial: tmux `@last_cmd` window-name hook, Ghostty SSH-target overlay, `MODERN_REMINDER` nudge, fzf-tab-style completion menu (fish's built-in pager replaces it).

## 🧪 Test plan

- [x] `scripts/test-fish-loads.sh` — parse-checks every `.fish` file and runs a full-session smoke against a fixture HOME (asserts `cat`/`ls`/`vim` aliases load).
- [x] All existing helper tests still pass (`test-helpers.sh`, `test-tmux-window-label.zsh`, `test-modern-reminder.zsh`, `test-wt-pre-remove-save.sh`, `test-claude-tmux-window-name.zsh`, `test-tmux-ssh-indicator.sh`, `test-tmux-ssh-target.zsh`, `test-s-session-root.sh`).
- [x] `brew bundle check --file=Brewfile --verbose` — `The Brewfile's dependencies are satisfied.`
- [x] `/etc/shells` confirmed unmodified — manual step lives in README "Manual extras" item 6.
- [x] Fixture-HOME spot-check confirms aliases load when our config is the active fish config (`cat`→`bat --paging=never`, `ls`→`eza ...`, `vim`→`nvim`).
- [ ] After merge: rerun `bootstrap.sh` from primary checkout to materialize `~/.config/fish` symlink + copy templates (worktree run blocked by `DOTFILES="$PROJECTS_HOME/dotfiles"` hardcode — verified via diff inspection).
- [ ] Optional follow-up sanity: `chsh -s /opt/homebrew/bin/fish`, open a new Ghostty tab, kick the tires; revert with `chsh -s /bin/zsh`.

## 📐 Design / plan

- Spec: `.superpowers/specs/2026-05-06-fish-trial-design.md` (gitignored)
- Plan: `.superpowers/plans/2026-05-06-fish-trial.md` (gitignored)

## ⚠️ Notes

- Branch is 4 commits behind `main` (starship glyph fixes); `git merge-tree` reports no conflicts.