### PR TITLE
🪟 tmux: simplify window-name format, leave Claude detection to the shell

### DIFF
--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -38,16 +38,26 @@ set -g monitor-bell off
 # ─── Window naming ──────────────────────────
 # allow-rename off: ignore OSC title escapes from apps (e.g. Claude Code,
 # which sets the title to its version string).
-# automatic-rename on: tmux drives the window name with three-tier precedence:
+# automatic-rename on: tmux drives the window name with four-tier precedence:
 #   1. @claude_session_name (per-pane) → render `claude[<name>]`. Set by the
 #      claude-tmux-window-name helper invoked from Claude Code's
-#      SessionStart/Stop/SessionEnd hooks; cleared on SessionEnd.
-#   2. @last_cmd (per-pane)            → render the last typed command. Set by
-#      the zsh preexec hook (_tmux_record_last_cmd in .zshrc).
-#   3. fallback                        → pane_current_command (typically `zsh`).
+#      SessionStart/Stop/SessionEnd hooks; cleared on SessionEnd. Currently
+#      dormant — Claude Code's session JSON dropped the `.name` field as of
+#      ~2.1.126, so the helper no-ops; tier kept for forward-compat in case
+#      upstream restores it.
+#   2. pane_current_command matches semver (^[0-9]+\.[0-9]+\.[0-9]+$) →
+#      render `claude[<basename(cwd)>]`. Detects Claude Code's per-version
+#      binary (~/.local/share/claude/versions/<X.Y.Z>) which the kernel
+#      records as the foreground `comm`. Sidesteps the dead .name field
+#      entirely.
+#   3. @last_cmd (per-pane)            → render the last typed command. Set by
+#      the zsh/fish preexec hooks (_tmux_record_last_cmd in
+#      .config/zsh/tmux-hooks.zsh and .config/fish/conf.d/50-tmux-hooks.fish).
+#   4. fallback                        → pane_current_command (typically the
+#      shell name).
 set -g allow-rename off
 set -g automatic-rename on
-set -g automatic-rename-format '#{?#{!=:#{@claude_session_name},},claude[#{@claude_session_name}],#{?#{==:#{@last_cmd},},#{pane_current_command},#{@last_cmd}}}'
+set -g automatic-rename-format '#{?#{!=:#{@claude_session_name},},claude[#{@claude_session_name}],#{?#{m/r:^[0-9]+\.[0-9]+\.[0-9]+$,#{pane_current_command}},claude[#{b:pane_current_path}],#{?#{==:#{@last_cmd},},#{pane_current_command},#{@last_cmd}}}}'
 
 # ─── Outer-terminal title (Ghostty tab) ────────
 # Drive the Ghostty tab title from the active pane. While an `ssh` command is

--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -38,26 +38,17 @@ set -g monitor-bell off
 # ─── Window naming ──────────────────────────
 # allow-rename off: ignore OSC title escapes from apps (e.g. Claude Code,
 # which sets the title to its version string).
-# automatic-rename on: tmux drives the window name with four-tier precedence:
-#   1. @claude_session_name (per-pane) → render `claude[<name>]`. Set by the
-#      claude-tmux-window-name helper invoked from Claude Code's
-#      SessionStart/Stop/SessionEnd hooks; cleared on SessionEnd. Currently
-#      dormant — Claude Code's session JSON dropped the `.name` field as of
-#      ~2.1.126, so the helper no-ops; tier kept for forward-compat in case
-#      upstream restores it.
-#   2. pane_current_command matches semver (^[0-9]+\.[0-9]+\.[0-9]+$) →
-#      render `claude[<basename(cwd)>]`. Detects Claude Code's per-version
-#      binary (~/.local/share/claude/versions/<X.Y.Z>) which the kernel
-#      records as the foreground `comm`. Sidesteps the dead .name field
-#      entirely.
-#   3. @last_cmd (per-pane)            → render the last typed command. Set by
-#      the zsh/fish preexec hooks (_tmux_record_last_cmd in
+# automatic-rename on: tmux drives the window name. Two-tier format:
+#   1. @last_cmd non-empty (per-pane) → render the last typed command. Set
+#      by the zsh/fish preexec hooks (_tmux_record_last_cmd in
 #      .config/zsh/tmux-hooks.zsh and .config/fish/conf.d/50-tmux-hooks.fish).
