### PR TITLE
🪟 Port tmux window-name follow-last-cmd hook to fish

### DIFF
--- a/.config/fish/conf.d/50-tmux-hooks.fish
+++ b/.config/fish/conf.d/50-tmux-hooks.fish
@@ -1,0 +1,32 @@
+# Per-pane tmux user-options driven by fish hooks:
+#   @last_cmd — fish_preexec, drives window name (automatic-rename-format
+#               in .config/tmux/tmux.conf reads it).
+# Pure helper on top, event-registered recorder below the
+# FISH_DOTFILES_TEST guard. Tests source this file with
+# FISH_DOTFILES_TEST=1 to load the helper without registering a
+# fish_preexec listener.
+
+function _tmux_window_label --argument-names cmd
+    # Strip leading KEY=value tokens (each followed by whitespace or end-of-string).
+    while string match -rq '^[A-Za-z_][A-Za-z0-9_]*=\S*(\s+|$)' -- $cmd
+        set cmd (string replace -r '^[A-Za-z_][A-Za-z0-9_]*=\S*(\s+|$)' '' -- $cmd)
+    end
+    set -l words (string match -ar '\S+' -- $cmd)
+    switch (count $words)
+        case 0
+            echo ''
+        case 1
+            echo $words[1]
+        case '*'
+            echo "$words[1] $words[2]"
+    end
+end
+
+if not set -q FISH_DOTFILES_TEST
+    function _tmux_record_last_cmd --on-event fish_preexec
+        test -n "$TMUX"; or return
+        set -l label (_tmux_window_label "$argv[1]")
+        test -n "$label"; or return
+        tmux set -p @last_cmd "$label"
+    end
+end

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,13 +60,16 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
   pinning load order: `00-env`, `10-colors`, `15-local` (per-machine,
   untracked), `20-mise`, `25-prompt` (starship), `30-aliases`,
   `40-plugins` (fzf, zoxide, wt, Polish-diacritic Alt-C unbind),
+  `50-tmux-hooks` (fish_preexec → `@last_cmd` per-pane stamp),
   `99-secrets` (untracked). The two untracked files (`15-local.fish`,
   `99-secrets.fish`) are copied from `.template` companions by
   `bootstrap.sh` on first run. `functions/less.fish` mirrors the zsh
   bat-backed `less` wrapper; `completions/wt.fish` adds tab-completion
-  for worktrunk subcommands/branches. Don't port interactive nudges
-  (`modern-reminder`, tmux preexec hooks) to fish without an explicit
-  ask — those are zsh-side by design while fish is on trial. Smoke
+  for worktrunk subcommands/branches. The fish_preexec port for the
+  tmux window-name `@last_cmd` stamp lives in
+  `conf.d/50-tmux-hooks.fish` (issue #131). Don't port the
+  `modern-reminder` interactive nudge to fish without an explicit ask —
+  that one stays zsh-side by design while fish is on trial. Smoke
   test: `scripts/test-fish-loads.sh`.
 - **`Brewfile` is report-only.** `bootstrap.sh` runs `brew bundle check` and
   prints what's missing — it does not install. Don't change that.
@@ -374,15 +377,19 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
   worktrunk paths, sibling worktrees alike). Don't replace with
   `git worktree list` parsing.
 - **tmux window name follows the active pane's last typed command.**
-  zsh `preexec` hook `_tmux_record_last_cmd` (in `.config/zsh/tmux-hooks.zsh`)
-  sets a per-pane `@last_cmd` user variable; `tmux.conf` enables
-  `automatic-rename` with a format that reads it. Env-var assignments are
-  stripped, then the first two whitespace-separated tokens are used.
-  `allow-rename off` stays so OSC titles from apps (e.g. Claude Code) cannot
-  override. Don't replace with `automatic-rename off` or wire app-specific
-  renames without an explicit ask. `scripts/test-tmux-window-label.zsh`
-  sources the same module under `ZSH_DOTFILES_TEST=1`, so the label
-  function `_tmux_window_label` has no duplicate copy.
+  Both zsh and fish set a per-pane `@last_cmd` user variable from their
+  respective preexec hooks: `.config/zsh/tmux-hooks.zsh` (zsh `preexec`)
+  and `.config/fish/conf.d/50-tmux-hooks.fish` (fish `fish_preexec`
+  event). `tmux.conf` enables `automatic-rename` with a format that reads
+  it. Env-var assignments are stripped, then the first two
+  whitespace-separated tokens are used. `allow-rename off` stays so OSC
+  titles from apps (e.g. Claude Code) cannot override. Don't replace
+  with `automatic-rename off` or wire app-specific renames without an
+  explicit ask. `scripts/test-tmux-window-label.zsh` sources the zsh
+  module under `ZSH_DOTFILES_TEST=1`; `scripts/test-fish-tmux-window-label.fish`
+  sources the fish module under `FISH_DOTFILES_TEST=1`. Both run the
+  same 11-case matrix, so the label function `_tmux_window_label` has
+  no duplicate copy in either shell.
   When a Claude Code session is active in the pane,
   `@claude_session_name` overrides `@last_cmd` and the window renders
   `claude[<name>]`. Set/cleared by `~/.config/tmux/bin/claude-tmux-window-name`
@@ -617,6 +624,7 @@ filename is the source of truth).
 - Helper smoke tests: `scripts/test-helpers.sh`
 - Regenerate screenshot thumbnails: `scripts/build-screenshots.sh`
 - Tmux window-label tests: `scripts/test-tmux-window-label.zsh`
