### PR TITLE
🐟 Fish-first: promote fish to primary shell, demote zsh to fallback

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -45,7 +45,7 @@ brew "zsh-syntax-highlighting"  # live command-line highlighting
 brew "zsh-autosuggestions"      # ghost-text completion from history
 brew "fzf-tab"                  # fzf-driven Tab completion menu
 brew "lnav"                     # TUI log file navigator
-brew "fish"                     # alternative interactive shell (trial)
+brew "fish"                     # primary interactive shell
 
 # Shell script linting & formatting
 brew "shellcheck"               # zsh/bash/sh static analysis (quoting bugs, unused vars, POSIX/bashism mismatches)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # dotfiles — Claude Code instructions
 
-Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zsh.
+Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + fish.
 
 ## Conventions — don't drift from these
 
@@ -8,16 +8,26 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
 - **Bash scripts target bash 5.** Shebang `#!/opt/homebrew/bin/bash`; may
   use `mapfile`, `declare -A`, `wait -n`. Apple Silicon only — `brew
   bundle` runs before `bootstrap.sh`. Don't reintroduce bash-3 shims.
-- **`.zprofile` runs `brew shellenv`** so `/opt/homebrew/bin` precedes
-  the paths macOS's `/etc/zprofile` (`path_helper`) installs. Don't move
-  into `.zshrc` — interactive subshells re-source it and re-stack PATH.
-  Machine-specific login init that needs to run before `compinit` (e.g.
-  OrbStack, anything doing `fpath+=`) goes in `~/.zprofile.local`
-  (untracked; copy from template). `.zshrc.local` is sourced *after*
-  `compinit`, so late `fpath+=` silently no-ops there.
-- **Zsh module layout.** `.zshrc` is a thin orchestrator (~20 lines:
-  `compinit`, one `source` per module, `~/.zshrc.local`, `~/.secrets`).
-  Concerns live in `.config/zsh/<concern>.zsh`:
+- **Fish module layout.** Fish is the primary interactive shell. Config
+  in `.config/fish/`, symlinked to `~/.config/fish`.
+  `config.fish` is empty; concerns in `conf.d/<NN>-<concern>.fish`,
+  numeric prefix pins load order:
+  `00-env`, `10-colors`, `15-local` (per-machine, untracked), `20-mise`,
+  `25-prompt` (starship), `30-aliases`,
+  `35-abbreviations` (git-flow mnemonic abbrs — `gst`, `gco`, `gp`, …),
+  `40-plugins` (fzf, zoxide, wt, Polish-diacritic Alt-C unbind),
+  `50-tmux-hooks` (fish_preexec → `@last_cmd` per-pane stamp),
+  `99-secrets` (untracked). The two untracked files are copied from
+  `.template` companions by `bootstrap.sh`. `functions/less.fish`
+  mirrors the zsh bat-backed `less`; `completions/wt.fish` adds wt
+  tab-completion. Don't port `modern-reminder` to fish without an ask.
+  Smoke test: `scripts/test-fish-loads.sh`.
+- **Zsh module layout (fallback).** Fallback shell. Kept until the fish
+  transition settles; see `REMOVAL.md` for the removal procedure. Don't
+  add new functionality here — port to fish first. `.zshrc` is a thin
+  orchestrator (~20 lines: `compinit`, one `source` per module,
+  `~/.zshrc.local`, `~/.secrets`). Concerns live in
+  `.config/zsh/<concern>.zsh`:
   - `env.zsh` — locale, EDITOR, PATH, MANPAGER, no-bells, emacs keys, history, shopts
   - `colors.zsh` — vivid `LS_COLORS`, fzf palette, autosuggest highlight
   - `mise.zsh` — `mise activate` chpwd hook
@@ -33,20 +43,14 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
   `mise.zsh` — after PATH appends, before hook-registering modules. New
   concerns get their own module file; don't add top-level `source` calls
   outside the `.config/zsh/` set.
