### PR TITLE
🐟 Add fish completions for the s worktree+session launcher

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -170,5 +170,18 @@ to the row above. If a brew formula hard-depends on a brew Python
 runtime, prefer reinstalling the tool via `uv tool install` and
 removing the brew formula instead of carrying both Python stacks.
 
+## Shell preferences
+
+Fish is the only shell I want to maintain config for. When a task involves
+adding or modifying shell config (completions, aliases, functions, prompt
+glue, hooks), do it in fish only — do not write a parallel zsh version,
+do not "port to zsh later", do not suggest it. Existing zsh config stays
+working but is in maintenance mode; don't extend it.
+
+How to apply: when asked to add a shell-level feature, write the fish
+version and stop. If a project-level CLAUDE.md still references zsh
+parity (e.g. dotfiles/CLAUDE.md), follow the user's per-project guidance
+but default to fish-only when the project rule is silent.
+
 @~/.claude/CLAUDE.local.md
 

--- a/.config/fish/completions/s.fish
+++ b/.config/fish/completions/s.fish
@@ -1,0 +1,67 @@
+# s — completion for the worktree+session launcher (bin/s).
+#
+# Layout:
+#   pos 1, outside tmux  -> sesh project names (excl. "Home 🏠")
+#   pos 1, inside tmux   -> existing worktree branches in cwd's project
+#   pos 2 (project given) -> existing worktree branches in that project
+#
+# File completion is disabled. Completions are non-exclusive — fresh names
+# (e.g. `s 123-new-work`) still work and create a new worktree as before.
+
+function __s_token_count
+    # Positional-arg index the user is about to type. `commandline -opc`
+    # returns parsed tokens up to (but excluding) the in-progress one, so
+    # `s foo|` and `s |` both return 1 token; `s foo |` returns 2.
+    set -l toks (commandline -opc)
+    math (count $toks) - 1
+end
+
+function __s_projects
+    sesh list -c -j 2>/dev/null \
+        | jq -r '.[] | select(.Name != "Home 🏠") | .Name' 2>/dev/null
+end
+
+function __s_project_path -a name
+    test -n "$name"; or return
+    sesh list -c -j 2>/dev/null \
+        | jq -r --arg n "$name" '.[] | select(.Name == $n) | .Path' 2>/dev/null \
+        | head -n1
+end
+
+function __s_worktree_branches -a project_path
+    test -n "$project_path"; or return
+    git -C "$project_path" worktree list --porcelain 2>/dev/null \
+        | awk '$1=="branch" {sub("refs/heads/", "", $2); if ($2 != "main" && $2 != "master") print $2}'
+end
+
+function __s_cwd_project_path
+    # Resolve cwd's project path even when inside a secondary worktree —
+    # mirrors bin/s:105-109.
+    set -l common (git -C "$PWD" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)
+    test -n "$common"; or return
+    pushd (dirname "$common") >/dev/null
+    pwd -P
+    popd >/dev/null
+end
+
+function __s_second_token
+    set -l toks (commandline -opc)
+    if test (count $toks) -ge 2
+        echo $toks[2]
+    end
+end
+
+# Disable file completion for `s` entirely.
+complete -c s -f
+
+# pos 1, outside tmux: project names.
+complete -c s -n 'not set -q TMUX; and test (__s_token_count) -eq 0' \
+    -a '(__s_projects)'
+
+# pos 1, inside tmux: worktree branches of cwd's project.
+complete -c s -n 'set -q TMUX; and test (__s_token_count) -eq 0' \
+    -a '(__s_worktree_branches (__s_cwd_project_path))'
+
+# pos 2 (project given): worktree branches of that project.
+complete -c s -n 'test (__s_token_count) -eq 1' \
+    -a '(__s_worktree_branches (__s_project_path (__s_second_token)))'

--- a/.config/fish/completions/s.fish
+++ b/.config/fish/completions/s.fish
@@ -29,9 +29,16 @@ function __s_project_path -a name
 end
 
 function __s_worktree_branches -a project_path
+    # Emit branch names of *secondary* worktrees only — skip the primary
+    # checkout (whose path equals project_path). `s <name>` creates/resumes
+    # secondary worktrees; the primary's branch (whatever is currently
+    # checked out at the project root) is not a valid target.
     test -n "$project_path"; or return
     git -C "$project_path" worktree list --porcelain 2>/dev/null \