+- Fish tmux window-label tests: `scripts/test-fish-tmux-window-label.fish`
 - Modern-reminder tests: `scripts/test-modern-reminder.zsh`
 - Pre-remove save-shared tests: `scripts/test-wt-pre-remove-save.sh`
 - Claude tmux window-name tests: `scripts/test-claude-tmux-window-name.zsh`

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ reverting is one `chsh` call.
 - ✅ Modern integrations (starship prompt, mise, zoxide, fzf bindings, wt)
 - ✅ Solarized syntax highlighting + autosuggestions (fish-native, no plugin)
 - ✅ Solarized fzf palette, LS_COLORS via vivid
-- ❌ Tmux window-name follow-last-cmd (`@last_cmd` hook is zsh-only for now)
+- ✅ Tmux window-name follow-last-cmd (`@last_cmd` stamped from `fish_preexec`)
 - ❌ Ghostty tab SSH-target overlay (`@ssh_target` hook is zsh-only for now)
 - ❌ `MODERN_REMINDER` discoverability nudge (zsh-only for now)
 - ❌ fzf-tab-style completion menu — fish's built-in completion pager

--- a/scripts/test-fish-tmux-window-label.fish
+++ b/scripts/test-fish-tmux-window-label.fish
@@ -1,0 +1,54 @@
+#!/usr/bin/env fish
+# Unit tests for _tmux_window_label (fish port).
+# Run: fish scripts/test-fish-tmux-window-label.fish
+
+set -gx FISH_DOTFILES_TEST 1
+set -e TMUX
+
+set -l REPO (cd (dirname (status filename))/..; and pwd)
+source $REPO/.config/fish/conf.d/50-tmux-hooks.fish
+
+set -g pass 0
+set -g fail 0
+set -g fail_msgs
+
+function check_label --argument-names input want desc
+    set -l got (_tmux_window_label $input)
+    if test "$got" = "$want"
+        set -g pass (math $pass + 1)
+        echo "  PASS  $desc"
+    else
+        set -g fail (math $fail + 1)
+        set -ga fail_msgs "FAIL  $desc"
+        set -ga fail_msgs "        got:  '$got'"
+        set -ga fail_msgs "        want: '$want'"
+        echo "  FAIL  $desc"
+    end
+end
+
+echo
+echo "_tmux_window_label"
+echo "──────────────────"
+
+check_label "git push origin main" "git push" "two-word command → first two words"
+check_label "RAILS_ENV=test bundle exec rspec spec/foo" "bundle exec" "leading env var stripped"
+check_label "DEBUG=1 npm run dev" "npm run" "single env var + multi-word command"
+check_label "BUNDLE_GEMFILE=Gemfile.next RAILS_ENV=test bundle exec rspec" "bundle exec" "two leading env vars stripped"
+check_label "nvim" "nvim" "single-word command"
+check_label "git log | head -5" "git log" "pipe → first two whitespace-separated tokens"
+check_label "cd ~/projects" "cd ~/projects" "cd with single arg → both words"
+check_label "" "" "empty input → empty label"
+check_label "FOO=bar" "" "env var alone → empty label"
+check_label "FOO=bar BAZ=qux ls -la" "ls -la" "multiple env vars → stripped, then first two words"
+check_label "  git   status  " "git status" "extra whitespace collapses"
+
+echo
+echo "──────────────────"
+echo "passed: $pass"
+echo "failed: $fail"
+if test $fail -gt 0
+    echo
+    printf '%s\n' $fail_msgs
+    exit 1
+end
+exit 0


### PR DESCRIPTION
Closes #131.

Ports the zsh `preexec` → tmux `@last_cmd` per-pane stamp to fish via `fish_preexec`, flipping the README parity row from ❌ to ✅.

## ✨ Summary

- 🐟 New module `.config/fish/conf.d/50-tmux-hooks.fish` — pure `_tmux_window_label` helper plus `_tmux_record_last_cmd` registered on `fish_preexec`. Strips leading `KEY=value` env-var tokens, then emits the first two whitespace-separated tokens. Module guards listener registration behind `FISH_DOTFILES_TEST` so tests can source the helper without firing on every command.
- 🧪 New fish-native test `scripts/test-fish-tmux-window-label.fish` mirrors the zsh test's 11-case matrix verbatim (env-var stripping, pipes, multi-env prefixes, whitespace collapse, empties).
- 📚 CLAUDE.md updated to document both shells in the window-name section, the new module in the fish module-layout enumeration, and the new test in the verify-changes list. Carve-out softened — `tmux preexec hooks` removed from "don't port without ask" since the port just landed.
- 🧷 README parity row flipped: ✅ Tmux window-name follow-last-cmd (`@last_cmd` stamped from `fish_preexec`).

## 🧪 Test plan

- ✅ `fish scripts/test-fish-tmux-window-label.fish` — 11/11 PASS
- ✅ `zsh scripts/test-tmux-window-label.zsh` — 11/11 PASS (no regression)
- ✅ `bash scripts/test-fish-loads.sh` — fish config loads clean
- 🖐️ Manual smoke (needs reviewer's fish+tmux+ghostty session):
  - [ ] `vim foo` renames the window to `vim foo`
  - [ ] `RAILS_ENV=test bundle exec rspec` renames to `bundle exec` (env vars stripped)
  - [ ] Claude Code session still wins via `@claude_session_name` → `claude[<name>]`

## 📐 Notes

- 🔬 fish 4.7's `string split` lacks `--regex`, so the helper uses `string match -ar '\S+'` to extract whitespace-separated tokens — same semantics, different idiom.
- 🚫 Out of scope (separate parity rows): outbound-SSH overlay, `MODERN_REMINDER` nudge, fzf-tab-style completion menu.