### PR TITLE
🩹 starship: drop bogus [transient_prompt] block to silence Unknown key warning

### DIFF
--- a/.config/starship.toml
+++ b/.config/starship.toml
@@ -53,6 +53,3 @@ style    = "fg:pastel_rose"
 
 [jobs]
 disabled = true
-
-[transient_prompt]
-format = "[❯](bold fg:pastel_rose) "

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -332,15 +332,17 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
   string — they will render with `bg` missing.
   Fish opts into Starship's transient prompt; zsh deliberately
   does not. After Enter, fish replaces the active line's rose chip
-  with a bare bold rose `❯` on the frozen line — `cmd_duration` and
-  `status` on the right side stay intact (no `[transient_right_prompt]`
-  configured, so starship preserves `right_format` for free). Wired
-  by `enable_transience` (defined by `starship init fish`) called from
-  `.config/fish/conf.d/25-prompt.fish`. The `[transient_prompt]` block
-  in `.config/starship.toml` is shared across shells but inert for zsh
-  because `prompt.zsh` does not call `enable_transience` (and on the
-  installed starship version, `starship init zsh` does not even define
-  the function — so zsh literally cannot opt in by accident). Why
+  with a bare bold `❯` on the frozen line — `cmd_duration` and
+  `status` on the right side stay intact. Wired by `enable_transience`
+  (defined by `starship init fish`) called from
+  `.config/fish/conf.d/25-prompt.fish`. Starship 1.25.x has no
+  `[transient_prompt]` TOML section, so the active-line format on the
+  frozen line is whatever the fish init's built-in fallback emits;
+  don't add a `[transient_prompt]` block to `.config/starship.toml`
+  (it's silently ignored and trips `[WARN] Unknown key`). zsh cannot
+  opt in by accident because `prompt.zsh` does not call
+  `enable_transience` (and on the installed starship version,
+  `starship init zsh` does not even define the function). Why
   fish-only: the feature is being evaluated as part of the fish trial;
   zsh remains the always-fancy daily driver until the trial concludes.
   How to apply: don't add `enable_transience` to `prompt.zsh` without


### PR DESCRIPTION
## 📝 Summary

- Starship 1.25.x has no top-level `[transient_prompt]` section (confirmed against the published [config schema](https://starship.rs/config-schema.json) — only `right_format` and `continuation_prompt` exist alongside the format keys). The block added in 13048f9 was silently ignored and produced `[WARN] Error in 'StarshipRoot' at 'transient_prompt': Unknown key` on every prompt render.
- Drop the dead block from `.config/starship.toml` and update the CLAUDE.md prompt bullet so the "shared across shells" / `[transient_right_prompt]` claims (both referenced features that don't exist in starship) are gone, plus a do-not-reintroduce note for future-me.

## 🧪 Test plan

- [x] 🟢 `STARSHIP_CONFIG=… starship prompt 2>&1 >/dev/null` is silent (no WARN/ERROR).
- [x] 🐟 `scripts/test-fish-loads.sh` passes.
- [ ] 👁️ Open a fresh fish session and confirm the transient prompt still behaves the same way it did before the merge — the block was dead all along, so this is a regression check, not a feature change.

## ⚠️ Risk

🟢 **Low.** The block was never read by starship; removing it cannot change runtime behavior. The only consumer was the warning printer.

## 📎 Notes

- Fish-side transient prompt is unaffected — it's wired by `enable_transience` in `.config/fish/conf.d/25-prompt.fish`, not by TOML.
- An unrelated `.config/ghostty/config.ghostty` font-size tweak (16→14) was present in the working tree at branch time and is intentionally **not** in this commit.