### PR TITLE
💾 Adopt dust + dua as modern du companions (#44)

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -56,7 +56,9 @@ brew "shfmt"                    # POSIX/bash/mksh formatter (`-d` for diff, `-w`
 
 # System monitoring & benchmarking
 brew "btop"                     # modern top replacement (themed Solarized)
+brew "dua-cli"                  # interactive disk-usage analyzer (TUI: `dua i`)
 brew "duf"                      # modern df replacement (grouped, color-coded)
+brew "dust"                     # tree-style du replacement (largest-first, bar graphs)
 brew "hyperfine"                # command benchmarking (warmups, multi-run stats)
 
 # Fonts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -315,6 +315,20 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + fi
   and POSIX habit; `duf` for interactive disk-free checks. **Deliberately
   NOT added to modern-reminder** — that system is deprecated alongside zsh
   (see `REMOVAL.md` §1 row 2). Don't alias or wrap.
+- **`dust` is a modern `du` companion** (raw, no alias). Tree-style output
+  sorted largest-first, colored bar graphs per node, depth-aware (`-d N`
+  to limit). Read-only inspection — fast parallel scan, zero side effects.
+  `du` stays for scripts and POSIX habit; `dust` for "where did my disk
+  go?" at-a-glance. **Deliberately NOT added to modern-reminder** — that
+  system is deprecated alongside zsh (see `REMOVAL.md` §1 row 2). Don't
+  alias or wrap.
+- **`dua` is a fast `du` aggregate with an interactive TUI deleter** (raw,
+  no alias). Plain `dua [path]` walks the tree in parallel and prints
+  aggregate sizes; `dua i [path]` opens a TUI for navigating, marking, and
+  *deleting* directories. `du` stays for scripts and POSIX habit; `dua`
+  for fast aggregates and interactive disk reclaim. **Deliberately NOT
+  added to modern-reminder** — that system is deprecated alongside zsh
+  (see `REMOVAL.md` §1 row 2). Don't alias or wrap.
 - **`modern-reminder` is a zsh discoverability nudge** for default→modern
   pairs left unaliased ("no synonyms" pattern: `tail`/`tspin`,
   `grep`/`rg`, `curl`/`xh`). Defined in

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Personal config for Ghostty + fish + tmux + vim, all in Solarized + JetBrainsMon
 Solarized-themed quick references — also browseable at
 [martinciu.github.io/dotfiles](https://martinciu.github.io/dotfiles/):
 
-- [Terminal](https://martinciu.github.io/dotfiles/terminal-cheatsheet.html) — eza, bat, less wrapper, git-delta, difftastic, glow, vivid, xh, duf, fzf, zsh plugins
+- [Terminal](https://martinciu.github.io/dotfiles/terminal-cheatsheet.html) — eza, bat, less wrapper, git-delta, difftastic, glow, vivid, xh, duf, dust, dua, fzf, zsh plugins
 - [tmux](https://martinciu.github.io/dotfiles/tmux-cheatsheet.html) — prefix `C-a` map, sessions/windows/panes, tmux-sessionx picker, status bar, copy mode
 - [Neovim](https://martinciu.github.io/dotfiles/nvim-cheatsheet.html) — LazyVim leader map, picker, LSP, neotest, Mason/Lazy
 

--- a/docs/terminal-cheatsheet.html
+++ b/docs/terminal-cheatsheet.html
@@ -68,7 +68,9 @@
       <tr><td class="key"><a href="https://github.com/bensadeh/tailspin"><code>tailspin</code></a></td><td class="desc">live-log highlighter (<code>tspin</code>); Solarized via <code>~/.config/tailspin/theme.toml</code></td></tr>
       <tr><td class="key"><a href="https://lnav.org/"><code>lnav</code></a></td><td class="desc">TUI log navigator; Solarized via built-in theme (see lnav section)</td></tr>
       <tr><td class="key"><a href="https://github.com/aristocratos/btop"><code>btop</code></a></td><td class="desc">modern <code>top</code> replacement; Solarized via <code>~/.config/btop/btop.conf</code></td></tr>
+      <tr><td class="key"><a href="https://github.com/Byron/dua-cli"><code>dua</code></a></td><td class="desc">interactive disk-usage analyzer with TUI deleter (<code>dua i</code>; raw, no alias)</td></tr>
       <tr><td class="key"><a href="https://github.com/muesli/duf"><code>duf</code></a></td><td class="desc">modern <code>df</code> replacement (grouped, color-coded; raw, no alias)</td></tr>
+      <tr><td class="key"><a href="https://github.com/bootandy/dust"><code>dust</code></a></td><td class="desc">tree-style <code>du</code> replacement (largest-first, bar graphs; raw, no alias)</td></tr>
       <tr><td class="key"><a href="https://github.com/ducaale/xh"><code>xh</code></a></td><td class="desc">modern HTTP client (HTTPie-compatible CLI); Solarized via <code>~/.config/xh/config.json</code></td></tr>
       <tr><td class="key"><a href="https://github.com/zsh-users/zsh-autosuggestions"><code>zsh-autosuggestions</code></a></td><td class="desc">ghost-text completion from history</td></tr>
       <tr><td class="key"><a href="https://github.com/zsh-users/zsh-syntax-highlighting"><code>zsh-syntax-highlighting</code></a></td><td class="desc">live command-line highlighting</td></tr>


### PR DESCRIPTION
## 📋 Summary

- 💾 Add `dua-cli` and `dust` to `Brewfile` under `# System monitoring & benchmarking` (alphabetical: btop → dua-cli → duf → dust → hyperfine).
- 📖 Document `dust` and `dua` as raw, no-alias modern peers to `du` in `CLAUDE.md`, inserted between the `duf` and `modern-reminder` bullets.
- 🧾 Surface both tools on the terminal cheatsheet's "Brew packages (recently added)" intro table (alphabetical: btop → dua → duf → dust → xh); footer date already reads 2026-05-07.
- 🪧 Add `dust, dua` to the `README.md` Terminal cheatsheet description line, clustered next to `duf`.

## 🎯 Why two tools

`dust` and `dua` solve **different jobs**:

- 🌳 **`dust`** — read-only tree visualization. Largest-first, colored bar graphs. Best answer to _"where did my disk go?"_ No side effects.
- 🗑️ **`dua`** — fast aggregate (`dua [path]`) plus interactive TUI deleter (`dua i [path]`). Different category from pure inspection — nothing else in the inventory occupies the deleter slot.

Both fill the "du modernization" slot in a single PR. This is not the kind of "multiple tool swaps" issue #44's "don't bundle" warning targets (which is about bundling unrelated `df` + `du` + `tail` etc. into one mega-PR).

## 🚫 Deliberately not done

- No alias — `du` keeps invoking POSIX `du`. Honors the "no synonyms" pattern.
- No `MODERN_REMINDER` pair — that system is deprecated alongside zsh (`REMOVAL.md` §1 row 2).
- No `.config/dust/` or `.config/dua/` — neither tool has a config file; theming is auto from the terminal palette.
- No fish abbreviation for `dua i` — keeps the abbr file focused on git-flow mnemonics.
- No dedicated `<h2 id="dust">` / `<h2 id="dua">` cheatsheet sections — minimal-touch Approach A, matches the `duf` precedent.
- No CLAUDE.md cross-references between the two bullets — Approach A; the "different jobs" framing lives in the spec and this PR description.

## 🧪 Test plan

- [x] 🛠 `brew install dua-cli dust` succeeds via `brew bundle`.
- [x] 🛠 `brew bundle check --file=Brewfile --verbose` reports satisfied.
- [x] ✅ `type du` returns `du is /usr/bin/du` — no alias regression.
- [x] ✅ `dust ~/code -d 2` renders tree with bar graphs under Ghostty + JetBrainsMono Nerd Font with Solarized palette.
- [x] ✅ `dua ~/code` prints aggregate sizes; parallel scan completes cleanly.
- [ ] ✅ `dua i ~/Downloads` enters TUI; `?` shows in-TUI keybindings; `q` exits cleanly. _(Skipped inline — TUI can't be driven headlessly.)_
- [ ] 🔍 Cheatsheet renders cleanly in browser; new `dua` and `dust` rows appear in alphabetical slots (btop → dua → duf → dust → xh).
- [ ] 🌿 Lived with both tools in real workflow before merge; muscle memory took.

## 🔗 Closes

- Closes #44.