### PR TITLE
🧹 bootstrap: keep machine-local content out of the repo working tree

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,12 +4,27 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + fi
 
 ## Conventions — don't drift from these
 
-- **Manual symlinks via `bootstrap.sh`.** No `stow`/`chezmoi`/etc.
+- **Manual symlinks via `bootstrap.sh`.** No `stow`/`chezmoi`/etc. Tools
+  whose `~/.config/<tool>/` dir contains nothing but tracked content get
+  whole-dir symlinks (`link "<rel>" "$HOME/..."`). Tools whose dir mixes
+  tracked content with machine-local or runtime state (fish, nvim,
+  worktrunk, lnav, sesh) use the **mixed-dir pattern** instead: real
+  `~/.config/<tool>/` dir, per-file symlinks for tracked entries, real
+  files for the rest. Helpers `prepare_real_dir` + `rescue_in_repo` +
+  `link_tracked_entries` + `seed_local` implement the pattern;
+  `link_tracked_entries` skips `*.template` files. Migration from a
+  legacy whole-dir symlink is automatic on next `bootstrap.sh` run.
 - **Bash scripts target bash 5.** Shebang `#!/opt/homebrew/bin/bash`; may
   use `mapfile`, `declare -A`, `wait -n`. Apple Silicon only — `brew
   bundle` runs before `bootstrap.sh`. Don't reintroduce bash-3 shims.
 - **Fish module layout.** Fish is the primary interactive shell. Config
-  in `.config/fish/`, symlinked to `~/.config/fish`.
+  in `.config/fish/`. `~/.config/fish/` is a real dir (mixed-dir pattern):
+  `config.fish`, `completions/`, `functions/` are symlinked from the
+  repo; `conf.d/` is itself a real dir with per-file symlinks for the
+  tracked `*.fish` modules and **real files** for `15-local.fish` +
+  `99-secrets.fish` (seeded from `.template` companions on first
+  bootstrap, untouched after). `fish_variables`, `fish_history`,
+  `generated_completions/` are real and stay outside the repo.
   `config.fish` is empty; concerns in `conf.d/<NN>-<concern>.fish`,
   numeric prefix pins load order:
   `00-env`, `10-colors`, `15-local` (per-machine, untracked), `20-mise`,
@@ -163,7 +178,10 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + fi
   (`.vimrc` ~30 lines, `.vim/colors/solarized8.vim`) is reachable via
   `vi`/`command vim`/`\vim`. Don't add vim-plug or LSP to it.
 - **nvim is built on LazyVim**, themed Solarized, configured at
-  `.config/nvim/`. Don't replace LazyVim.
+  `.config/nvim/`. Don't replace LazyVim. `~/.config/nvim/` is a real
+  dir (mixed-dir pattern): `init.lua`, `lazy-lock.json`,
+  `mason-lock.json`, `lua/` are symlinked from the repo; `lazy/`,
+  `mason/`, `site/`, `lazyvim.json` are real and stay outside the repo.
 - **LazyVim Alt-keymaps removed** in `lua/config/keymaps.lua`
   (`<A-j>/<A-k>`) — Alt is reserved for Polish diacritics. Don't re-add.
 - **LSPs off by default in nvim.** `lua/plugins/lsp-disable-all.lua`
@@ -205,7 +223,9 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + fi
   1.25.x has no `[transient_prompt]` section — don't add one (silently
   ignored, trips `[WARN]`).
 - **wt user config is symlinked from `.config/worktrunk/config.toml`.**
-  Per-project `approvals.toml` is machine-local and gitignored.
+  `~/.config/worktrunk/` is a real dir (mixed-dir pattern): `config.toml`
+  is the only symlink; per-project `approvals.toml` is a real file there,
+  outside the repo working tree.
 - **Gitignored content flows between primary and worktrees in two
   stages**, both using `wt step copy-ignored`. `[post-start] copy`
   reflinks primary's ignored content into a new worktree at creation;

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -106,7 +106,12 @@ link ".config/tmux"    "$HOME/.config/tmux"
 link ".config/ccstatusline" "$HOME/.config/ccstatusline"
 
 # --- worktrunk