-- **Fish module layout (trial shell).** Fish is a *trial* — zsh stays
-  primary. Config in `.config/fish/`, symlinked to `~/.config/fish`.
-  `config.fish` is empty; concerns in `conf.d/<NN>-<concern>.fish`,
-  numeric prefix pins load order:
-  `00-env`, `10-colors`, `15-local` (per-machine, untracked), `20-mise`,
-  `25-prompt` (starship), `30-aliases`,
-  `35-abbreviations` (git-flow mnemonic abbrs — `gst`, `gco`, `gp`, …),
-  `40-plugins` (fzf, zoxide, wt, Polish-diacritic Alt-C unbind),
-  `50-tmux-hooks` (fish_preexec → `@last_cmd` per-pane stamp),
-  `99-secrets` (untracked). The two untracked files are copied from
-  `.template` companions by `bootstrap.sh`. `functions/less.fish`
-  mirrors the zsh bat-backed `less`; `completions/wt.fish` adds wt
-  tab-completion. Don't port `modern-reminder` to fish without an ask.
-  Smoke test: `scripts/test-fish-loads.sh`.
+- **`.zprofile` runs `brew shellenv`** (zsh-side login init; fish parity
+  is in `.config/fish/conf.d/00-env.fish`) so `/opt/homebrew/bin` precedes
+  the paths macOS's `/etc/zprofile` (`path_helper`) installs. Don't move
+  into `.zshrc` — interactive subshells re-source it and re-stack PATH.
+  Machine-specific login init that needs to run before `compinit` (e.g.
+  OrbStack, anything doing `fpath+=`) goes in `~/.zprofile.local`
+  (untracked; copy from template). `.zshrc.local` is sourced *after*
+  `compinit`, so late `fpath+=` silently no-ops there.
 - **`Brewfile` is report-only.** `bootstrap.sh` runs `brew bundle check`;
   it does not install.
 - **Global gitignore is symlinked from `.gitignore_global`.**
@@ -187,12 +191,12 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + zs
   custom palette names in the top-level format. Don't extend pastel to
   other tools; don't add `(fg:custom_a bg:custom_b)` chips.
 
-  Fish opts into Starship's transient prompt; zsh deliberately does not.
-  After Enter, fish replaces the active chip with a bold `❯`;
-  `cmd_duration`/`status` stay intact. Wired via `enable_transience`
-  from `.config/fish/conf.d/25-prompt.fish`. Starship 1.25.x has no
-  `[transient_prompt]` section — don't add one (silently ignored,
-  trips `[WARN]`). The asymmetry is deliberate (fish is on trial).
+  Fish (primary) opts into Starship's transient prompt; zsh (fallback)
+  does not — don't add it to zsh. After Enter, fish replaces the active
+  chip with a bold `❯`; `cmd_duration`/`status` stay intact. Wired via
+  `enable_transience` from `.config/fish/conf.d/25-prompt.fish`. Starship
+  1.25.x has no `[transient_prompt]` section — don't add one (silently
+  ignored, trips `[WARN]`).
 - **wt user config is symlinked from `.config/worktrunk/config.toml`.**
   Per-project `approvals.toml` is machine-local and gitignored.
 - **Gitignored content flows between primary and worktrees in two

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotfiles
 
-Personal config for Ghostty + zsh + tmux + vim, all in Solarized + JetBrainsMono Nerd Font.
+Personal config for Ghostty + fish + tmux + vim, all in Solarized + JetBrainsMono Nerd Font.
 
 <p align="center">
   <a href="docs/images/example_terminal.png"><img src="docs/images/example_terminal-thumb.png" alt="terminal" width="32%" /></a>
@@ -34,28 +34,30 @@ operational checklist.
 
 ### Manual extras
 
