### PR TITLE
[#159] Add mermaid-cli (mmdc) for diagram rendering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -296,6 +296,13 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + fi
   aggregate sizes; `dua i [path]` opens a TUI for navigating, marking, and
   *deleting* directories. `du` stays for scripts and POSIX habit; `dua`
   for fast aggregates and interactive disk reclaim. Don't alias or wrap.
+- **`mmdc` renders Mermaid diagrams** (`@mermaid-js/mermaid-cli`), installed
+  via mise as a global npm tool (`mise.global.toml`). `.mmd` source files
+  live co-located with the docs that reference them; rendered `.svg` files
+  sit alongside (same directory, same basename). Both are committed.
+  Build all: `scripts/build-diagrams.sh`. Single file:
+  `mmdc -i file.mmd -o file.svg`. Don't install via brew (parallel node
+  stack) or `npm install -g` (not declarative, lost on node upgrade).
 
 ## Where things live
 
@@ -333,6 +340,7 @@ is `nvim-cheatsheet.html`).
 
 - Helper smoke tests: `scripts/test-helpers.sh`
 - Regenerate screenshots: `scripts/build-screenshots.sh`
+- Render diagrams: `scripts/build-diagrams.sh`
 - Tmux window-label: `scripts/test-fish-tmux-window-label.fish`
 - Pre-remove save-shared: `scripts/test-wt-pre-remove-save.sh`
 - Claude tmux window-name: `scripts/test-claude-tmux-window-name.sh`

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -166,6 +166,7 @@ fi
 # Stored as mise.global.toml at repo root (not under .config/mise/) to avoid
 # mise auto-discovering it as a local project config when inside the dotfiles dir.
 link "mise.global.toml" "$HOME/.config/mise/config.toml"
+mise install
 
 # --- nvim
 # ~/.config/nvim/ is a real dir; tracked entries are individually symlinked.

--- a/mise.global.toml
+++ b/mise.global.toml
@@ -1,6 +1,7 @@
 [tools]
 node = "lts"
 ruby = "3.4.8"
+"npm:@mermaid-js/mermaid-cli" = "latest"
 
 [settings]
 legacy_version_file = true

--- a/scripts/build-diagrams.sh
+++ b/scripts/build-diagrams.sh
@@ -1,0 +1,31 @@
+#!/opt/homebrew/bin/bash
+# Render every .mmd file in the repo to a co-located .svg.
+# Skips files whose .svg is already newer than the .mmd source.
+# Re-run after editing any .mmd diagram.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+shopt -s nullglob
+
+command -v mmdc >/dev/null || { echo "mmdc not found — run 'mise install'"; exit 1; }
+
+count=0
+skipped=0
+while IFS= read -r -d '' mmd; do
+  svg="${mmd%.mmd}.svg"
+  if [ -f "$svg" ] && [ "$svg" -nt "$mmd" ]; then
+    skipped=$((skipped + 1))
+    continue
+  fi
+  mmdc -i "$mmd" -o "$svg" -q
+  echo "OK $(basename "$mmd") -> $(basename "$svg")"
+  count=$((count + 1))
+done < <(find . -path ./.claude/worktrees -prune -o -name '*.mmd' -print0)
+
+if [ "$count" -eq 0 ] && [ "$skipped" -eq 0 ]; then
+  echo "No .mmd files found."
+  exit 0
+fi
+[ "$skipped" -gt 0 ] && echo "Skipped $skipped up-to-date diagram(s)."
+[ "$count" -gt 0 ] && echo "Rendered $count diagram(s)."


### PR DESCRIPTION
## Summary

- Add `@mermaid-js/mermaid-cli` as a mise-managed global npm tool in `mise.global.toml`
- Add `mise install` to `bootstrap.sh` after the config symlink so tools are available on new machines
- Add `scripts/build-diagrams.sh` — batch converts co-located `.mmd` files to `.svg` in-place
- Document mmdc convention and build script in `CLAUDE.md`

Closes #159

## Test Plan

- [ ] `mise install` picks up mmdc: `mmdc --version`
- [ ] `scripts/build-diagrams.sh` runs clean (no `.mmd` files yet → "No .mmd files found.")
- [ ] `bash -n bootstrap.sh` passes
- [ ] `scripts/test-fish-loads.sh` passes