-        | awk '$1=="branch" {sub("refs/heads/", "", $2); if ($2 != "main" && $2 != "master") print $2}'
+        | awk -v project="$project_path" '
+            $1=="worktree" {wt=$2}
+            $1=="branch"   {sub("refs/heads/", "", $2); if (wt != project) print $2}
+        '
 end
 
 function __s_cwd_project_path

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,7 +136,13 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + fi
   single arg = project name. Two args = `<project> <name>`. Session
   naming uses `/` (tmux disallows `:`/`.`). Branch name is verbatim —
   `s` does **not** apply `worktree-`; that's reserved for `EnterWorktree`.
-  Project list from `sesh list -c -j`.
+  Project list from `sesh list -c -j`. Fish completions live in
+  `.config/fish/completions/s.fish`: pos 1 (outside tmux) suggests
+  sesh project names, pos 1 (inside tmux) and pos 2 suggest existing
+  *secondary* worktree branches via `git worktree list --porcelain`
+  (the primary checkout's branch is filtered out by path comparison).
+  Completions are non-exclusive — typing a fresh name still creates
+  a new worktree.
 - **`dashboard` is the multi-session live preview command**
   (`bin/dashboard`, symlinked to `~/.local/bin/dashboard`). Surface:
   `dashboard <pattern> [--cols N]`, plus internal

--- a/bin/s
+++ b/bin/s
@@ -20,11 +20,18 @@ EOF
 }
 
 # Create or find a worktree for <name> in <project_path>. Echoes the
-# worktree path on stdout. wt is itself idempotent: if branch+worktree
-# already exist, it reports their location instead of erroring.
+# worktree path on stdout. `wt switch --create` errors when the branch
+# already exists, so pre-flight via `git show-ref` and dispatch to the
+# right form. Both forms emit `{"action":..., "path":...}` JSON.
+# Resume-existing matters because the fish completer suggests existing
+# secondary-worktree branches as completions for `s`.
 ensure_worktree() {
   local project_path="$1" name="$2" json
-  json=$(wt -C "$project_path" switch --create --no-cd --format=json "$name") || return $?
+  if git -C "$project_path" show-ref --verify --quiet "refs/heads/$name"; then
+    json=$(wt -C "$project_path" switch --no-cd --format=json "$name") || return $?
+  else
+    json=$(wt -C "$project_path" switch --create --no-cd --format=json "$name") || return $?
+  fi
   printf '%s\n' "$json" | jq -r '.path'
 }
 


### PR DESCRIPTION
## ✨ Summary

- Add `.config/fish/completions/s.fish` — tab completion for `bin/s`.
  - Pos 1 outside tmux → sesh project names (excludes `Home 🏠`).
  - Pos 1 inside tmux → existing secondary-worktree branches in cwd's project.
  - Pos 2 (after a project name) → existing secondary-worktree branches in that project.
  - Completions are non-exclusive: typing a fresh name (`s 123-new-work`) still creates a new worktree, current `bin/s` flow unchanged.
- 🩹 Fix `bin/s` to **resume** an existing worktree instead of erroring. The old `ensure_worktree` comment claimed `wt switch --create` was idempotent — that's no longer true. Pre-flight via `git show-ref` and dispatch to `wt switch` with or without `--create` accordingly. Surfaced naturally because the new completer suggests existing worktree names.
- 📝 Add a `## Shell preferences` section to global `.claude/CLAUDE.md` codifying fish-only as the rule for shell config going forward.
- 📝 Bump dotfiles `CLAUDE.md` `s` bullet to point at the completion file.

## 🧪 Test plan

- [x] `env -u TMUX fish -c 'complete -C "s "'` lists project names (no `Home 🏠`, no file paths).
- [x] `TMUX=fake fish -c 'cd ~/code/dotfiles; complete -C "s "'` lists existing secondary-worktree branches (e.g. `45-duf`), excludes the primary's branch.
- [x] `fish -c 'complete -C "s dotfiles "'` lists worktree branches for dotfiles.
- [x] `scripts/test-s-session-root.sh` still passes.
- [x] `s 45-duf` from inside the dotfiles main checkout switches into the existing session (was erroring before the `bin/s` fix).
- [ ] Manual: `s ` then Tab in a real fish prompt shows the right list inside vs. outside tmux.
- [ ] Manual: `s <fresh-name>` still creates a new worktree.

## 🧷 Notes

- `bin/s` change is a real regression fix, not refactor — keeping it on the same PR because the new completion makes the resume path the common case.
- No zsh equivalent — per the new global rule.
- Pushed via HTTPS one-shot (gh token) because outbound SSH to github.com was timing out at push time. No git config or remote URL changes left behind.