-**1. `~/.zshrc.local`** — per-machine env (e.g. `PROJECTS_HOME` and any
-secrets paths).
+**1. Login shell — fish.** `bootstrap.sh` installs the fish config and copies
+`15-local.fish` / `99-secrets.fish` from templates, but it does *not* change
+your login shell. Enable manually:
 
 ```sh
-cp $PROJECTS_HOME/dotfiles/.zshrc.local.template ~/.zshrc.local
-$EDITOR ~/.zshrc.local
+# One-time: register fish as a valid login shell
+echo /opt/homebrew/bin/fish | sudo tee -a /etc/shells
+
+# Edit the per-machine fish overlays:
+$EDITOR ~/.config/fish/conf.d/15-local.fish    # PROJECTS_HOME, PATH overrides
+$EDITOR ~/.config/fish/conf.d/99-secrets.fish  # API keys etc.
+
+# Switch login shell to fish
+chsh -s /opt/homebrew/bin/fish
 ```
 
-**2. `~/.zprofile.local`** — per-machine *login-shell* init (e.g. OrbStack's
-`source ~/.orbstack/shell/init.zsh`). Use this instead of `.zshrc.local`
-for tools that need PATH or `fpath+=` set up before `compinit` runs.
+After `chsh`, open a new Ghostty tab (or `exec /opt/homebrew/bin/fish` to
+hot-swap an existing pane).
 
-```sh
-cp $PROJECTS_HOME/dotfiles/.zprofile.local.template ~/.zprofile.local
-$EDITOR ~/.zprofile.local
-```
-
-**3. `~/.config/sesh/sesh.local.toml`** — `bootstrap.sh` copies the template
+**2. `~/.config/sesh/sesh.local.toml`** — `bootstrap.sh` copies the template
 on first run. Edit it to add machine-local project sessions; the shared
 `sesh.toml` is the wrong place for them.
 
-**4. Wire delta into git** (one-time, global).
+**3. Wire delta into git** (one-time, global).
 
 ```sh
 git config --global core.pager delta
@@ -65,7 +67,7 @@ git config --global delta.line-numbers true
 git config --global delta.syntax-theme "Solarized (dark)"
 ```
 
-**5. Claude Code window-title hooks.** `~/.claude/settings.json` is not
+**4. Claude Code window-title hooks.** `~/.claude/settings.json` is not
 symlinked from this repo (it accumulates machine-local permission state),
 so this is a one-time manual edit. Add (or merge into) the top-level
 `hooks` object:
@@ -88,42 +90,24 @@ so this is a one-time manual edit. Add (or merge into) the top-level
 These drive the `claude[<name>]` window title (tmux's
 `automatic-rename-format` reads `@claude_session_name`).
 
-**6. Try fish as the login shell (optional).** `bootstrap.sh` installs the
-fish config and copies `15-local.fish` / `99-secrets.fish` from templates,
-but it does *not* change your login shell. Enable and revert manually:
+**5. Fallback shell — zsh.** zsh stays installed and configured as a
+fallback while the fish transition settles. See [`REMOVAL.md`](REMOVAL.md)
+for the procedure to drop zsh later.
 
 ```sh
-# One-time: register fish as a valid login shell
-echo /opt/homebrew/bin/fish | sudo tee -a /etc/shells
+# Per-machine env (PROJECTS_HOME and any secrets paths):
+cp $PROJECTS_HOME/dotfiles/.zshrc.local.template ~/.zshrc.local
+$EDITOR ~/.zshrc.local
 
-# Edit the per-machine fish overlays (parallel to .zshrc.local + .secrets):
-$EDITOR ~/.config/fish/conf.d/15-local.fish    # PROJECTS_HOME, PATH overrides
-$EDITOR ~/.config/fish/conf.d/99-secrets.fish  # API keys etc.
+# Per-machine login-shell init (e.g. OrbStack's `source ~/.orbstack/shell/init.zsh`).
+# Use this instead of .zshrc.local for tools that need PATH or `fpath+=` set up
+# before `compinit` runs.
+cp $PROJECTS_HOME/dotfiles/.zprofile.local.template ~/.zprofile.local
+$EDITOR ~/.zprofile.local
 
-# Enable: switch login shell to fish
-chsh -s /opt/homebrew/bin/fish
-
-# Revert: switch back to zsh
+# Revert login shell to zsh:
 chsh -s /bin/zsh
 ```
