### PR TITLE
🗓️ tmux-resurrect: keep snapshots for 1 year (was 30 days)

### DIFF
--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -122,6 +122,9 @@ set -g @plugin 'tmux-plugins/tmux-sensible'
 set -g @plugin 'tmux-plugins/tmux-resurrect'
 set -g @plugin 'tmux-plugins/tmux-continuum'
 set -g @continuum-restore 'on'
+# Keep resurrect snapshots for a full year before pruning (default is 30 days).
+# tmux-resurrect always retains at least 5 newest backups regardless of age.
+set -g @resurrect-delete-backup-after 365
 
 # tmux-sessionx provides the <prefix> t session picker (replacing the
 # sesh-picker wrapper). The plugin claims `t` via @sessionx-bind during


### PR DESCRIPTION
## 🎯 Summary
- ⚙️ Sets `@resurrect-delete-backup-after 365` in `.config/tmux/tmux.conf`.
- ⏳ Default was 30 days; that meant a session left dormant for over a month could be silently scrubbed before I came back to it.
- 🛟 tmux-resurrect always retains at least the 5 newest backups regardless of age, so the existing safety floor is unchanged — the change only affects how long *older* snapshots stick around.

## 💡 Why
- 📌 I sometimes return to a project after weeks/months and want the saved layout back. 30 days is too aggressive for that workflow; 365 covers any realistic gap.

## ✅ Test plan
- [x] `tmux -f /dev/null source-file .config/tmux/tmux.conf` — no syntax errors
- [ ] Reload running tmux (`<prefix> r`); confirm new option is set via `tmux show-option -gv @resurrect-delete-backup-after` → `365`