-#   4. fallback                        → pane_current_command (typically the
-#      shell name).
+#   2. fallback → pane_current_command, with a substitution that rewrites
+#      Claude Code's per-version `comm` (^[0-9]+\.[0-9]+\.[0-9]+$, e.g.
+#      `2.1.131`, basename of ~/.local/share/claude/versions/<X.Y.Z>) to
+#      the literal `claude`. Non-matching values pass through unchanged.
 set -g allow-rename off
 set -g automatic-rename on
-set -g automatic-rename-format '#{?#{!=:#{@claude_session_name},},claude[#{@claude_session_name}],#{?#{m/r:^[0-9]+\.[0-9]+\.[0-9]+$,#{pane_current_command}},claude[#{b:pane_current_path}],#{?#{==:#{@last_cmd},},#{pane_current_command},#{@last_cmd}}}}'
+set -g automatic-rename-format '#{?#{==:#{@last_cmd},},#{s/^[0-9]+\.[0-9]+\.[0-9]+$/claude/:#{pane_current_command}},#{@last_cmd}}'
 
 # ─── Outer-terminal title (Ghostty tab) ────────
 # Drive the Ghostty tab title from the active pane. While an `ssh` command is

--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -41,14 +41,19 @@ set -g monitor-bell off
 # automatic-rename on: tmux drives the window name. Two-tier format:
 #   1. @last_cmd non-empty (per-pane) → render the last typed command. Set
 #      by the zsh/fish preexec hooks (_tmux_record_last_cmd in
-#      .config/zsh/tmux-hooks.zsh and .config/fish/conf.d/50-tmux-hooks.fish).
-#   2. fallback → pane_current_command, with a substitution that rewrites
-#      Claude Code's per-version `comm` (^[0-9]+\.[0-9]+\.[0-9]+$, e.g.
-#      `2.1.131`, basename of ~/.local/share/claude/versions/<X.Y.Z>) to
-#      the literal `claude`. Non-matching values pass through unchanged.
+#      .config/zsh/tmux-hooks.zsh and .config/fish/conf.d/50-tmux-hooks.fish);
+#      cleared on Claude Code SessionEnd by claude-tmux-window-name.
+#   2. fallback → pane_current_command (typically the shell name).
+# Caveat: panes that bypass the shell preexec (e.g. tmux new-window 'claude',
+# sesh/tmuxinator templates with command="claude") render whatever the kernel
+# records as `comm` for the foreground process. For Claude Code that's the
+# version string (`2.1.131`) because the binary lives at
+# ~/.local/share/claude/versions/<X.Y.Z> via a `claude` symlink. Fix on the
+# shell-config side (always launch through an interactive shell) rather than
+# papering over in the format.
 set -g allow-rename off
 set -g automatic-rename on
-set -g automatic-rename-format '#{?#{==:#{@last_cmd},},#{s/^[0-9]+\.[0-9]+\.[0-9]+$/claude/:#{pane_current_command}},#{@last_cmd}}'
+set -g automatic-rename-format '#{?#{==:#{@last_cmd},},#{pane_current_command},#{@last_cmd}}'
 
 # ─── Outer-terminal title (Ghostty tab) ────────
 # Drive the Ghostty tab title from the active pane. While an `ssh` command is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -390,28 +390,27 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
   sources the fish module under `FISH_DOTFILES_TEST=1`. Both run the
   same 11-case matrix, so the label function `_tmux_window_label` has
   no duplicate copy in either shell.
