### PR TITLE
🧹 Purge zsh-ghost comments and gitignore residue

### DIFF
--- a/.config/fish/conf.d/00-env.fish
+++ b/.config/fish/conf.d/00-env.fish
@@ -1,5 +1,5 @@
-# brew shellenv — replaces .zprofile's role on the fish side. conf.d
-# runs for non-interactive shells too, so child processes inherit PATH.
+# brew shellenv. conf.d runs for non-interactive shells too, so child
+# processes inherit PATH.
 eval (/opt/homebrew/bin/brew shellenv)
 
 set -gx EDITOR vim
@@ -12,12 +12,11 @@ set -gx LC_ALL en_US.UTF-8
 # `set -e fish_greeting`.
 set -g fish_greeting ''
 
-# Bell parity (CLAUDE.md → "Bells are silenced at every layer"). Fish has
-# no `unsetopt BEEP` equivalent — fish doesn't ring the bell on the events
-# zsh does (completion miss, backspace at empty line, etc.). Any `\a` that
-# fish does emit is consumed by Ghostty's `bell-features =` and tmux's
-# `bell-action none` upstream. Documented here so the per-shell layer is
-# accounted for.
+# Bell parity (CLAUDE.md → "Bells are silenced at every layer"). Fish
+# doesn't ring the bell on common events (completion miss, backspace at
+# an empty line, etc.). Any `\a` it does emit is consumed by Ghostty's
+# `bell-features =` and tmux's `bell-action none` upstream. Documented
+# here so the per-shell layer is accounted for.
 
 if command -q bat
     set -gx MANPAGER 'sh -c "col -bx | bat -l man -p --paging=always"'

--- a/.config/fish/conf.d/10-colors.fish
+++ b/.config/fish/conf.d/10-colors.fish
@@ -11,7 +11,7 @@ set -gx FZF_DEFAULT_OPTS '
 # Ghost-text autosuggestions — dim, readable on Solarized Dark.
 set -g fish_color_autosuggestion brblack
 
-# Solarized syntax-highlighting palette (replaces zsh-syntax-highlighting).
+# Solarized syntax-highlighting palette.
 set -g fish_color_command       blue
 set -g fish_color_param         normal
 set -g fish_color_quote         cyan

--- a/.config/fish/conf.d/40-plugins.fish
+++ b/.config/fish/conf.d/40-plugins.fish
@@ -6,7 +6,7 @@ end
 # Alt-C is reserved for Polish diacritics; remove fzf's cd-widget binding.
 bind -e \ec 2>/dev/null
 
-# zoxide — frecency-ranked cd. Same exclusions as the zsh side.
+# zoxide — frecency-ranked cd.
 if command -q zoxide
     set -gx _ZO_EXCLUDE_DIRS "$HOME:$HOME/Downloads/*:$HOME/.config/*:$HOME/Library/*"
     zoxide init fish | source

--- a/.config/fish/functions/less.fish
+++ b/.config/fish/functions/less.fish
@@ -1,4 +1,4 @@
-# bat-backed less wrapper. Direct port of the zsh function in aliases.zsh.
+# bat-backed less wrapper.
 function less
     if isatty stdin
         command bat --paging=always $argv

--- a/.config/procs/procs-heavy.toml
+++ b/.config/procs/procs-heavy.toml
@@ -1,5 +1,6 @@
 # .config/procs/procs-heavy.toml — "what's hot right now" view.
-# Loaded by `psh` (alias in .zshrc) via `--load-config`. Trimmed column set
+# Loaded by `psh` (alias in `.config/fish/conf.d/30-aliases.fish`) via
+# `--load-config`. Trimmed column set
 # (Pid, User, UsageCpu, UsageMem, VmRss, Command) and default sort by
 # UsageCpu descending so heavy processes float to the top.
 #

--- a/.gitignore
+++ b/.gitignore
@@ -25,9 +25,6 @@
 # superpowers plans/specs (per ~/.claude/CLAUDE.md, never committed)
 tmp/
 
-# zsh local machine config — lives at ~/.zshrc.local, never in the repo
-.zshrc.local
-
 # git worktrees (project-local, per CLAUDE.md)
 .claude/worktrees/
 

--- a/bin/s
+++ b/bin/s
@@ -1,4 +1,4 @@
-#!/usr/bin/env zsh
+#!/opt/homebrew/bin/bash
 # s — one-command worktree + tmux session.
 # See tmp/specs/2026-04-30-s-worktree-session-design.md for design rationale.
 set -euo pipefail


### PR DESCRIPTION
Closes #156.

## 📋 Summary

- 🧽 Drops 5 stale zsh-era comments (4 fish files + procs-heavy.toml) and 1 mid-file zsh comparison in 00-env.fish (bell-parity note rephrased to drop the zsh reference, keep the rationale).
- 🗑️ Removes the dead `.zshrc.local` rule from `.gitignore`.
- 🔁 Flips `bin/s` shebang from `zsh` to bash 5 — last live zsh dep on the system.

## 🧪 Test plan

- [x] `rg -n 'zsh' --glob '!.config/tmux/plugins' --glob '!scripts/test-tmux-ssh-indicator.sh' --glob '!.claude/worktrees'` returns nothing
- [x] `bootstrap.sh` runs clean (idempotent re-link)
- [x] `scripts/test-fish-loads.sh` passes
- [x] `scripts/test-helpers.sh` passes (includes `scripts/test-s.sh` — 53 cases exercising `bin/s` end-to-end under the new bash shebang)
- [x] `bash -n bin/s` parses cleanly

## ⚠️ Risk

Low. Six of seven edits are comment / `.gitignore`-only. The seventh (`bin/s` shebang) is fully covered by the existing `test-s.sh` suite (53 PASS post-conversion). Script body uses only bash-4+ features (`set -euo pipefail`, `[[ ]]`, `(( ))`, `$'\t'`, `${var%%pat}`, `local`, here-docs) — no zsh-only constructs.

## 🔗 Notes

- Spec: `.superpowers/specs/2026-05-08-zsh-cleanup-design.md` (gitignored — not in this PR).
- Plan: `.superpowers/plans/2026-05-08-zsh-cleanup.md` (gitignored — not in this PR).