### PR TITLE
feat(bootstrap): install Brewfile deps before symlinking

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,8 +51,9 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + fi
   OrbStack, anything doing `fpath+=`) goes in `~/.zprofile.local`
   (untracked; copy from template). `.zshrc.local` is sourced *after*
   `compinit`, so late `fpath+=` silently no-ops there.
-- **`Brewfile` is report-only.** `bootstrap.sh` runs `brew bundle check`;
-  it does not install.
+- **`Brewfile` is installed by bootstrap.** `bootstrap.sh` runs
+  `brew bundle --file=$DOTFILES/Brewfile` unconditionally at the top,
+  before any symlinks. Aborts on failure (`set -euo pipefail`).
 - **Global gitignore is symlinked from `.gitignore_global`.**
   `bootstrap.sh` links it to `~/.gitignore_global` (the path
   `core.excludesfile` already points to). Lists the cross-repo
@@ -374,7 +375,7 @@ is `nvim-cheatsheet.html`).
 - Dashboard smoke + integration: `scripts/test-dashboard.sh`
 - Fish config smoke: `scripts/test-fish-loads.sh`
 - Reapply symlinks (idempotent): `$PROJECTS_HOME/dotfiles/bootstrap.sh`
-- Brew dep check: `brew bundle check --file=$PROJECTS_HOME/dotfiles/Brewfile --verbose`
+- Brew deps (installed by bootstrap): `brew bundle check --file=$PROJECTS_HOME/dotfiles/Brewfile --verbose`
 - nvim plugin smoke: `scripts/test-nvim.sh`
 
 ## First-time setup on a new machine

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -7,6 +7,11 @@ DOTFILES="$PROJECTS_HOME/dotfiles"
 
 echo "🚀 dotfiles bootstrap"
 
+# --- brew (install missing formulae; abort on failure)
+echo
+echo "🍺 brew bundle install:"
+brew bundle --file="$DOTFILES/Brewfile"
+
 # link <source-relative-to-DOTFILES> <target-absolute>
 link() {
   local src="$DOTFILES/$1"
@@ -147,12 +152,6 @@ if [ ! -d "$TPM_DIR/.git" ]; then
 else
   echo "✅  $TPM_DIR (TPM present)"
 fi
-
-# --- brew check (don't install — just report)
-echo
-echo "🍺 brew bundle check:"
-brew bundle check --file="$DOTFILES/Brewfile" --verbose || \
-  echo "→ run: brew bundle --file=$DOTFILES/Brewfile"
 
 echo
 echo "🎯 next steps:"


### PR DESCRIPTION
## Summary

- Move `brew bundle` from a report-only check at the bottom of `bootstrap.sh` to an unconditional install at the top
- Tools are now installed before their configs are symlinked
- Script aborts on failure (`set -euo pipefail`)
- Update CLAUDE.md to reflect the new Brewfile policy

## Test plan

- [ ] Run `bootstrap.sh` on a machine with all deps installed — verify it completes without error
- [ ] Run `bootstrap.sh` after removing a formula — verify it installs the missing dep then continues
- [ ] Verify script aborts if `brew bundle` fails (e.g. invalid Brewfile)