### PR TITLE
📚 feat: adopt tealdeer as modern man supplement (#53)

### DIFF
--- a/.config/fish/conf.d/00-env.fish
+++ b/.config/fish/conf.d/00-env.fish
@@ -24,6 +24,14 @@ if command -q bat
     set -gx MANROFFOPT -c
 end
 
+# tealdeer (tldr): on macOS its OS-convention config dir is
+# ~/Library/Application Support/tealdeer/. Redirect to our .config/-shape so
+# the symlinked .config/tealdeer/config.toml (Solarized [style] + auto_update)
+# is what tldr actually reads.
+if command -q tldr
+    set -gx TEALDEER_CONFIG_DIR $HOME/.config/tealdeer
+end
+
 fish_add_path -gP $HOME/.local/bin $HOME/.cargo/bin
 
 # Force Claude Code truecolor inside tmux. Single env line; the only tmux

--- a/.config/tealdeer/config.toml
+++ b/.config/tealdeer/config.toml
@@ -1,0 +1,34 @@
+# tealdeer config — https://tealdeer-rs.github.io/tealdeer/config.html
+# Solarized comes from the terminal's 16-color palette (Ghostty + tmux);
+# tealdeer 1.8.x only accepts named ANSI colors here, so we lean on the
+# palette to do the Solarized translation. Auto-update is lazy: tealdeer
+# refreshes on the next `tldr <cmd>` once the cache is older than the
+# interval below — no cron, no launchd.
+#
+# macOS note: tealdeer's default config path is
+# ~/Library/Application Support/tealdeer/. We set TEALDEER_CONFIG_DIR in
+# fish/conf.d/00-env.fish so it reads from ~/.config/tealdeer/ instead,
+# keeping the .config/<tool>/ source-of-truth shape used elsewhere.
+
+[updates]
+auto_update = true
+auto_update_interval_hours = 720   # 30 days
+
+[style.command_name]
+foreground = "blue"     # palette → Solarized blue (#268bd2)
+bold = true
+
+[style.description]
+italic = true           # default fg (base0/base1 from terminal palette)
+
+[style.example_text]
+italic = false          # default fg
+
+[style.example_code]
+foreground = "green"    # palette → Solarized green (#859900)
+bold = true
+
+[style.example_variable]
+foreground = "yellow"   # palette → Solarized yellow (#b58900); stands in
+                        # for orange, which isn't in tealdeer's named set
+italic = true

--- a/Brewfile
+++ b/Brewfile
@@ -56,7 +56,9 @@ brew "shfmt"                    # POSIX/bash/mksh formatter (`-d` for diff, `-w`
 
 # System monitoring & benchmarking
 brew "btop"                     # modern top replacement (themed Solarized)
+brew "dua-cli"                  # interactive disk-usage analyzer (TUI: `dua i`)
 brew "duf"                      # modern df replacement (grouped, color-coded)
+brew "dust"                     # tree-style du replacement (largest-first, bar graphs)
 brew "hyperfine"                # command benchmarking (warmups, multi-run stats)
 
 # Documentation & help

--- a/Brewfile
+++ b/Brewfile
@@ -59,5 +59,8 @@ brew "btop"                     # modern top replacement (themed Solarized)
 brew "duf"                      # modern df replacement (grouped, color-coded)
 brew "hyperfine"                # command benchmarking (warmups, multi-run stats)
 
+# Documentation & help
+brew "tealdeer"                 # modern man supplement (tldr); raw, no alias
+
 # Fonts
 cask "font-jetbrains-mono-nerd-font"  # Solarized + JetBrainsMono Nerd Font everywhere (CLAUDE.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -315,6 +315,20 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + fi
   and POSIX habit; `duf` for interactive disk-free checks. **Deliberately
   NOT added to modern-reminder** — that system is deprecated alongside zsh
   (see `REMOVAL.md` §1 row 2). Don't alias or wrap.
+- **`dust` is a modern `du` companion** (raw, no alias). Tree-style output
+  sorted largest-first, colored bar graphs per node, depth-aware (`-d N`
+  to limit). Read-only inspection — fast parallel scan, zero side effects.
+  `du` stays for scripts and POSIX habit; `dust` for "where did my disk
+  go?" at-a-glance. **Deliberately NOT added to modern-reminder** — that
+  system is deprecated alongside zsh (see `REMOVAL.md` §1 row 2). Don't
+  alias or wrap.
+- **`dua` is a fast `du` aggregate with an interactive TUI deleter** (raw,
+  no alias). Plain `dua [path]` walks the tree in parallel and prints
+  aggregate sizes; `dua i [path]` opens a TUI for navigating, marking, and
+  *deleting* directories. `du` stays for scripts and POSIX habit; `dua`
+  for fast aggregates and interactive disk reclaim. **Deliberately NOT
+  added to modern-reminder** — that system is deprecated alongside zsh
+  (see `REMOVAL.md` §1 row 2). Don't alias or wrap.
 - **`tealdeer` (`tldr`) is a modern `man` supplement** (raw, no alias).
   Community-curated example pages cached locally; `.config/tealdeer/config.toml`
   pins `[updates] auto_update = true` with a 720h (30-day) refresh interval —

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -315,6 +315,26 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + fi
   and POSIX habit; `duf` for interactive disk-free checks. **Deliberately
   NOT added to modern-reminder** — that system is deprecated alongside zsh
   (see `REMOVAL.md` §1 row 2). Don't alias or wrap.
+- **`tealdeer` (`tldr`) is a modern `man` supplement** (raw, no alias).
+  Community-curated example pages cached locally; `.config/tealdeer/config.toml`
+  pins `[updates] auto_update = true` with a 720h (30-day) refresh interval —
+  the first `tldr <cmd>` after the interval lazily fetches. Pairs with
+  bat-paged `man` (see `MANPAGER` in `conf.d/00-env.fish`): `man` for full
+  manuals, `tldr` for "show me the common flags". Theming uses **named ANSI
+  colors** (`"blue"`/`"green"`/`"yellow"`) in tealdeer's `[style]` block —
+  tealdeer 1.8.x doesn't accept hex; the Solarized translation comes from
+  the terminal's 16-color palette (Ghostty + tmux), so `"blue"` renders as
+  Solarized blue (#268bd2), `"green"` as Solarized green (#859900), etc.
+  `"yellow"` stands in for orange (not in the named set) for
+  `example_variable`. **macOS path quirk**: tealdeer's OS-convention config
+  dir is `~/Library/Application Support/tealdeer/`; `TEALDEER_CONFIG_DIR`
+  is set in `conf.d/00-env.fish` to redirect tealdeer to `~/.config/tealdeer/`,
+  keeping the repo's `.config/<tool>/` source-of-truth shape. fish/zsh
+  completion comes from the brew formula (`vendor_completions.d/` /
+  `site-functions/`); no per-shell completion file in this repo. Brew
+  formula doesn't ship a man page — `man tldr` will not resolve. **Deliberately
+  NOT added to modern-reminder** — deprecated alongside zsh (see `REMOVAL.md`
+  §1 row 2). Don't alias or wrap.
 - **`modern-reminder` is a zsh discoverability nudge** for default→modern
   pairs left unaliased ("no synonyms" pattern: `tail`/`tspin`,
   `grep`/`rg`, `curl`/`xh`). Defined in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,12 +4,27 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + fi
 
 ## Conventions — don't drift from these
 
-- **Manual symlinks via `bootstrap.sh`.** No `stow`/`chezmoi`/etc.
+- **Manual symlinks via `bootstrap.sh`.** No `stow`/`chezmoi`/etc. Tools
+  whose `~/.config/<tool>/` dir contains nothing but tracked content get
+  whole-dir symlinks (`link "<rel>" "$HOME/..."`). Tools whose dir mixes
+  tracked content with machine-local or runtime state (fish, nvim,
+  worktrunk, lnav, sesh) use the **mixed-dir pattern** instead: real
+  `~/.config/<tool>/` dir, per-file symlinks for tracked entries, real
+  files for the rest. Helpers `prepare_real_dir` + `rescue_in_repo` +
+  `link_tracked_entries` + `seed_local` implement the pattern;
+  `link_tracked_entries` skips `*.template` files. Migration from a
+  legacy whole-dir symlink is automatic on next `bootstrap.sh` run.
 - **Bash scripts target bash 5.** Shebang `#!/opt/homebrew/bin/bash`; may
   use `mapfile`, `declare -A`, `wait -n`. Apple Silicon only — `brew
   bundle` runs before `bootstrap.sh`. Don't reintroduce bash-3 shims.
 - **Fish module layout.** Fish is the primary interactive shell. Config
-  in `.config/fish/`, symlinked to `~/.config/fish`.
+  in `.config/fish/`. `~/.config/fish/` is a real dir (mixed-dir pattern):
+  `config.fish`, `completions/`, `functions/` are symlinked from the
+  repo; `conf.d/` is itself a real dir with per-file symlinks for the
+  tracked `*.fish` modules and **real files** for `15-local.fish` +
+  `99-secrets.fish` (seeded from `.template` companions on first
+  bootstrap, untouched after). `fish_variables`, `fish_history`,
+  `generated_completions/` are real and stay outside the repo.
   `config.fish` is empty; concerns in `conf.d/<NN>-<concern>.fish`,
   numeric prefix pins load order:
   `00-env`, `10-colors`, `15-local` (per-machine, untracked), `20-mise`,
@@ -163,7 +178,10 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + fi
   (`.vimrc` ~30 lines, `.vim/colors/solarized8.vim`) is reachable via
   `vi`/`command vim`/`\vim`. Don't add vim-plug or LSP to it.
 - **nvim is built on LazyVim**, themed Solarized, configured at
-  `.config/nvim/`. Don't replace LazyVim.
+  `.config/nvim/`. Don't replace LazyVim. `~/.config/nvim/` is a real
+  dir (mixed-dir pattern): `init.lua`, `lazy-lock.json`,
+  `mason-lock.json`, `lua/` are symlinked from the repo; `lazy/`,
+  `mason/`, `site/`, `lazyvim.json` are real and stay outside the repo.
 - **LazyVim Alt-keymaps removed** in `lua/config/keymaps.lua`
   (`<A-j>/<A-k>`) — Alt is reserved for Polish diacritics. Don't re-add.
 - **LSPs off by default in nvim.** `lua/plugins/lsp-disable-all.lua`
@@ -205,7 +223,9 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + fi
   1.25.x has no `[transient_prompt]` section — don't add one (silently
   ignored, trips `[WARN]`).
 - **wt user config is symlinked from `.config/worktrunk/config.toml`.**
-  Per-project `approvals.toml` is machine-local and gitignored.
+  `~/.config/worktrunk/` is a real dir (mixed-dir pattern): `config.toml`
+  is the only symlink; per-project `approvals.toml` is a real file there,
+  outside the repo working tree.
 - **Gitignored content flows between primary and worktrees in two
   stages**, both using `wt step copy-ignored`. `[post-start] copy`
   reflinks primary's ignored content into a new worktree at creation;

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Personal config for Ghostty + fish + tmux + vim, all in Solarized + JetBrainsMon
 Solarized-themed quick references — also browseable at
 [martinciu.github.io/dotfiles](https://martinciu.github.io/dotfiles/):
 
-- [Terminal](https://martinciu.github.io/dotfiles/terminal-cheatsheet.html) — eza, bat, less wrapper, git-delta, difftastic, glow, vivid, xh, duf, tldr, fzf, zsh plugins
+- [Terminal](https://martinciu.github.io/dotfiles/terminal-cheatsheet.html) — eza, bat, less wrapper, git-delta, difftastic, glow, vivid, xh, duf, dust, dua, tldr, fzf, zsh plugins
 - [tmux](https://martinciu.github.io/dotfiles/tmux-cheatsheet.html) — prefix `C-a` map, sessions/windows/panes, tmux-sessionx picker, status bar, copy mode
 - [Neovim](https://martinciu.github.io/dotfiles/nvim-cheatsheet.html) — LazyVim leader map, picker, LSP, neotest, Mason/Lazy
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Personal config for Ghostty + fish + tmux + vim, all in Solarized + JetBrainsMon
 Solarized-themed quick references — also browseable at
 [martinciu.github.io/dotfiles](https://martinciu.github.io/dotfiles/):
 
-- [Terminal](https://martinciu.github.io/dotfiles/terminal-cheatsheet.html) — eza, bat, less wrapper, git-delta, difftastic, glow, vivid, xh, duf, fzf, zsh plugins
+- [Terminal](https://martinciu.github.io/dotfiles/terminal-cheatsheet.html) — eza, bat, less wrapper, git-delta, difftastic, glow, vivid, xh, duf, tldr, fzf, zsh plugins
 - [tmux](https://martinciu.github.io/dotfiles/tmux-cheatsheet.html) — prefix `C-a` map, sessions/windows/panes, tmux-sessionx picker, status bar, copy mode
 - [Neovim](https://martinciu.github.io/dotfiles/nvim-cheatsheet.html) — LazyVim leader map, picker, LSP, neotest, Mason/Lazy
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -166,7 +166,13 @@ fi
 link "mise.global.toml" "$HOME/.config/mise/config.toml"
 
 # --- nvim
-link ".config/nvim"    "$HOME/.config/nvim"
+# ~/.config/nvim/ is a real dir; tracked entries are individually symlinked.
+# LazyVim's lazy/, mason/, site/, lazyvim.json stay outside the repo.
+prepare_real_dir "$HOME/.config/nvim"
+for f in lazy mason site lazyvim.json; do
+  rescue_in_repo "$DOTFILES/.config/nvim/$f" "$HOME/.config/nvim/$f"
+done
+link_tracked_entries ".config/nvim" "$HOME/.config/nvim"
 
 # --- vim
 link ".vimrc"          "$HOME/.vimrc"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -106,7 +106,12 @@ link ".config/tmux"    "$HOME/.config/tmux"
 link ".config/ccstatusline" "$HOME/.config/ccstatusline"
 
 # --- worktrunk
-link ".config/worktrunk" "$HOME/.config/worktrunk"
+# ~/.config/worktrunk/ is a real dir; tracked entries are individually symlinked.
+# Per-project approvals.toml stays outside the repo.
+prepare_real_dir "$HOME/.config/worktrunk"
+rescue_in_repo "$DOTFILES/.config/worktrunk/approvals.toml" \
+               "$HOME/.config/worktrunk/approvals.toml"
+link_tracked_entries ".config/worktrunk" "$HOME/.config/worktrunk"
 
 # --- glow
 link ".config/glow"    "$HOME/.config/glow"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -61,6 +61,9 @@ link ".config/procs"   "$HOME/.config/procs"
 # --- xh (modern HTTP client; Solarized via default_options)
 link ".config/xh"      "$HOME/.config/xh"
 
+# --- tealdeer (modern man supplement; Solarized [style] + auto-update)
+link ".config/tealdeer" "$HOME/.config/tealdeer"
+
 # --- lnav (TUI log navigator; only installed/ subdirs are symlinked from repo)
 # lnav writes its built-in samples (configs/default, formats/default), crash
 # dumps, staging area, log_metadata.db, view-info-*.json, and :config-written

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -65,7 +65,11 @@ rescue_in_repo() {
 #   Per-entry symlinks every tracked top-level entry from <source> into
 #   <target>, skipping *.template files. Tracked entries that are dirs
 #   are whole-dir-symlinked; tracked files are file-symlinked. Reuses the
-#   existing link() helper, so already-correct symlinks no-op.
+#   existing link() helper, so already-correct symlinks no-op. Entries
+#   whose destination already exists as a real (non-symlink) dir are
+#   left alone — that means the caller is handling them recursively
+#   (e.g. fish/conf.d/ inside fish/) and link() would otherwise back up
+#   the real dir and replace it with a symlink.
 link_tracked_entries() {
   local src_rel="$1"; local dst="$2"
   local src="$DOTFILES/$src_rel"
@@ -73,6 +77,9 @@ link_tracked_entries() {
     [ -e "$entry" ] || continue
     local name; name="$(basename "$entry")"
     case "$name" in *.template) continue ;; esac
+    if [ -d "$entry" ] && [ -d "$dst/$name" ] && [ ! -L "$dst/$name" ]; then
+      continue
+    fi
     link "$src_rel/$name" "$dst/$name"
   done
 }
@@ -173,17 +180,23 @@ link ".zprofile"   "$HOME/.zprofile"
 link ".config/starship.toml" "$HOME/.config/starship.toml"
 
 # --- fish (primary)
-link ".config/fish" "$HOME/.config/fish"
-if [ ! -f "$HOME/.config/fish/conf.d/15-local.fish" ]; then
-  cp "$DOTFILES/.config/fish/conf.d/15-local.fish.template" \
-     "$HOME/.config/fish/conf.d/15-local.fish"
-  echo "✨  ~/.config/fish/conf.d/15-local.fish (edit to set PROJECTS_HOME etc.)"
-fi
-if [ ! -f "$HOME/.config/fish/conf.d/99-secrets.fish" ]; then
-  cp "$DOTFILES/.config/fish/conf.d/99-secrets.fish.template" \
-     "$HOME/.config/fish/conf.d/99-secrets.fish"
-  echo "✨  ~/.config/fish/conf.d/99-secrets.fish (edit to add machine secrets)"
-fi
+# ~/.config/fish/ is a real dir; tracked entries are individually symlinked.
+# 15-local.fish + 99-secrets.fish + fish runtime state stay outside the repo.
+prepare_real_dir "$HOME/.config/fish"
+prepare_real_dir "$HOME/.config/fish/conf.d"
+for f in 15-local.fish 99-secrets.fish; do
+  rescue_in_repo "$DOTFILES/.config/fish/conf.d/$f" \
+                 "$HOME/.config/fish/conf.d/$f"
+done
+for f in fish_variables fish_history generated_completions; do
+  rescue_in_repo "$DOTFILES/.config/fish/$f" "$HOME/.config/fish/$f"
+done
+link_tracked_entries ".config/fish"        "$HOME/.config/fish"
+link_tracked_entries ".config/fish/conf.d" "$HOME/.config/fish/conf.d"
+seed_local ".config/fish/conf.d/15-local.fish.template" \
+           "$HOME/.config/fish/conf.d/15-local.fish"
+seed_local ".config/fish/conf.d/99-secrets.fish.template" \
+           "$HOME/.config/fish/conf.d/99-secrets.fish"
 
 # --- git (global ignore — paths excluded across every repo on this machine)
 link ".gitignore_global" "$HOME/.gitignore_global"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -34,6 +34,61 @@ link() {
   echo "🔗  $dst → $src"
 }
 
+# prepare_real_dir <target-abs-dir>
+#   Tears down a legacy whole-dir symlink at <target> if present, then
+#   ensures <target> exists as a real directory. Idempotent.
+prepare_real_dir() {
+  local dst="$1"
+  if [ -L "$dst" ]; then
+    rm "$dst"
+    echo "🗑️  $dst (legacy whole-dir symlink)"
+  fi
+  mkdir -p "$dst"
+}
+
+# rescue_in_repo <repo-abs-path> <target-abs-path>
+#   Migration aid for machines that ran an older bootstrap where the dir
+#   was whole-dir-symlinked. If <repo-abs-path> exists as a real file or
+#   dir (not a symlink), and <target-abs-path> doesn't yet, MOVE it across.
+#   Idempotent: no-op once rescued. Must run AFTER prepare_real_dir on
+#   the parent so the destination path is no longer aliased to the repo.
+rescue_in_repo() {
+  local in_repo="$1"; local new_home="$2"
+  if [ -e "$in_repo" ] && [ ! -L "$in_repo" ] && [ ! -e "$new_home" ]; then
+    mkdir -p "$(dirname "$new_home")"
+    mv "$in_repo" "$new_home"
+    echo "🚚  $in_repo → $new_home"
+  fi
+}
+
+# link_tracked_entries <repo-rel-source-dir> <target-abs-dir>
+#   Per-entry symlinks every tracked top-level entry from <source> into
+#   <target>, skipping *.template files. Tracked entries that are dirs
+#   are whole-dir-symlinked; tracked files are file-symlinked. Reuses the
+#   existing link() helper, so already-correct symlinks no-op.
+link_tracked_entries() {
+  local src_rel="$1"; local dst="$2"
+  local src="$DOTFILES/$src_rel"
+  for entry in "$src"/*; do
+    [ -e "$entry" ] || continue
+    local name; name="$(basename "$entry")"
+    case "$name" in *.template) continue ;; esac
+    link "$src_rel/$name" "$dst/$name"
+  done
+}
+
+# seed_local <template-repo-rel> <target-abs>
+#   First-run copy of a .template into a real file on disk. Idempotent:
+#   no-op if the target already exists.
+seed_local() {
+  local tmpl="$DOTFILES/$1"; local dst="$2"
+  if [ ! -f "$dst" ]; then
+    mkdir -p "$(dirname "$dst")"
+    cp "$tmpl" "$dst"
+    echo "✨  $dst (seeded from $(basename "$tmpl"))"
+  fi
+}
+
 # --- ghostty (already done; idempotent re-link)
 link ".config/ghostty" "$HOME/.config/ghostty"
 

--- a/docs/terminal-cheatsheet.html
+++ b/docs/terminal-cheatsheet.html
@@ -69,6 +69,7 @@
       <tr><td class="key"><a href="https://lnav.org/"><code>lnav</code></a></td><td class="desc">TUI log navigator; Solarized via built-in theme (see lnav section)</td></tr>
       <tr><td class="key"><a href="https://github.com/aristocratos/btop"><code>btop</code></a></td><td class="desc">modern <code>top</code> replacement; Solarized via <code>~/.config/btop/btop.conf</code></td></tr>
       <tr><td class="key"><a href="https://github.com/muesli/duf"><code>duf</code></a></td><td class="desc">modern <code>df</code> replacement (grouped, color-coded; raw, no alias)</td></tr>
+      <tr><td class="key"><a href="https://github.com/tealdeer-rs/tealdeer"><code>tealdeer</code></a></td><td class="desc">modern <code>man</code> supplement (<code>tldr</code>); Solarized via terminal palette in <code>~/.config/tealdeer/config.toml</code> (<code>TEALDEER_CONFIG_DIR</code>), auto-updates every 30 days</td></tr>
       <tr><td class="key"><a href="https://github.com/ducaale/xh"><code>xh</code></a></td><td class="desc">modern HTTP client (HTTPie-compatible CLI); Solarized via <code>~/.config/xh/config.json</code></td></tr>
       <tr><td class="key"><a href="https://github.com/zsh-users/zsh-autosuggestions"><code>zsh-autosuggestions</code></a></td><td class="desc">ghost-text completion from history</td></tr>
       <tr><td class="key"><a href="https://github.com/zsh-users/zsh-syntax-highlighting"><code>zsh-syntax-highlighting</code></a></td><td class="desc">live command-line highlighting</td></tr>

--- a/docs/terminal-cheatsheet.html
+++ b/docs/terminal-cheatsheet.html
@@ -68,7 +68,9 @@
       <tr><td class="key"><a href="https://github.com/bensadeh/tailspin"><code>tailspin</code></a></td><td class="desc">live-log highlighter (<code>tspin</code>); Solarized via <code>~/.config/tailspin/theme.toml</code></td></tr>
       <tr><td class="key"><a href="https://lnav.org/"><code>lnav</code></a></td><td class="desc">TUI log navigator; Solarized via built-in theme (see lnav section)</td></tr>
       <tr><td class="key"><a href="https://github.com/aristocratos/btop"><code>btop</code></a></td><td class="desc">modern <code>top</code> replacement; Solarized via <code>~/.config/btop/btop.conf</code></td></tr>
+      <tr><td class="key"><a href="https://github.com/Byron/dua-cli"><code>dua</code></a></td><td class="desc">interactive disk-usage analyzer with TUI deleter (<code>dua i</code>; raw, no alias)</td></tr>
       <tr><td class="key"><a href="https://github.com/muesli/duf"><code>duf</code></a></td><td class="desc">modern <code>df</code> replacement (grouped, color-coded; raw, no alias)</td></tr>
+      <tr><td class="key"><a href="https://github.com/bootandy/dust"><code>dust</code></a></td><td class="desc">tree-style <code>du</code> replacement (largest-first, bar graphs; raw, no alias)</td></tr>
       <tr><td class="key"><a href="https://github.com/tealdeer-rs/tealdeer"><code>tealdeer</code></a></td><td class="desc">modern <code>man</code> supplement (<code>tldr</code>); Solarized via terminal palette in <code>~/.config/tealdeer/config.toml</code> (<code>TEALDEER_CONFIG_DIR</code>), auto-updates every 30 days</td></tr>
       <tr><td class="key"><a href="https://github.com/ducaale/xh"><code>xh</code></a></td><td class="desc">modern HTTP client (HTTPie-compatible CLI); Solarized via <code>~/.config/xh/config.json</code></td></tr>
       <tr><td class="key"><a href="https://github.com/zsh-users/zsh-autosuggestions"><code>zsh-autosuggestions</code></a></td><td class="desc">ghost-text completion from history</td></tr>

--- a/scripts/test-bootstrap-shape.sh
+++ b/scripts/test-bootstrap-shape.sh
@@ -1,0 +1,125 @@
+#!/opt/homebrew/bin/bash
+# Asserts the post-bootstrap shape of ~/.config/{fish,nvim,worktrunk}/.
+# Run AFTER bootstrap.sh on the live machine. Fails if any leaked file
+# is back inside the repo working tree, or any required symlink is missing.
+set -u
+
+REPO="${REPO:-$PROJECTS_HOME/dotfiles}"
+
+pass=0
+fail=0
+fail_msgs=()
+
+# ─── helpers ────────────────────────────────
+record_pass() { pass=$((pass+1)); echo "  PASS  $1"; }
+record_fail() {
+  fail=$((fail+1))
+  fail_msgs+=("FAIL  $1"$'\n'"        $2")
+  echo "  FAIL  $1"
+}
+
+assert_real_dir() {
+  local path="$1" desc="$2"
+  if [ -L "$path" ]; then
+    record_fail "$desc" "expected real dir, found symlink: $path → $(readlink "$path")"
+  elif [ ! -d "$path" ]; then
+    record_fail "$desc" "expected real dir, missing: $path"
+  else
+    record_pass "$desc"
+  fi
+}
+
+assert_symlink_to() {
+  local path="$1" want_target="$2" desc="$3"
+  if [ ! -L "$path" ]; then
+    record_fail "$desc" "expected symlink, not a symlink: $path"
+  elif [ "$(readlink "$path")" != "$want_target" ]; then
+    record_fail "$desc" "symlink target mismatch: $path → $(readlink "$path"), want → $want_target"
+  else
+    record_pass "$desc"
+  fi
+}
+
+assert_real_file() {
+  local path="$1" desc="$2"
+  if [ -L "$path" ]; then
+    record_fail "$desc" "expected real file, found symlink: $path → $(readlink "$path")"
+  elif [ ! -f "$path" ]; then
+    record_fail "$desc" "expected real file, missing: $path"
+  else
+    record_pass "$desc"
+  fi
+}
+
+assert_not_in_repo() {
+  local path="$1" desc="$2"
+  if [ -e "$path" ] && [ ! -L "$path" ]; then
+    record_fail "$desc" "leaked into repo working tree: $path"
+  else
+    record_pass "$desc"
+  fi
+}
+
+# ─── fish ───────────────────────────────────
+echo
+echo "fish layout"
+echo "───────────"
+assert_real_dir   "$HOME/.config/fish"                              "~/.config/fish/ is a real dir"
+assert_real_dir   "$HOME/.config/fish/conf.d"                       "~/.config/fish/conf.d/ is a real dir"
+assert_symlink_to "$HOME/.config/fish/config.fish"     "$REPO/.config/fish/config.fish"     "config.fish symlink"
+assert_symlink_to "$HOME/.config/fish/completions"     "$REPO/.config/fish/completions"     "completions/ symlink"
+assert_symlink_to "$HOME/.config/fish/functions"       "$REPO/.config/fish/functions"       "functions/ symlink"
+for f in 00-env.fish 10-colors.fish 20-mise.fish 25-prompt.fish \
+         30-aliases.fish 35-abbreviations.fish 40-plugins.fish 50-tmux-hooks.fish; do
+  assert_symlink_to "$HOME/.config/fish/conf.d/$f" "$REPO/.config/fish/conf.d/$f" "conf.d/$f symlink"
+done
+assert_real_file  "$HOME/.config/fish/conf.d/15-local.fish"  "15-local.fish is a real file"
+assert_real_file  "$HOME/.config/fish/conf.d/99-secrets.fish" "99-secrets.fish is a real file"
+
+# No .template symlinks anywhere
+for f in 15-local.fish.template 99-secrets.fish.template; do
+  if [ -L "$HOME/.config/fish/conf.d/$f" ]; then
+    record_fail "no .template symlink for $f" "found symlink: $HOME/.config/fish/conf.d/$f"
+  else
+    record_pass "no .template symlink for $f"
+  fi
+done
+
+# Repo-side leak check
+for f in 15-local.fish 99-secrets.fish fish_variables fish_history generated_completions; do
+  assert_not_in_repo "$REPO/.config/fish/conf.d/$f" "no $f leaked under repo conf.d/"
+  assert_not_in_repo "$REPO/.config/fish/$f"        "no $f leaked under repo fish/"
+done
+
+# ─── nvim ───────────────────────────────────
+echo
+echo "nvim layout"
+echo "───────────"
+assert_real_dir   "$HOME/.config/nvim"                                                "~/.config/nvim/ is a real dir"
+assert_symlink_to "$HOME/.config/nvim/init.lua"        "$REPO/.config/nvim/init.lua"        "init.lua symlink"
+assert_symlink_to "$HOME/.config/nvim/lazy-lock.json"  "$REPO/.config/nvim/lazy-lock.json"  "lazy-lock.json symlink"
+assert_symlink_to "$HOME/.config/nvim/mason-lock.json" "$REPO/.config/nvim/mason-lock.json" "mason-lock.json symlink"
+assert_symlink_to "$HOME/.config/nvim/lua"             "$REPO/.config/nvim/lua"             "lua/ symlink"
+for f in lazy mason site lazyvim.json; do
+  assert_not_in_repo "$REPO/.config/nvim/$f" "no $f leaked under repo nvim/"
+done
+
+# ─── worktrunk ──────────────────────────────
+echo
+echo "worktrunk layout"
+echo "────────────────"
+assert_real_dir   "$HOME/.config/worktrunk"                                            "~/.config/worktrunk/ is a real dir"
+assert_symlink_to "$HOME/.config/worktrunk/config.toml" "$REPO/.config/worktrunk/config.toml" "config.toml symlink"
+assert_not_in_repo "$REPO/.config/worktrunk/approvals.toml" "no approvals.toml leaked under repo worktrunk/"
+
+# ─── summary ────────────────────────────────
+echo
+echo "───────────────────────────────────────"
+echo "PASS: $pass    FAIL: $fail"
+if [ "$fail" -gt 0 ]; then
+  echo
+  for msg in "${fail_msgs[@]}"; do
+    printf '%s\n' "$msg"
+  done
+  exit 1
+fi


### PR DESCRIPTION
## 📚 Summary
- Adopts `tealdeer` (`tldr`) as a Solarized-themed, 30-day auto-refreshing supplement to `man`. `man` itself stays — already bat-paged via `MANPAGER` in `conf.d/00-env.fish`.
- New `.config/tealdeer/config.toml` pins `[updates] auto_update = true`, `auto_update_interval_hours = 720`, and a `[style]` map. Tealdeer 1.8.x only accepts named ANSI colors there (`"blue"`, `"green"`, `"yellow"`) — the Solarized translation comes from the terminal's 16-color palette (Ghostty + tmux), so `"blue"` renders as `#268bd2`, `"green"` as `#859900`, `"yellow"` as `#b58900`. `"yellow"` stands in for orange (not in tealdeer's named set) on `example_variable`.
- macOS path quirk: tealdeer's OS-convention config dir is `~/Library/Application Support/tealdeer/`. `TEALDEER_CONFIG_DIR=$HOME/.config/tealdeer` is set in `conf.d/00-env.fish` to keep the repo's `.config/<tool>/` source-of-truth shape working.
- New `# Documentation & help` section in `Brewfile`; symlink wired through `bootstrap.sh` next to the other Solarized-themed CLI tools (`procs`, `xh`).
- Documentation: CLAUDE.md convention bullet near the `duf` entry; cheatsheet "recently added" row; README cheatsheet description line.
- No alias, no `modern-reminder` pair (deprecated alongside zsh per `REMOVAL.md` §1 row 2), no per-shell completion file (brew formula installs `vendor_completions.d/tldr.fish` + `site-functions/_tldr`).

## 🧪 Test plan
- [x] `brew bundle --file=./Brewfile` → installs tealdeer 1.8.1
- [x] `tldr --update` → cache primed (`~/Library/Caches/tealdeer/tldr-pages/`)
- [x] `tldr --show-paths` reports `Config dir: ~/.config/tealdeer/ (env variable)` — confirms `TEALDEER_CONFIG_DIR` redirect works
- [x] `tldr tar` renders bold blue command-name, italic description, bold green example-code, italic yellow `{{placeholder}}` variables (verified via raw ANSI: `\e[1;34m`, `\e[3m`, `\e[1;32m`, `\e[3;33m`)
- [x] Fish completion: 16 `complete -c tldr` entries at `/opt/homebrew/share/fish/vendor_completions.d/tldr.fish`, on default `$fish_complete_path`
- [ ] Re-run `bootstrap.sh` from primary checkout post-merge → idempotent, prints `🔗 ~/.config/tealdeer → …/dotfiles/.config/tealdeer`
- [ ] (skipped) `man tldr` — brew formula doesn't ship a man page; not a regression

## 🔭 Out of scope
- ❌ No other tool swaps (issue #53 explicit)
- ❌ No `tldr` alias/wrapper, no launchd cache cron, no `modern-reminder` entry

## 📦 Files changed
- `Brewfile` (+3) — new `# Documentation & help` section
- `.config/tealdeer/config.toml` (+34) — new file
- `.config/fish/conf.d/00-env.fish` (+8) — `TEALDEER_CONFIG_DIR` redirect
- `bootstrap.sh` (+3) — `--- tealdeer` link block
- `CLAUDE.md` (+20) — convention bullet near `duf` (covers the env-var quirk and named-ANSI schema)
- `docs/terminal-cheatsheet.html` (+1) — recently-added row
- `README.md` (+1/-1) — `tldr` in cheatsheet line

Closes #53

## 📊 Session stats
| | |
|---|---|
| Start | 2026-05-07 17:45 UTC |
| End | 2026-05-07 19:08 UTC |
| Elapsed | 1h 22m |
| Working | 23m 36s (28% of elapsed) |
| Idle | 59m 2s |
| Total billed tokens | 21.1M |
| Total cost (USD, public rates) | \$52.22 |
| Effective rate | \$132.78/hr |

| Model | Messages | Input | Output | Cache Read | Cache Write 5m | Cache Write 1h | Cost |
|---|---:|---:|---:|---:|---:|---:|---:|
| Opus 4.7 | 196 | 331 | 129k | 20.6M | 0 | 386k | \$52.22 |

_Public-rate estimate (Anthropic API list pricing); plan billing differs._ Cache reads dominate as expected (prompt caching at ~10% of base input price). Live-session "end" is the timestamp of the most recent entry.