-
-After `chsh`, open a new Ghostty tab (or `exec /opt/homebrew/bin/fish` to
-hot-swap an existing pane). zsh stays installed and fully configured —
-reverting is one `chsh` call.
-
-**Parity status during the trial:**
-- ✅ Aliases (cat→bat, ls→eza, vim→nvim, ps→procs, top→btop, diff→difft,
-  md/mdp→glow, less wrapper)
-- ✅ Modern integrations (starship prompt, mise, zoxide, fzf bindings, wt)
-- ✅ Solarized syntax highlighting + autosuggestions (fish-native, no plugin)
-- ✅ Solarized fzf palette, LS_COLORS via vivid
-- ✅ Tmux window-name follow-last-cmd (`@last_cmd` stamped from `fish_preexec`)
-- ❌ Ghostty tab SSH-target overlay (`@ssh_target` hook is zsh-only for now)
-- ❌ `MODERN_REMINDER` discoverability nudge (zsh-only for now)
-- ❌ fzf-tab-style completion menu — fish's built-in completion pager
-  replaces it; the look-and-feel differs but the UX is on par.
-
-If you decide to keep fish, the deferred items can be ported in a follow-up.
 
 ## What's where
 
@@ -133,8 +117,8 @@ If you decide to keep fish, the deferred items can be ported in a follow-up.
 | [tmux](https://github.com/tmux/tmux) | `.config/tmux/`      | `~/.config/tmux`    |
 | [nvim](https://neovim.io/) | `.config/nvim/`                | `~/.config/nvim`    |
 | [vim](https://www.vim.org/) | `.vimrc`, `.vim/colors/`      | `~/.vimrc`, `~/.vim/colors` |
-| [zsh](https://www.zsh.org/) | `.zshrc`, `.zprofile`, `.config/starship.toml` | `~/.zshrc`, `~/.zprofile`, `~/.config/starship.toml` |
-| [fish](https://fishshell.com/) (alt shell) | `.config/fish/`              | `~/.config/fish/`   |
+| [fish](https://fishshell.com/) | `.config/fish/`              | `~/.config/fish/`   |
+| [zsh](https://www.zsh.org/) (fallback) | `.zshrc`, `.zprofile`, `.config/starship.toml` | `~/.zshrc`, `~/.zprofile`, `~/.config/starship.toml` |
 | [sesh](https://github.com/joshmedeski/sesh) | `.config/sesh/sesh.toml` | `~/.config/sesh/sesh.toml` |
 | [worktrunk](https://worktrunk.dev/) | `.config/worktrunk/` | `~/.config/worktrunk` |
 | [glow](https://github.com/charmbracelet/glow) | `.config/glow/` | `~/.config/glow` |

--- a/REMOVAL.md
+++ b/REMOVAL.md
@@ -1,0 +1,58 @@
+# Removing zsh
+
+zsh is currently kept as a fallback while the fish transition settles. This
+file lives until zsh is removed; deleting it is the last step of the
+removal procedure (§2 step 10).
+
+## §1 Pre-flight checks
+
+Each row below is a known-zsh-only behavior that disappears when zsh is
+removed. For each, decide *port to fish*, *accept the loss*, or *block
+removal until fixed*. When every row is `accept` or `port` (none `block`),
+removal is unblocked.
+
+| # | Behavior | Currently | Decision |
+|---|----------|-----------|----------|
+| 1 | Ghostty tab title shows ` user@host` while ssh'd | zsh-only (`@ssh_target` hook in `.config/zsh/tmux-hooks.zsh`) | port / accept / block |
+| 2 | `MODERN_REMINDER` discoverability nudge (`tail`/`tspin`, `grep`/`rg`, `curl`/`xh`) | zsh-only (`.config/zsh/modern-reminder.zsh`) | port / accept / block |
+| 3 | fzf-tab style completion menu | zsh-only; fish has its own pager | already accepted |
+| 4 | Starship transient prompt | fish-only on purpose; nothing to lose | n/a |
+| 5 | Per-machine init that runs before `compinit` (`~/.zprofile.local`) | zsh-only | confirm content has migrated to `~/.config/fish/conf.d/15-local.fish` |
+| 6 | Per-machine interactive overrides (`~/.zshrc.local`) | zsh-only | confirm content has migrated to `15-local.fish` (or `99-secrets.fish` if sensitive) |
+
+## §2 Removal procedure
+
+1. **Confirm pre-flight** — every row in §1 is `accept` or `port` (none `block`).
+2. **Repo files to delete:**
+   - `.zshrc`, `.zprofile`
+   - `.zshrc.local.template`, `.zprofile.local.template`
+   - `.config/zsh/` (entire directory)
+   - `scripts/test-modern-reminder.zsh`
+   - `scripts/test-tmux-window-label.zsh` (zsh variant; the fish equivalent
+     `scripts/test-fish-tmux-window-label.fish` stays)
+   - `scripts/test-tmux-ssh-target.zsh`
+   - `scripts/test-claude-tmux-window-name.zsh` — audit before deleting. If
+     it tests cross-shell behavior, port to bash; if zsh-only, delete.
+3. **`bootstrap.sh`** — delete the `# --- zsh (fallback — see REMOVAL.md)`
+   block (the four `link` calls for `.config/zsh`, `.zshrc`, `.zprofile`,
+   `.config/starship.toml`). Keep the `starship.toml` link — fish uses it
+   too. Move it into the fish block.
+4. **`Brewfile`** — remove `zsh-syntax-highlighting`, `zsh-autosuggestions`,
+   `fzf-tab`. Run
+   `brew bundle cleanup --file=$PROJECTS_HOME/dotfiles/Brewfile` to
+   uninstall.
+5. **Machine-local files** (per machine):
+   `rm ~/.zshrc ~/.zprofile ~/.zshrc.local ~/.zprofile.local`;
+   `rm -rf ~/.config/zsh/` (these are repo symlinks; safe to remove).
+6. **`/etc/shells`** — optional. Removing `/bin/zsh` is harmless to leave;
+   only edit if you want to be tidy.
+7. **System zsh (`/bin/zsh`)** — Apple-shipped, can't be uninstalled.
+   Leave it.
+8. **`CLAUDE.md`** — remove the "Zsh module layout (fallback)" subsection,
+   remove the `.zprofile` bullet, drop `~/.zshrc.local` references in the
+   env block, simplify the transient-prompt note ("fish has transient
+   prompt; nothing else to qualify").
+9. **`README.md`** — drop the "Fallback shell — zsh" subsection from
+   "Manual extras"; drop the `~/.zshrc.local` line if still cited; drop
+   the zsh row from the "What's where" table.
+10. **Delete this file** — `rm REMOVAL.md` is the last commit.

--- a/REMOVAL.md
+++ b/REMOVAL.md
@@ -55,4 +55,11 @@ removal is unblocked.
 9. **`README.md`** — drop the "Fallback shell — zsh" subsection from
    "Manual extras"; drop the `~/.zshrc.local` line if still cited; drop
    the zsh row from the "What's where" table.
-10. **Delete this file** — `rm REMOVAL.md` is the last commit.
+10. **Cheatsheets** — `docs/terminal-cheatsheet.html` and
+    `docs/tmux-cheatsheet.html` carry zsh-specific references (plugin
+    source order in `.zshrc`, `MODERN_REMINDER` toggle, `_tmux_window_label`
+    location, plugin rows for `zsh-autosuggestions` /
+    `zsh-syntax-highlighting` / `fzf-tab`, references to the zsh-only test
+    scripts deleted in step 2). Audit both files and drop zsh-only content;
+    refresh footer dates.
+11. **Delete this file** — `rm REMOVAL.md` is the last commit.

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -103,13 +103,13 @@ link ".vimrc"          "$HOME/.vimrc"
 link ".vim/colors"     "$HOME/.vim/colors"
 mkdir -p "$HOME/.vim/undo" "$HOME/.vim/backup" "$HOME/.vim/swap"
 
-# --- zsh
+# --- zsh (fallback — see REMOVAL.md)
 link ".config/zsh" "$HOME/.config/zsh"
 link ".zshrc"      "$HOME/.zshrc"
 link ".zprofile"   "$HOME/.zprofile"
 link ".config/starship.toml" "$HOME/.config/starship.toml"
 
-# --- fish (alternative shell trial)
+# --- fish (primary)
 link ".config/fish" "$HOME/.config/fish"
 if [ ! -f "$HOME/.config/fish/conf.d/15-local.fish" ]; then
   cp "$DOTFILES/.config/fish/conf.d/15-local.fish.template" \
@@ -159,8 +159,8 @@ echo "🎯 next steps:"
 echo "  🪟 start tmux:               tmux"
 echo "  🧩 install plugins:          <prefix> I  (capital I, prefix = C-a)"
 echo "  🔍 test session picker:      <prefix> t"
-echo "  🏠 create machine config:    cp \$DOTFILES/.zshrc.local.template ~/.zshrc.local && \$EDITOR ~/.zshrc.local"
-echo "  🔐 login-shell machine cfg:  cp \$DOTFILES/.zprofile.local.template ~/.zprofile.local && \$EDITOR ~/.zprofile.local"
+echo "  🐟 set fish as login shell:  see README.md → \"Manual extras\" → 1 (Login shell — fish)"
+echo "  🛟 zsh fallback machine cfg: see README.md → \"Manual extras\" → 5 (Fallback shell — zsh)"
 echo "  🪝 delta + Claude hooks:     see README.md → \"Setup (new machine)\" → Manual extras"
 
 echo "🎉 dotfiles linked — finish with the next steps above"


### PR DESCRIPTION
## 🎯 Summary

- Flip the dotfiles repo so fish is documented as the primary interactive shell and zsh is the fallback. The login shell on this machine is already `chsh`'d to fish; this PR catches the docs and conventions up.
- Add `REMOVAL.md` at repo root: pre-flight checklist (zsh-only behaviors that disappear) + 11-step removal procedure for the day zsh is dropped.
- No code restructuring, no install-time machinery, no fish parity work. Pure docs + comment edits.

## 📂 Files touched

- 📘 `README.md` — tagline; "Setup → Manual extras" reordered (fish §1, zsh fallback §5); parity-status block deleted (migrated to REMOVAL.md); fish/zsh row order + tags in "What's where".
- 🤖 `CLAUDE.md` — tagline; "Conventions" reordered (Fish layout before Zsh layout, `.zprofile` annotated as zsh-side); transient-prompt asymmetry reframed (primary/fallback, not "trial").
- 🛠️ `bootstrap.sh` — section-header comments + "next steps" footer reflect fish-first.
- 🍺 `Brewfile` — inline comment on `fish` flipped from "alternative interactive shell (trial)" to "primary interactive shell".
- 🆕 `REMOVAL.md` (new) — pre-flight + procedure (includes a cheatsheet-cleanup step caught during plan execution).

## ✅ Test plan

- 🔁 \`./bootstrap.sh\` runs idempotently (every link prints ✅, no relink/backup messages)
- 🐟 \`scripts/test-fish-loads.sh\` passes
- 🍺 \`brew bundle check --file=Brewfile --verbose\` clean
- 👀 Skim \`README.md\` rendered (Manual extras numbering 1–5; fish §1 doesn't say "optional"; no parity-status block)
- 👀 Skim \`CLAUDE.md\` Conventions section (Fish bullet appears before Zsh bullet; neither says "trial")
- 👀 Skim \`REMOVAL.md\` (pre-flight 6-row table + 11-step procedure)