-  When a Claude Code session is active in the pane the window renders
-  `claude[<basename(cwd)>]`. Two tiers wire this in `automatic-rename-format`,
-  in order:
-  (1) `@claude_session_name` (per-pane), set by
-  `~/.config/tmux/bin/claude-tmux-window-name` via Claude Code hooks
-  (`SessionStart`, `Stop`, `SessionEnd`) wired in `~/.claude/settings.json` —
-  currently dormant because Claude Code's `~/.claude/sessions/<pid>.json`
-  dropped the `.name` field as of ~2.1.126, so the helper's jq lookup
-  `.name // empty` always bails. Tier kept for forward-compat in case
-  upstream restores it.
-  (2) `pane_current_command` regex-matches semver
-  (`^[0-9]+\.[0-9]+\.[0-9]+$`) — Claude Code installs as
+  When a Claude Code session is active in the pane the window renders the
+  literal `claude`. Mechanism: tmux's `automatic-rename-format` falls back
+  to `#{pane_current_command}` when `@last_cmd` is empty, with a `s///:`
+  substitution that rewrites a semver-shaped `comm`
+  (`^[0-9]+\.[0-9]+\.[0-9]+$`) to `claude`. Claude Code installs as
   `~/.local/bin/claude → ~/.local/share/claude/versions/<X.Y.Z>`, so the
   kernel-recorded `comm` for the foreground process is the version string
