### PR TITLE
🐟 Fish UX: kill greeting, add git abbreviations, document bell parity

### DIFF
--- a/.config/fish/conf.d/00-env.fish
+++ b/.config/fish/conf.d/00-env.fish
@@ -6,6 +6,19 @@ set -gx EDITOR vim
 set -gx LANG en_US.UTF-8
 set -gx LC_ALL en_US.UTF-8
 
+# Kill the default "Welcome to fish, the friendly interactive shell" banner.
+# `-g` (not `-U`) so this conf.d file stays the source of truth — flipping
+# the line here takes effect on the next shell start without a manual
+# `set -e fish_greeting`.
+set -g fish_greeting ''
+
+# Bell parity (CLAUDE.md → "Bells are silenced at every layer"). Fish has
+# no `unsetopt BEEP` equivalent — fish doesn't ring the bell on the events
+# zsh does (completion miss, backspace at empty line, etc.). Any `\a` that
+# fish does emit is consumed by Ghostty's `bell-features =` and tmux's
+# `bell-action none` upstream. Documented here so the per-shell layer is
+# accounted for.
+
 if command -q bat
     set -gx MANPAGER 'sh -c "col -bx | bat -l man -p --paging=always"'
     set -gx MANROFFOPT -c

--- a/.config/fish/conf.d/35-abbreviations.fish
+++ b/.config/fish/conf.d/35-abbreviations.fish
@@ -1,0 +1,32 @@
+# Fish abbreviations — type the abbreviation + Space/Enter and fish
+# expands it inline before running. Better discoverability than aliases:
+# you see what's actually being run, and `history` records the expansion.
+#
+# Conventions:
+# - Git-flow shortcuts only for now. Mnemonic only — anything you'd want
+#   to *see* before running (cat→bat, vim→nvim, ps→procs) stays an alias
+#   in 30-aliases.fish; mnemonic shortcuts (gst, gco, gp) live here.
+# - Since fish 3.6 abbreviations are per-shell (no longer universal vars),
+#   so this file is the authoritative source — no manual `abbr -e` needed
+#   to remove an entry, just delete the line and start a new shell.
+
+abbr -a gst   git status
+abbr -a gd    git diff
+abbr -a gds   git diff --staged
+abbr -a ga    git add
+abbr -a gaa   git add -A
+abbr -a gc    git commit
+abbr -a gcm   git commit -m
+abbr -a gcam  git commit -am
+abbr -a gca   git commit --amend
+abbr -a gco   git checkout
+abbr -a gsw   git switch
+abbr -a gcb   git checkout -b
+abbr -a gb    git branch
+abbr -a gp    git push
+abbr -a gpf   git push --force-with-lease
+abbr -a gpl   git pull
+abbr -a gl    git log
+abbr -a glo   git log --oneline
+abbr -a gss   git stash
+abbr -a grb   git rebase

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -360,7 +360,10 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
   `scripts/test-claude-tmux-window-name.zsh` exercises the script through a
   temp `$HOME` and a `tmux` PATH shim, so no in-place duplication of logic.
 - **Bells are silenced at every layer** (Ghostty `bell-features =`, zsh
-  `unsetopt BEEP/HIST_BEEP/LIST_BEEP`, vim `belloff=all`, tmux
+  `unsetopt BEEP/HIST_BEEP/LIST_BEEP`, fish n/a — no `BEEP`-equivalent
+  option (fish doesn't ring on completion miss / empty-line backspace);
+  any `\a` it does emit is consumed at the Ghostty/tmux layer (documented
+  inline in `.config/fish/conf.d/00-env.fish`), vim `belloff=all`, tmux
   `bell-action/visual-bell/monitor-bell off`). Don't re-enable without
   an explicit ask.
 - **Terminal tools are Solarized Dark, end-to-end.** Tools: `eza` (ls),


### PR DESCRIPTION
## 📋 Summary

Three small fish-side improvements bundled together — the recommendation from a brainstorm of \"must-have\" additions that aren't already covered by parity issues #131–133.

- 🤫 **Kill the default greeting** — `set -g fish_greeting ''` in `00-env.fish`. No more \"Welcome to fish, the friendly interactive shell\" on every new shell. Uses `-g` (not `-U`) so the conf.d file stays the source of truth.
- ⚡ **Git abbreviations starter set** — new `35-abbreviations.fish` with 20 mnemonic git shortcuts (`gst`, `gd`, `gp`, `gco`, `gcb`, `gpf`, `glo`, …). Type the abbreviation + Space and fish expands it inline before running, so `history` records the real command. Aliases (cat→bat, vim→nvim, etc.) stay aliases — abbreviations are reserved for *mnemonic* shortcuts where seeing the expansion is the point.
- 🔔 **Bell parity note** — fish has no `unsetopt BEEP` equivalent because fish doesn't ring on the events zsh does. Inline comment in `00-env.fish` and a one-line CLAUDE.md update so the per-shell layer of \"bells silenced at every layer\" is explicitly accounted for.

## 🛠 Files changed

- `.config/fish/conf.d/00-env.fish` — `fish_greeting` line + bell-parity comment
- `.config/fish/conf.d/35-abbreviations.fish` — new, 20 git abbreviations
- `CLAUDE.md` — bell bullet now mentions fish status

## 🧪 Test plan

- [x] 🟢 `scripts/test-fish-loads.sh` — parse-check all `.fish` files + smoke a fish session. Passes.
- [x] 🔍 Spot-check in a live fish: `fish_greeting` is empty, `abbr -q gst/gp/glo` all return 0.
- [ ] 🌀 Open a fresh Ghostty tab in fish — confirm no greeting banner.
- [ ] ⌨️ Type `gst<space>` — confirm it expands to `git status` inline.
- [ ] 🔕 Backspace at empty prompt / tab-complete to nothing — confirm no audible bell.

## 🔮 Related

- Parity gaps still tracked separately: #131 (window-name `@last_cmd`), #132 (outbound SSH overlay), #133 (`MODERN_REMINDER`).
- Brainstorm catalogued more candidates (completions for `s`/`gh`/`sesh`, history-config pin, fish module conventions in CLAUDE.md) — deferred until these three land and #131–133 are resolved.