### PR TITLE
🐟 fish: wt tab-completion for worktrees and branches

### DIFF
--- a/.config/fish/completions/wt.fish
+++ b/.config/fish/completions/wt.fish
@@ -1,0 +1,3 @@
+# worktrunk completions — dynamic, served by `wt` itself via COMPLETE=fish.
+# Covers subcommands, flags, and contextual args (worktree names, branches).
+complete --keep-order --exclusive --command wt --arguments "(test -n \"\$WORKTRUNK_BIN\"; or set -l WORKTRUNK_BIN (type -P wt 2>/dev/null); and COMPLETE=fish \$WORKTRUNK_BIN -- (commandline --current-process --tokenize --cut-at-cursor) (commandline --current-token))"


### PR DESCRIPTION
## 📝 Summary
- 🐟 Adds `.config/fish/completions/wt.fish` with a dynamic `complete` line — `wt` itself supplies subcommands, flags, worktree names, and branches via `COMPLETE=fish wt -- …`.
- 🧩 Fills the gap left by `conf.d/40-plugins.fish`, which only sources `wt config shell init fish` (function only, no completions). This is the same line `wt config shell install fish` would write.
- 🔗 Picked up automatically — `.config/fish/` is symlinked whole by `bootstrap.sh`, no re-run needed.

## 🧪 Test plan
- [ ] In a fresh fish shell, `wt switch <TAB>` lists worktrees with age / ahead-behind / merged hints
- [ ] `wt <TAB>` lists subcommands (switch, list, remove, merge, step, hook, config)
- [ ] `wt remove <TAB>` lists removable worktrees