### PR TITLE
📦 Brewfile: add rsync, uv, shellcheck, shfmt

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -8,6 +8,7 @@ brew "jq"   # JSON parsing in shell helpers
 brew "gh"   # GitHub CLI — drives tmux-pr-detect + <prefix> P (gh pr view --web)
 brew "watch"  # procps watch — used by `dashboard` for live tile polling (-c ANSI passthrough)
 brew "bash"   # bash 5; pinned-shebang scripts target /opt/homebrew/bin/bash
+brew "rsync"  # GNU rsync 3.x; shadows BSD openrsync — restores --info=progress2, -A (ACLs), -N (crtimes), --partial-dir
 
 # Session switcher (sesh + fzf, sesh comes from a tap)
 brew "fzf"
@@ -18,8 +19,9 @@ brew "zoxide"  # frecency-ranked dir jumping; sesh picker source
 # Worktree manager
 brew "worktrunk"
 
-# Runtime version manager (Node + Ruby)
+# Runtime version manager (Node + Ruby) + Python package runner
 brew "mise"
+brew "uv"  # fast Python package manager + ephemeral-venv runner; "uv run --with pyyaml script.py" without polluting global Python
 
 # Editor — neovim IDE (LazyVim)
 brew "neovim"
@@ -44,6 +46,10 @@ brew "zsh-autosuggestions"      # ghost-text completion from history
 brew "fzf-tab"                  # fzf-driven Tab completion menu
 brew "lnav"                     # TUI log file navigator
 brew "fish"                     # alternative interactive shell (trial)
+
+# Shell script linting & formatting
+brew "shellcheck"               # zsh/bash/sh static analysis (quoting bugs, unused vars, POSIX/bashism mismatches)
+brew "shfmt"                    # POSIX/bash/mksh formatter (`-d` for diff, `-w` to write)
 
 # System monitoring & benchmarking
 brew "btop"                     # modern top replacement (themed Solarized)


### PR DESCRIPTION
## 📋 Summary

Brewfile-only change — adds four tools the dotfiles already lean on implicitly:

- 🔄 \`rsync\` — GNU rsync 3.x; shadows the BSD \`openrsync\` macOS ships. Restores \`--info=progress2\`, \`-A\` (ACLs), \`-N\` (crtimes), \`--partial-dir\`.
- 🐍 \`uv\` — fast Python package manager + ephemeral-venv runner. Lets \`uv run --with pyyaml script.py\` work without polluting global Python.
- 🧹 \`shellcheck\` + \`shfmt\` — static analysis and formatting for the bash/zsh scripts under \`bin/\`, \`scripts/\`, and \`.config/zsh/\`.

## ✅ Test plan

- [ ] \`brew bundle --file=Brewfile\` installs all four cleanly.
- [ ] \`brew bundle check --file=Brewfile --verbose\` reports satisfied afterwards (this is what \`bootstrap.sh\` invokes).
- [ ] \`which rsync\` resolves to \`/opt/homebrew/bin/rsync\`; \`rsync --version\` reports protocol 31+ (i.e. GNU, not openrsync).
- [ ] \`uv --version\`, \`shellcheck --version\`, \`shfmt --version\` all run.

## 📝 Notes

\`Brewfile\` is report-only — \`bootstrap.sh\` runs \`brew bundle check\` but never installs. After this lands, run \`brew bundle\` once to pick the new tools up.