-link ".config/worktrunk" "$HOME/.config/worktrunk"
+# ~/.config/worktrunk/ is a real dir; tracked entries are individually symlinked.
+# Per-project approvals.toml stays outside the repo.
+prepare_real_dir "$HOME/.config/worktrunk"
+rescue_in_repo "$DOTFILES/.config/worktrunk/approvals.toml" \
+               "$HOME/.config/worktrunk/approvals.toml"
+link_tracked_entries ".config/worktrunk" "$HOME/.config/worktrunk"
 
 # --- glow
 link ".config/glow"    "$HOME/.config/glow"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -65,7 +65,11 @@ rescue_in_repo() {
 #   Per-entry symlinks every tracked top-level entry from <source> into
 #   <target>, skipping *.template files. Tracked entries that are dirs
 #   are whole-dir-symlinked; tracked files are file-symlinked. Reuses the
-#   existing link() helper, so already-correct symlinks no-op.
+#   existing link() helper, so already-correct symlinks no-op. Entries
+#   whose destination already exists as a real (non-symlink) dir are
+#   left alone — that means the caller is handling them recursively
+#   (e.g. fish/conf.d/ inside fish/) and link() would otherwise back up
+#   the real dir and replace it with a symlink.
 link_tracked_entries() {
   local src_rel="$1"; local dst="$2"
   local src="$DOTFILES/$src_rel"
@@ -73,6 +77,9 @@ link_tracked_entries() {
     [ -e "$entry" ] || continue
     local name; name="$(basename "$entry")"
     case "$name" in *.template) continue ;; esac
+    if [ -d "$entry" ] && [ -d "$dst/$name" ] && [ ! -L "$dst/$name" ]; then
+      continue
+    fi
     link "$src_rel/$name" "$dst/$name"
   done
 }
@@ -170,17 +177,23 @@ link ".zprofile"   "$HOME/.zprofile"
 link ".config/starship.toml" "$HOME/.config/starship.toml"
 
 # --- fish (primary)
-link ".config/fish" "$HOME/.config/fish"
-if [ ! -f "$HOME/.config/fish/conf.d/15-local.fish" ]; then
-  cp "$DOTFILES/.config/fish/conf.d/15-local.fish.template" \
-     "$HOME/.config/fish/conf.d/15-local.fish"
-  echo "✨  ~/.config/fish/conf.d/15-local.fish (edit to set PROJECTS_HOME etc.)"
-fi
-if [ ! -f "$HOME/.config/fish/conf.d/99-secrets.fish" ]; then
-  cp "$DOTFILES/.config/fish/conf.d/99-secrets.fish.template" \
-     "$HOME/.config/fish/conf.d/99-secrets.fish"
-  echo "✨  ~/.config/fish/conf.d/99-secrets.fish (edit to add machine secrets)"
-fi
+# ~/.config/fish/ is a real dir; tracked entries are individually symlinked.
+# 15-local.fish + 99-secrets.fish + fish runtime state stay outside the repo.
+prepare_real_dir "$HOME/.config/fish"
+prepare_real_dir "$HOME/.config/fish/conf.d"
+for f in 15-local.fish 99-secrets.fish; do
+  rescue_in_repo "$DOTFILES/.config/fish/conf.d/$f" \
+                 "$HOME/.config/fish/conf.d/$f"
+done
+for f in fish_variables fish_history generated_completions; do
+  rescue_in_repo "$DOTFILES/.config/fish/$f" "$HOME/.config/fish/$f"
+done
+link_tracked_entries ".config/fish"        "$HOME/.config/fish"
+link_tracked_entries ".config/fish/conf.d" "$HOME/.config/fish/conf.d"
+seed_local ".config/fish/conf.d/15-local.fish.template" \
+           "$HOME/.config/fish/conf.d/15-local.fish"
+seed_local ".config/fish/conf.d/99-secrets.fish.template" \
+           "$HOME/.config/fish/conf.d/99-secrets.fish"
 
 # --- git (global ignore — paths excluded across every repo on this machine)
 link ".gitignore_global" "$HOME/.gitignore_global"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -163,7 +163,13 @@ fi
 link "mise.global.toml" "$HOME/.config/mise/config.toml"
 
 # --- nvim
-link ".config/nvim"    "$HOME/.config/nvim"
+# ~/.config/nvim/ is a real dir; tracked entries are individually symlinked.
+# LazyVim's lazy/, mason/, site/, lazyvim.json stay outside the repo.
+prepare_real_dir "$HOME/.config/nvim"
+for f in lazy mason site lazyvim.json; do
+  rescue_in_repo "$DOTFILES/.config/nvim/$f" "$HOME/.config/nvim/$f"
+done
+link_tracked_entries ".config/nvim" "$HOME/.config/nvim"
 
 # --- vim
 link ".vimrc"          "$HOME/.vimrc"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -34,6 +34,61 @@ link() {
   echo "🔗  $dst → $src"
 }
 
+# prepare_real_dir <target-abs-dir>
+#   Tears down a legacy whole-dir symlink at <target> if present, then
+#   ensures <target> exists as a real directory. Idempotent.
+prepare_real_dir() {
+  local dst="$1"
+  if [ -L "$dst" ]; then
+    rm "$dst"
+    echo "🗑️  $dst (legacy whole-dir symlink)"
+  fi
+  mkdir -p "$dst"
+}
+
+# rescue_in_repo <repo-abs-path> <target-abs-path>
+#   Migration aid for machines that ran an older bootstrap where the dir
+#   was whole-dir-symlinked. If <repo-abs-path> exists as a real file or
+#   dir (not a symlink), and <target-abs-path> doesn't yet, MOVE it across.
+#   Idempotent: no-op once rescued. Must run AFTER prepare_real_dir on
+#   the parent so the destination path is no longer aliased to the repo.
+rescue_in_repo() {
+  local in_repo="$1"; local new_home="$2"
+  if [ -e "$in_repo" ] && [ ! -L "$in_repo" ] && [ ! -e "$new_home" ]; then
+    mkdir -p "$(dirname "$new_home")"
+    mv "$in_repo" "$new_home"
+    echo "🚚  $in_repo → $new_home"
+  fi
+}
+
+# link_tracked_entries <repo-rel-source-dir> <target-abs-dir>
+#   Per-entry symlinks every tracked top-level entry from <source> into
+#   <target>, skipping *.template files. Tracked entries that are dirs
+#   are whole-dir-symlinked; tracked files are file-symlinked. Reuses the
+#   existing link() helper, so already-correct symlinks no-op.
+link_tracked_entries() {
+  local src_rel="$1"; local dst="$2"
+  local src="$DOTFILES/$src_rel"
+  for entry in "$src"/*; do
+    [ -e "$entry" ] || continue
+    local name; name="$(basename "$entry")"
+    case "$name" in *.template) continue ;; esac
+    link "$src_rel/$name" "$dst/$name"
+  done
+}
+
+# seed_local <template-repo-rel> <target-abs>
+#   First-run copy of a .template into a real file on disk. Idempotent:
+#   no-op if the target already exists.
+seed_local() {
+  local tmpl="$DOTFILES/$1"; local dst="$2"
+  if [ ! -f "$dst" ]; then
+    mkdir -p "$(dirname "$dst")"
+    cp "$tmpl" "$dst"
+    echo "✨  $dst (seeded from $(basename "$tmpl"))"
+  fi
+}
+
 # --- ghostty (already done; idempotent re-link)
 link ".config/ghostty" "$HOME/.config/ghostty"
 

--- a/scripts/test-bootstrap-shape.sh
+++ b/scripts/test-bootstrap-shape.sh
@@ -1,0 +1,125 @@
+#!/opt/homebrew/bin/bash
+# Asserts the post-bootstrap shape of ~/.config/{fish,nvim,worktrunk}/.
+# Run AFTER bootstrap.sh on the live machine. Fails if any leaked file
+# is back inside the repo working tree, or any required symlink is missing.
+set -u
+
+REPO="${REPO:-$PROJECTS_HOME/dotfiles}"
+
+pass=0
+fail=0
+fail_msgs=()
+
+# ─── helpers ────────────────────────────────
+record_pass() { pass=$((pass+1)); echo "  PASS  $1"; }
+record_fail() {
+  fail=$((fail+1))
+  fail_msgs+=("FAIL  $1"$'\n'"        $2")
+  echo "  FAIL  $1"
+}
+
+assert_real_dir() {
+  local path="$1" desc="$2"
+  if [ -L "$path" ]; then
+    record_fail "$desc" "expected real dir, found symlink: $path → $(readlink "$path")"
+  elif [ ! -d "$path" ]; then
+    record_fail "$desc" "expected real dir, missing: $path"
+  else
+    record_pass "$desc"
+  fi
+}
+
+assert_symlink_to() {
+  local path="$1" want_target="$2" desc="$3"
+  if [ ! -L "$path" ]; then
+    record_fail "$desc" "expected symlink, not a symlink: $path"
+  elif [ "$(readlink "$path")" != "$want_target" ]; then
+    record_fail "$desc" "symlink target mismatch: $path → $(readlink "$path"), want → $want_target"
+  else
+    record_pass "$desc"
+  fi
+}
+
+assert_real_file() {
+  local path="$1" desc="$2"
+  if [ -L "$path" ]; then
+    record_fail "$desc" "expected real file, found symlink: $path → $(readlink "$path")"
+  elif [ ! -f "$path" ]; then
+    record_fail "$desc" "expected real file, missing: $path"
+  else
+    record_pass "$desc"
+  fi
+}
+
+assert_not_in_repo() {
+  local path="$1" desc="$2"
+  if [ -e "$path" ] && [ ! -L "$path" ]; then
+    record_fail "$desc" "leaked into repo working tree: $path"
+  else
+    record_pass "$desc"
+  fi
+}
+
+# ─── fish ───────────────────────────────────
+echo
+echo "fish layout"
+echo "───────────"
+assert_real_dir   "$HOME/.config/fish"                              "~/.config/fish/ is a real dir"
+assert_real_dir   "$HOME/.config/fish/conf.d"                       "~/.config/fish/conf.d/ is a real dir"
+assert_symlink_to "$HOME/.config/fish/config.fish"     "$REPO/.config/fish/config.fish"     "config.fish symlink"
+assert_symlink_to "$HOME/.config/fish/completions"     "$REPO/.config/fish/completions"     "completions/ symlink"
+assert_symlink_to "$HOME/.config/fish/functions"       "$REPO/.config/fish/functions"       "functions/ symlink"
+for f in 00-env.fish 10-colors.fish 20-mise.fish 25-prompt.fish \
+         30-aliases.fish 35-abbreviations.fish 40-plugins.fish 50-tmux-hooks.fish; do
+  assert_symlink_to "$HOME/.config/fish/conf.d/$f" "$REPO/.config/fish/conf.d/$f" "conf.d/$f symlink"
+done
+assert_real_file  "$HOME/.config/fish/conf.d/15-local.fish"  "15-local.fish is a real file"
+assert_real_file  "$HOME/.config/fish/conf.d/99-secrets.fish" "99-secrets.fish is a real file"
+
+# No .template symlinks anywhere
+for f in 15-local.fish.template 99-secrets.fish.template; do
+  if [ -L "$HOME/.config/fish/conf.d/$f" ]; then
+    record_fail "no .template symlink for $f" "found symlink: $HOME/.config/fish/conf.d/$f"
+  else
+    record_pass "no .template symlink for $f"
+  fi
+done
+
+# Repo-side leak check
+for f in 15-local.fish 99-secrets.fish fish_variables fish_history generated_completions; do
+  assert_not_in_repo "$REPO/.config/fish/conf.d/$f" "no $f leaked under repo conf.d/"
+  assert_not_in_repo "$REPO/.config/fish/$f"        "no $f leaked under repo fish/"
+done
+
+# ─── nvim ───────────────────────────────────
+echo
+echo "nvim layout"
+echo "───────────"
+assert_real_dir   "$HOME/.config/nvim"                                                "~/.config/nvim/ is a real dir"
+assert_symlink_to "$HOME/.config/nvim/init.lua"        "$REPO/.config/nvim/init.lua"        "init.lua symlink"
+assert_symlink_to "$HOME/.config/nvim/lazy-lock.json"  "$REPO/.config/nvim/lazy-lock.json"  "lazy-lock.json symlink"
+assert_symlink_to "$HOME/.config/nvim/mason-lock.json" "$REPO/.config/nvim/mason-lock.json" "mason-lock.json symlink"
+assert_symlink_to "$HOME/.config/nvim/lua"             "$REPO/.config/nvim/lua"             "lua/ symlink"
+for f in lazy mason site lazyvim.json; do
+  assert_not_in_repo "$REPO/.config/nvim/$f" "no $f leaked under repo nvim/"
+done
+
+# ─── worktrunk ──────────────────────────────
+echo
+echo "worktrunk layout"
+echo "────────────────"
+assert_real_dir   "$HOME/.config/worktrunk"                                            "~/.config/worktrunk/ is a real dir"
+assert_symlink_to "$HOME/.config/worktrunk/config.toml" "$REPO/.config/worktrunk/config.toml" "config.toml symlink"
+assert_not_in_repo "$REPO/.config/worktrunk/approvals.toml" "no approvals.toml leaked under repo worktrunk/"
+
+# ─── summary ────────────────────────────────
+echo
+echo "───────────────────────────────────────"
+echo "PASS: $pass    FAIL: $fail"
+if [ "$fail" -gt 0 ]; then
+  echo
+  for msg in "${fail_msgs[@]}"; do
+    printf '%s\n' "$msg"
+  done
+  exit 1
+fi


### PR DESCRIPTION
## 📋 Summary

- 🌳 Switch fish, nvim, and worktrunk from whole-dir symlinks to a **mixed-dir pattern** — `~/.config/<tool>/` is a real directory; only tracked entries are symlinked into the repo.
- 🚪 Machine-local + runtime state (fish's `15-local.fish` / `99-secrets.fish` / `fish_variables` / `fish_history` / `generated_completions/`, nvim's `lazy/` / `mason/` / `site/` / `lazyvim.json`, worktrunk's `approvals.toml`) is now **physically outside** the working tree — gitignored *and* unreachable from `git status`, accidental `git add -f`, dotfile-unaware backup tools, etc.
- 🛠 Adds 4 reusable bootstrap helpers: `prepare_real_dir`, `rescue_in_repo`, `link_tracked_entries`, `seed_local`.
- 🧪 Adds `scripts/test-bootstrap-shape.sh` to assert the post-bootstrap layout (39 PASS on this machine).
- 📚 Updates `CLAUDE.md` with the new pattern + per-tool layout details.

## 🔄 Migration

Automatic on next `bootstrap.sh` run. For each switched tool:

1. 🗑️ Old whole-dir symlink at `~/.config/<tool>` is torn down.
2. 🚚 Any gitignored files that had leaked into `$DOTFILES/.config/<tool>/` are *moved* back to `~/.config/<tool>/` before any per-file linking happens.
3. 🔗 Tracked entries get individual symlinks; `*.template` files are skipped.
4. ✨ `seed_local` copies `15-local.fish.template` / `99-secrets.fish.template` to real files on first run only.

Idempotent: subsequent runs only print ✅ for already-correct symlinks.

## ✅ Test plan

- [x] 🧪 `scripts/test-bootstrap-shape.sh` — 39 PASS, 0 FAIL
- [x] 🐟 `scripts/test-fish-loads.sh` — PASS
- [x] 📝 `scripts/test-nvim.sh` — OK (LazyVim healthcheck clean)
- [x] 🌲 `wt list` — works (worktrunk config still loads through symlinked `config.toml`)
- [x] ♻️ Bootstrap re-run is idempotent (only ✅ lines printed)
- [x] 🧼 Repo working tree clean of leaked machine-local files (`git status` confirms)

## 📦 Commits

- `test(bootstrap): add post-bootstrap shape verification`
- `feat(bootstrap): add mixed-dir symlink helpers`
- `feat(bootstrap): switch fish to mixed-dir layout`
- `feat(bootstrap): switch nvim to mixed-dir layout`
- `feat(bootstrap): switch worktrunk to mixed-dir layout`
- `docs(CLAUDE.md): describe mixed-dir layout for fish/nvim/worktrunk`