### PR TITLE
📁 retire tmp/, route planning artefacts to .superpowers/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,16 +22,13 @@
 !.vim/backup/.gitkeep
 !.vim/swap/.gitkeep
 
-# superpowers plans/specs (per ~/.claude/CLAUDE.md, never committed)
-tmp/
-
 # git worktrees (project-local, per CLAUDE.md)
 .claude/worktrees/
 
 # macOS
 .DS_Store
 
-# brainstorming visual companion session files
+# superpowers planning artefacts (specs, plans, brainstorm sessions, postmortems) — per ~/.claude/CLAUDE.md, never committed
 .superpowers/
 
 # editor swap


### PR DESCRIPTION
## 📦 Summary

- 🧹 Drops the `tmp/` rule from `.gitignore` and removes the directory from this worktree.
- 📂 Moves 14 plans and 15 specs from `tmp/` into `.superpowers/` (no filename collisions).
- 🗑️ Deletes four draft files (`tmp/{nvim,shell-colors,tmux}-cheatsheet.html`, `tmp/claude-code-env-vars.md`); regenerable, nvim and tmux already published in `docs/`.
- 💬 Refreshes the `.superpowers/` comment in `.gitignore` to reflect actual usage (plans, specs, brainstorm sessions, postmortems) instead of the stale "brainstorming visual companion session files".

Working-tree moves and deletes produce no git diff (both `tmp/` and `.superpowers/` are gitignored). The only committed change is `.gitignore` (1 insertion, 4 deletions).

## 🧪 Test plan

- 🔍 `git diff .gitignore` — exactly the `tmp/` rule removal and `.superpowers/` comment refresh, nothing else.
- 📂 `test ! -e tmp` — directory removed from this worktree.
- 🔢 `ls .superpowers/plans | wc -l` → 48 (34 baseline + 14 moved).
- 🔢 `ls .superpowers/specs | wc -l` → 48 (33 baseline + 15 moved).
- 🩺 `bash scripts/test-helpers.sh` — passes (131 PASS).
- 🩺 `bash scripts/test-fish-loads.sh` — passes.

## 🧹 Manual followup (primary checkout)

`wt step copy-ignored` is additive only (`--force` off), and the `[pre-remove] save-shared` hook reflinks worktree-ignored content into the primary but does not propagate deletes. After this PR merges, run the same cleanup once in the primary dotfiles checkout:

```fish
cd $PROJECTS_HOME/dotfiles
mv tmp/plans/* .superpowers/plans/
mv tmp/specs/* .superpowers/specs/
rm tmp/*.html tmp/claude-code-env-vars.md
rmdir tmp/plans tmp/specs tmp
```

If the primary has accumulated new entries since this worktree was created, watch for collisions during `mv` and resolve by hand.

## 🔗 Closes

Closes #157.

## 📊 Session stats

| | |
|---|---|
| Start | 2026-05-08 06:54 UTC |
| End | 2026-05-08 08:47 UTC |
| Elapsed | 1h 52m |
| Working | 13m 55s (12% of elapsed) |
| Idle | 1h 38m |
| Total billed tokens | 10.4M |
| Total cost (public rates) | \$58.33 |
| Effective rate | \$251.57/hr |

| Model | Msgs | Input | Output | Cache Read | Cache Write 5m | Cache Write 1h | Cost |
|---|---|---|---|---|---|---|---|
| Opus 4.7 | 117 | 247 | 130k | 9.1M | 0 | 1.2M | \$58.33 |

**Notes**
- 💰 Public-rate estimate; verify at anthropic.com/pricing.
- 🎟️ Plan billing differs — Claude Max bundles usage.
- 🗄️ Cache reads dominate (9.1M) — normal; prompt caching reuses prior turns at ~10% of base input price.