### PR TITLE
🔠 ghostty: drop default font-size from 16 to 14

### DIFF
--- a/.config/ghostty/config.ghostty
+++ b/.config/ghostty/config.ghostty
@@ -11,7 +11,7 @@ selection-background = #93a1a1
 
 # ─── Font ─────────────────────────────────────
 font-family = JetBrainsMono Nerd Font Mono
-font-size = 16
+font-size = 14
 # Slightly bolder strokes on macOS retina.
 font-thicken = true
 


### PR DESCRIPTION
## 📝 Summary

- Lower the default `font-size` in `.config/ghostty/config.ghostty` from 16 to 14.
- Tighter default makes more room for split panes and tmux status content at the same window dimensions; per-display zoom shortcuts (cmd-+ / cmd--) still work for one-off adjustments.

## 🧪 Test plan

- [ ] 👁️ Reload Ghostty (`cmd-shift-,` then save) and confirm the new size renders cleanly with JetBrainsMono Nerd Font Mono.
- [ ] 🪟 Spot-check a tmux split layout — status bar chips and Nerd Font glyphs still align without truncation.

## ⚠️ Risk

🟢 **Low.** Single-line config change, easily reverted.