-  (e.g. `2.1.131`). When that matches, render `claude[#{b:pane_current_path}]`
-  (basename of the pane's cwd — gives the project/worktree). Sidesteps the
-  dead `.name` field entirely; works without any helper invocation.
-  The hook config is per-machine (not symlinked from this repo — see
-  [`README.md`](README.md) → "Setup (new machine)"). The script's test mock
-  and the script itself live separately —
-  `scripts/test-claude-tmux-window-name.zsh` exercises the script through a
-  temp `$HOME` and a `tmux` PATH shim, so no in-place duplication of logic.
+  (e.g. `2.1.131`); the substitution catches that. Non-matching commands
+  (`fish`, `vim`, etc.) pass through unchanged. Sidesteps Claude Code's
+  dropped `.name` field in `~/.claude/sessions/<pid>.json` entirely; no
+  helper invocation needed.
+  The legacy helper at `~/.config/tmux/bin/claude-tmux-window-name` and
+  its Claude Code hooks (`SessionStart`, `Stop`, `SessionEnd`) wired in
+  `~/.claude/settings.json` are kept dormant — they wrote
+  `@claude_session_name`, which the format no longer reads. Useful only
+  if upstream ever restores the `.name` field, in which case the format
+  needs a new tier added back. The hook config is per-machine (not
+  symlinked from this repo — see [`README.md`](README.md) → "Setup
+  (new machine)"). `scripts/test-claude-tmux-window-name.zsh` still
+  exercises the helper through a temp `$HOME` and a `tmux` PATH shim
+  so the no-op contract stays verified.
 - **Bells are silenced at every layer** (Ghostty `bell-features =`, zsh
   `unsetopt BEEP/HIST_BEEP/LIST_BEEP`, fish n/a — no `BEEP`-equivalent
   option (fish doesn't ring on completion miss / empty-line backspace);

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -390,27 +390,27 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
   sources the fish module under `FISH_DOTFILES_TEST=1`. Both run the
   same 11-case matrix, so the label function `_tmux_window_label` has
   no duplicate copy in either shell.
-  When a Claude Code session is active in the pane the window renders the
-  literal `claude`. Mechanism: tmux's `automatic-rename-format` falls back
-  to `#{pane_current_command}` when `@last_cmd` is empty, with a `s///:`
-  substitution that rewrites a semver-shaped `comm`
-  (`^[0-9]+\.[0-9]+\.[0-9]+$`) to `claude`. Claude Code installs as
-  `~/.local/bin/claude → ~/.local/share/claude/versions/<X.Y.Z>`, so the
-  kernel-recorded `comm` for the foreground process is the version string
-  (e.g. `2.1.131`); the substitution catches that. Non-matching commands
-  (`fish`, `vim`, etc.) pass through unchanged. Sidesteps Claude Code's
-  dropped `.name` field in `~/.claude/sessions/<pid>.json` entirely; no
-  helper invocation needed.
+  Claude Code is **not** specially handled in the format — when launched
+  through an interactive shell, `@last_cmd=claude` is stamped by preexec
+  and the window renders `claude` like any other command. Caveat: panes
+  that bypass the shell (e.g. `tmux new-window 'claude'`, sesh/tmuxinator
+  templates with `command = "claude"`) have no preexec stamp, so the
+  window falls back to `#{pane_current_command}` — for Claude Code that
+  is the version string (e.g. `2.1.131`) because the binary lives at
+  `~/.local/share/claude/versions/<X.Y.Z>` and the kernel records `comm`
+  as the resolved-symlink basename. Fix that on the launch-config side
+  rather than in the tmux format.
   The legacy helper at `~/.config/tmux/bin/claude-tmux-window-name` and
   its Claude Code hooks (`SessionStart`, `Stop`, `SessionEnd`) wired in
-  `~/.claude/settings.json` are kept dormant — they wrote
-  `@claude_session_name`, which the format no longer reads. Useful only
-  if upstream ever restores the `.name` field, in which case the format
-  needs a new tier added back. The hook config is per-machine (not
-  symlinked from this repo — see [`README.md`](README.md) → "Setup
-  (new machine)"). `scripts/test-claude-tmux-window-name.zsh` still
+  `~/.claude/settings.json` survive: `set` mode is dormant (Claude Code
+  dropped the session JSON `.name` field as of ~2.1.126), but `clear`
+  mode still does useful work — unsetting `@last_cmd` on `SessionEnd`
+  so the window flips back to the shell name promptly when a Claude
+  session ends rather than holding stale `claude`. The hook config is
+  per-machine (not symlinked from this repo — see [`README.md`](README.md)
+  → "Setup (new machine)"). `scripts/test-claude-tmux-window-name.zsh`
   exercises the helper through a temp `$HOME` and a `tmux` PATH shim
-  so the no-op contract stays verified.
+  so its contract stays verified even though `set` is currently a no-op.
 - **Bells are silenced at every layer** (Ghostty `bell-features =`, zsh
   `unsetopt BEEP/HIST_BEEP/LIST_BEEP`, fish n/a — no `BEEP`-equivalent
   option (fish doesn't ring on completion miss / empty-line backspace);

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -390,13 +390,26 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
   sources the fish module under `FISH_DOTFILES_TEST=1`. Both run the
   same 11-case matrix, so the label function `_tmux_window_label` has
   no duplicate copy in either shell.
-  When a Claude Code session is active in the pane,
-  `@claude_session_name` overrides `@last_cmd` and the window renders
-  `claude[<name>]`. Set/cleared by `~/.config/tmux/bin/claude-tmux-window-name`
-  via Claude Code hooks (`SessionStart`, `Stop`, `SessionEnd`) wired in
-  `~/.claude/settings.json`. The hook config is per-machine (not symlinked
-  from this repo — see [`README.md`](README.md) → "Setup (new machine)"). The script's
-  test mock and the script itself live separately —
+  When a Claude Code session is active in the pane the window renders
+  `claude[<basename(cwd)>]`. Two tiers wire this in `automatic-rename-format`,
+  in order:
+  (1) `@claude_session_name` (per-pane), set by
+  `~/.config/tmux/bin/claude-tmux-window-name` via Claude Code hooks
+  (`SessionStart`, `Stop`, `SessionEnd`) wired in `~/.claude/settings.json` —
+  currently dormant because Claude Code's `~/.claude/sessions/<pid>.json`
+  dropped the `.name` field as of ~2.1.126, so the helper's jq lookup
+  `.name // empty` always bails. Tier kept for forward-compat in case
+  upstream restores it.
+  (2) `pane_current_command` regex-matches semver
+  (`^[0-9]+\.[0-9]+\.[0-9]+$`) — Claude Code installs as
+  `~/.local/bin/claude → ~/.local/share/claude/versions/<X.Y.Z>`, so the
+  kernel-recorded `comm` for the foreground process is the version string
+  (e.g. `2.1.131`). When that matches, render `claude[#{b:pane_current_path}]`
+  (basename of the pane's cwd — gives the project/worktree). Sidesteps the
+  dead `.name` field entirely; works without any helper invocation.
+  The hook config is per-machine (not symlinked from this repo — see
+  [`README.md`](README.md) → "Setup (new machine)"). The script's test mock
+  and the script itself live separately —
   `scripts/test-claude-tmux-window-name.zsh` exercises the script through a
   temp `$HOME` and a `tmux` PATH shim, so no in-place duplication of logic.
 - **Bells are silenced at every layer** (Ghostty `bell-features =`, zsh


### PR DESCRIPTION
The `claude[<name>]` window-name flow was already broken when this branch started — both upstream-side. Investigated, then chose a smaller fix than the original draft.

## 🐛 What was broken

**1. `@claude_session_name` is never set.** `~/.config/tmux/bin/claude-tmux-window-name set` looks up `.name` in `~/.claude/sessions/<pid>.json`; that field doesn't exist anymore. Verified across 4 session files (versions 2.1.126 / 2.1.128 / 2.1.131): only `pid, sessionId, cwd, startedAt, procStart, version, peerProtocol, kind, entrypoint, status, updatedAt` are present. Helper hits `[[ -z $name ]] && exit 0`, no-ops. Test #4 in `scripts/test-claude-tmux-window-name.zsh` already covers this path; it's now hit for every real session.

**2. Tier-3 fallback renders `2.1.131`.** Claude installs as `~/.local/bin/claude → ~/.local/share/claude/versions/2.1.131`. Kernel records `comm` as the basename of the resolved executable, so `#{pane_current_command}` returns the version string.

## ✨ Approach

Earlier draft added a regex tier in the format (`s/^[0-9]+\.[0-9]+\.[0-9]+$/claude/`). Walked it back: that's papering over the real fix. When the user types `claude` at a fish/zsh prompt, the existing `_tmux_record_last_cmd` preexec hook already stamps `@last_cmd=claude`, and the window correctly renders `claude`. The regex was only a safety net for panes that bypass the shell (`tmux new-window 'claude'`, sesh templates with `command = "claude"`, etc.) — those should be fixed at the launcher, not in the tmux format.

Final format collapses back to the original two-tier shape:

```
'#{?#{==:#{@last_cmd},},#{pane_current_command},#{@last_cmd}}'
```

## 🧹 Net change

- 🗑️  Drop the dormant `@claude_session_name` tier from `automatic-rename-format`. Helper script + its 11-case test stay (helper's `clear` mode still usefully unsets `@last_cmd` on Claude `SessionEnd`).
- 📝 `tmux.conf` comment + `CLAUDE.md` window-naming bullet rewritten to document the simpler shape and the bypass-the-preexec caveat.

## 🧪 Test plan

- ✅ `zsh scripts/test-claude-tmux-window-name.zsh` — 11/11 PASS (helper untouched).
- ✅ Live `tmux source-file ~/.config/tmux/tmux.conf`: window with `@last_cmd` set renders that value; window without falls back to `#{pane_current_command}` (e.g. `fish`, or for Claude panes spawned outside an interactive shell, the version string — that's the behavior we're choosing to leave visible).
- ✅ Format syntax probe: `tmux display -p` evaluates without error.

## 📐 Why not detect Claude in the format

- The format would have to hardcode the literal `claude` somewhere (kernel doesn't preserve the symlink basename), and the regex would need updating if Claude's binary path scheme changes again.
- It hides the real bug: a launcher path that bypasses the shell and so doesn't stamp `@last_cmd`.
- `@last_cmd` already works for the typical case (typing `claude` interactively) on every shell that has the preexec hook.

## 🔁 Forward-compat

If Claude Code restores `.name` in session JSON later, the helper starts writing `@claude_session_name` again — re-add a tier to the format (one ternary).