### PR TITLE
💾 Adopt duf as modern df companion (#45)

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -56,6 +56,7 @@ brew "shfmt"                    # POSIX/bash/mksh formatter (`-d` for diff, `-w`
 
 # System monitoring & benchmarking
 brew "btop"                     # modern top replacement (themed Solarized)
+brew "duf"                      # modern df replacement (grouped, color-coded)
 brew "hyperfine"                # command benchmarking (warmups, multi-run stats)
 
 # Fonts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -302,6 +302,12 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + fi
   alias). `time` for one-shot wall-clock; `hyperfine` for warmups,
   multiple runs, A/B. **Deliberately NOT in modern-reminder** — not a
   1:1 swap (different use cases). Don't alias or wrap.
+- **`duf` is a modern `df` companion** (raw, no alias). Grouped output by
+  device class (local/network/special/fuse), color-coded usage bars, theme-
+  aware (auto-detects dark; `--theme dark` pins it). `df` stays for scripts
+  and POSIX habit; `duf` for interactive disk-free checks. **Deliberately
+  NOT added to modern-reminder** — that system is deprecated alongside zsh
+  (see `REMOVAL.md` §1 row 2). Don't alias or wrap.
 - **`modern-reminder` is a zsh discoverability nudge** for default→modern
   pairs left unaliased ("no synonyms" pattern: `tail`/`tspin`,
   `grep`/`rg`, `curl`/`xh`). Defined in

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Personal config for Ghostty + fish + tmux + vim, all in Solarized + JetBrainsMon
 Solarized-themed quick references — also browseable at
 [martinciu.github.io/dotfiles](https://martinciu.github.io/dotfiles/):
 
-- [Terminal](https://martinciu.github.io/dotfiles/terminal-cheatsheet.html) — eza, bat, less wrapper, git-delta, difftastic, glow, vivid, xh, fzf, zsh plugins
+- [Terminal](https://martinciu.github.io/dotfiles/terminal-cheatsheet.html) — eza, bat, less wrapper, git-delta, difftastic, glow, vivid, xh, duf, fzf, zsh plugins
 - [tmux](https://martinciu.github.io/dotfiles/tmux-cheatsheet.html) — prefix `C-a` map, sessions/windows/panes, tmux-sessionx picker, status bar, copy mode
 - [Neovim](https://martinciu.github.io/dotfiles/nvim-cheatsheet.html) — LazyVim leader map, picker, LSP, neotest, Mason/Lazy
 

--- a/docs/terminal-cheatsheet.html
+++ b/docs/terminal-cheatsheet.html
@@ -68,6 +68,7 @@
       <tr><td class="key"><a href="https://github.com/bensadeh/tailspin"><code>tailspin</code></a></td><td class="desc">live-log highlighter (<code>tspin</code>); Solarized via <code>~/.config/tailspin/theme.toml</code></td></tr>
       <tr><td class="key"><a href="https://lnav.org/"><code>lnav</code></a></td><td class="desc">TUI log navigator; Solarized via built-in theme (see lnav section)</td></tr>
       <tr><td class="key"><a href="https://github.com/aristocratos/btop"><code>btop</code></a></td><td class="desc">modern <code>top</code> replacement; Solarized via <code>~/.config/btop/btop.conf</code></td></tr>
+      <tr><td class="key"><a href="https://github.com/muesli/duf"><code>duf</code></a></td><td class="desc">modern <code>df</code> replacement (grouped, color-coded; raw, no alias)</td></tr>
       <tr><td class="key"><a href="https://github.com/ducaale/xh"><code>xh</code></a></td><td class="desc">modern HTTP client (HTTPie-compatible CLI); Solarized via <code>~/.config/xh/config.json</code></td></tr>
       <tr><td class="key"><a href="https://github.com/zsh-users/zsh-autosuggestions"><code>zsh-autosuggestions</code></a></td><td class="desc">ghost-text completion from history</td></tr>
       <tr><td class="key"><a href="https://github.com/zsh-users/zsh-syntax-highlighting"><code>zsh-syntax-highlighting</code></a></td><td class="desc">live command-line highlighting</td></tr>
@@ -756,7 +757,7 @@
 </ol>
 
 <footer>
-  Built from <code>~/.zshrc</code>, <code>Brewfile</code>, and project CLAUDE.md on 2026-05-04.
+  Built from <code>~/.zshrc</code>, <code>Brewfile</code>, and project CLAUDE.md on 2026-05-07.
   Refresh after meaningful color-tooling changes.
 </footer>
 


### PR DESCRIPTION
## 📋 Summary

- 💾 Add `duf` to `Brewfile` under `# System monitoring & benchmarking` (alphabetical: btop → duf → hyperfine).
- 📖 Document `duf` as a raw, no-alias modern peer to `df` in `CLAUDE.md`, between the `hyperfine` and `modern-reminder` bullets.
- 🧾 Surface `duf` on the terminal cheatsheet's "Brew packages (recently added)" intro table; refresh footer date to 2026-05-07.
- 🪧 Add `duf` to the `README.md` Terminal cheatsheet description line.

🚫 **Deliberately not done:**
- No alias (`df` keeps invoking POSIX `df`).
- No `MODERN_REMINDER` pair — that system is deprecated alongside zsh (`REMOVAL.md` §1 row 2).
- No `.config/duf/` (duf has no config file; theme is `--theme` flag only and auto-detects dark).
- No dedicated `<h2 id="duf">` cheatsheet section — minimal-touch Approach A per spec.

## 🧪 Test plan

- 🛠 `brew install duf` succeeds.
- 🛠 `brew bundle check --file=Brewfile --verbose` reports satisfied.
- ✅ `type df` returns `df is /bin/df` — no alias regression.
- ✅ `duf` launches under Ghostty + JetBrainsMono Nerd Font with Solarized palette via auto-detect (no `--theme dark` needed).
- 🔍 Cheatsheet renders cleanly in browser; new `duf` row appears between `btop` and `xh`; footer date refreshed.
- 🌿 Lived with `duf` in real workflow before opening this PR; muscle memory took.

## 🔗 Closes

- Closes #45.

## 📊 Session stats

| | |
|---|---|
| Start | 2026-05-07 11:32 UTC |
| End | 2026-05-07 13:42 UTC |
| Elapsed | 2h 10m |
| Working | 1h 7m (52% of elapsed) |
| Idle | 1h 2m |
| Total billed tokens | 20.5M |
| Total cost (public rates) | \$72.83 |
| Effective rate | \$64.39/hr |

| Model | Messages | Input | Output | Cache Read | Cache Write 1h | Cost |
|---|---:|---:|---:|---:|---:|---:|
| Opus 4.7 | 194 | 1.5k | 159k | 19.3M | 1.1M | \$72.83 |

_Caveats:_ Public-rate estimate (Anthropic API list prices); plan billing (Max / Pro / Team) bundles usage and the incremental cost may be effectively within plan limits. Cache reads dominate by design — prompt caching re-uses prior turns at ~10% of base input price.