### PR TITLE
✨ fish: enable Starship transient prompt

### DIFF
--- a/.config/fish/conf.d/25-prompt.fish
+++ b/.config/fish/conf.d/25-prompt.fish
@@ -1,1 +1,2 @@
 starship init fish | source
+enable_transience

--- a/.config/starship.toml
+++ b/.config/starship.toml
@@ -53,3 +53,6 @@ style    = "fg:pastel_rose"
 
 [jobs]
 disabled = true
+
+[transient_prompt]
+format = "[❯](bold fg:pastel_rose) "

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -314,6 +314,21 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
   extend the pastel palette to other tools without an explicit ask, and
   don't add chips with `(fg:custom_a bg:custom_b)` styles in the format
   string — they will render with `bg` missing.
+  Fish opts into Starship's transient prompt; zsh deliberately
+  does not. After Enter, fish replaces the active line's rose chip
+  with a bare bold rose `❯` on the frozen line — `cmd_duration` and
+  `status` on the right side stay intact (no `[transient_right_prompt]`
+  configured, so starship preserves `right_format` for free). Wired
+  by `enable_transience` (defined by `starship init fish`) called from
+  `.config/fish/conf.d/25-prompt.fish`. The `[transient_prompt]` block
+  in `.config/starship.toml` is shared across shells but inert for zsh
+  because `prompt.zsh` does not call `enable_transience` (and on the
+  installed starship version, `starship init zsh` does not even define
+  the function — so zsh literally cannot opt in by accident). Why
+  fish-only: the feature is being evaluated as part of the fish trial;
+  zsh remains the always-fancy daily driver until the trial concludes.
+  How to apply: don't add `enable_transience` to `prompt.zsh` without
+  an explicit ask — the asymmetry is deliberate.
 - **wt user config is symlinked from `.config/worktrunk/config.toml`.**
   Per-project hook approvals (`approvals.toml`) are machine-local and
   gitignored.


### PR DESCRIPTION
## 🎯 Summary

- Adds a `[transient_prompt]` block to `.config/starship.toml`
- Calls `enable_transience` from `.config/fish/conf.d/25-prompt.fish`
- Documents the fish-only choice in `CLAUDE.md` alongside the existing rose-chip exception

After Enter, fish collapses each scrollback line's rose chip to a bare bold rose `❯`. Right-side `cmd_duration` / `status` stay intact (no `[transient_right_prompt]` configured, so starship preserves `right_format` for free). zsh is unchanged — the shared TOML block is dormant there because `prompt.zsh` does not call `enable_transience`, and on the installed starship version `starship init zsh` does not even define the function.

## 🛠️ Mechanism

`enable_transience` on this machine takes the fish ≥ 4.1 fast path: it sets `fish_transient_prompt 1` (fish-builtin) rather than rebinding Enter. Active prompt rendering is unchanged; only the frozen-line render swaps to the new format.

## ✅ Test plan

- [x] `scripts/test-fish-loads.sh` passes (parse + non-interactive runtime — exercises both new TOML and the `enable_transience` call)
- [x] `starship explain` produces no warnings against the new config
- [x] `starship init zsh` confirmed not to define `enable_transience` (zsh literally cannot opt in by accident)
- [x] No `enable_transience` callsites in `.config/zsh/` or `~/.zshrc.local`
- [ ] 👀 Manual visual: fresh fish pane — `ls`, `sleep 3`, `false` — frozen lines show bare `❯` left, with `cmd_duration` / `status` still on the right (requires interactive TTY; please confirm post-merge or in a pre-merge sanity check)
- [ ] 👀 Manual visual: fresh zsh pane — frozen lines unchanged (full rose chip)

## 🔗 Spec / plan

- Spec: `.superpowers/specs/2026-05-06-fish-transient-prompt-design.md` (gitignored)
- Plan: `.superpowers/plans/2026-05-06-fish-transient-prompt.md` (gitignored)

## ⚠️ Risk surface

- **Starship version drift.** The fish ≥ 4.1 builtin path uses `fish_transient_prompt`; older fish versions hit the Enter-rebind path inside `enable_transience`. Both paths are upstream-defined — nothing in this PR locks behavior to one path.
- **Trailing space in `format`.** Required so cursor column matches `[character]`. If `[character]` is later restyled, this trailing space may need to follow.

## 📊 Session stats

| | |
|---|---|
| Started | 2026-05-06 18:34 UTC |
| Ended | 2026-05-06 18:46 UTC |
| Elapsed | 12m 31s |
| Working | 9m 25s (75% of elapsed) |
| Idle | 2m 45s |
| Total billed tokens | 8.7M |
| Total cost (public rates) | \$37.64 |
| Effective rate | \$240/hr |

| Model | Messages | Input | Output | Cache Read | Cache Write 5m | Cache Write 1h | Cost |
|---|---|---|---|---|---|---|---|
| Opus 4.7 | 103 | 757 | 92.9k | 8.0M | 0 | 622k | \$37.64 |

> Cost is a public-rate estimate; plan billing (Max / Pro / Team) bundles usage and the incremental cost is typically format. Cache reads dominating is normal — prompt caching re-uses prior turns at ~10% of base input price.