### PR TITLE
 config: ccstatusline + starship UI tweaks

### DIFF
--- a/.config/ccstatusline/settings.json
+++ b/.config/ccstatusline/settings.json
@@ -10,7 +10,10 @@
       {
         "id": "a83ffe56-6074-4e7d-826b-e4f89c4904f7",
         "type": "context-percentage",
-        "backgroundColor": "bgBrightWhite"
+        "backgroundColor": "bgBrightWhite",
+        "metadata": {
+          "inverse": "false"
+        }
       },
       {
         "id": "41900a0a-d664-4970-a166-bf3ff25c9ee2",

--- a/.config/starship.toml
+++ b/.config/starship.toml
@@ -6,6 +6,7 @@ format = """$directory[](fg:pastel_rose)
 $character"""
 
 right_format = "$status$cmd_duration"
+get = "transient_prompt.format"
 
 [palettes.solarized_dark]
 # Same hex codes already pinned in tmux/btop/lnav configs.


### PR DESCRIPTION
##  Summary
-  **ccstatusline**: set `inverse: "false"` metadata on the `context-percentage` element so its rendering stays pinned
-  **starship**: add `get = "transient_prompt.format"` alongside `right_format`

##  Test plan
- [ ] Reload Claude Code and confirm the statusline context-percentage chip renders as expected
- [ ] Open a fresh shell and confirm the starship prompt still renders correctly
- [ ] `scripts/test-helpers.sh` passes