### PR TITLE
🧽 Ignore .ruby-lsp/ and document s vs EnterWorktree prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@
 # worktrunk runtime state — per-project hook approvals are machine-local
 .config/worktrunk/approvals.toml
 
+# ruby-lsp runtime state (auto-generated when ruby-lsp picks up the repo)
+.ruby-lsp/
+
 # sesh — shared config tracked; machine-local sessions in ~/.config/sesh/sesh.local.toml (outside repo)
 
 # vim runtime files (real dirs in $HOME, not symlinks; never tracked)

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ These drive the `claude[<name>]` window title (tmux's
 - splits: `<prefix> |` (right) / `<prefix> -` (down)
 - reload tmux: `<prefix> r`
 - TPM plugin install: `<prefix> I` (capital I)
-- worktree+session command (any shell): `s [<project>] [<name>]` — inside tmux 1 arg = worktree name in current project; outside tmux 1 arg = project name (attach), 0 args = fzf picker
+- worktree+session command (any shell): `s [<project>] [<name>]` — inside tmux 1 arg = worktree name in current project; outside tmux 1 arg = project name (attach), 0 args = fzf picker. Branch name verbatim — the `worktree-` prefix is reserved for the `EnterWorktree` workflow.
 
 ## Status bar (right side)
 


### PR DESCRIPTION
Closes #158.

## 📝 Summary

Two unrelated one-liners bundled per the issue's "fine to bundle" note:

- 🙈 **`.ruby-lsp/` ignored.** ruby-lsp generates `Gemfile`, `Gemfile.lock`, `last_updated`, `.gitignore` under `.ruby-lsp/` at repo root the first time it picks up the repo. Was untracked-but-not-ignored, so `git status` kept nagging.
- 📌 **README note on `s` vs `EnterWorktree`.** Surfaces the existing `CLAUDE.md` rule — `s` uses the branch name verbatim; the `worktree-` prefix is reserved for the `EnterWorktree` workflow — somewhere a reader of "Setup / Tools" can find it.

## ✅ Test plan

- [x] 🧹 `git status` clean for `.ruby-lsp/` after the ignore (only the two intended file changes show as modified)
- [x] 🔎 `git check-ignore -v .ruby-lsp/` matches `.gitignore:16:.ruby-lsp/`
- [x] 📖 README line 122 still renders as a single bullet (no broken markdown)

## 🚫 Out of scope

- No `CLAUDE.md` change — the asymmetry is already documented there.
- No cheatsheet update — `s` isn't on a cheatsheet, and adding it is bigger than this hygiene PR.