### PR TITLE
🐍 Apply uv-first Python rule: cleanup brewed state + uv-managed python3 default

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -145,9 +145,23 @@ offers something `mise` can't replicate; otherwise use `mise`.
   loses the ergonomics.
 - **Python → `uv` (preferred) or `mise`**. `uv` covers the whole Python
   lifecycle: installs interpreters, runs scripts (`uv run`), manages
-  projects, installs CLIs (`uv tool`), 10–100× faster than `pip`. Where
-  `mise` only installs interpreters, `uv` does the rest. Use `mise` only
-  if consistency with other runtimes outweighs `uv`'s lifecycle wins.
+  projects (`uv init` / `add` / `sync`), installs CLIs (`uv tool`),
+  provides a pip-compatible surface (`uv pip`). 10–100× faster than
+  `pip`. Use `mise` only if consistency with other runtimes outweighs
+  `uv`'s lifecycle wins.
+  - **Global `python3` on PATH:** `uv python install <ver> --default`
+    drops `python` / `python3` / `python3.<minor>` symlinks into
+    `~/.local/bin`. Without `--default`, uv interpreters are reachable
+    only through `uv run` / `uv tool`, and bare `python3` falls through
+    to Apple's 3.9.6 (EOL Oct 2025).
+  - **Apple's `/usr/bin/python3`** is system-only — used by macOS
+    internal scripts (Xcode, launchd, App Bundles). Leave it physically
+    untouched. After `--default` it stops being the PATH default;
+    reach it by full path if a system tool needs it.
+  - **No system `pip`.** Inside a project: `uv add` (modifies
+    `pyproject.toml`) or `uv pip install` (pip-syntax shim). One-off
+    script: `uv run --with <pkg> script.py`. One-off CLI: `uvx <cli>`.
+    Never need `pip3` on PATH.
 - **Node → `mise`**. No specialized Node manager offers materially more.
   `fnm` is faster but offers nothing else; `nvm` is shell-script-slow.
 - **Ruby → `mise`**. Same logic. `rbenv`/`chruby` are good but offer
@@ -164,6 +178,10 @@ offers something `mise` can't replicate; otherwise use `mise`.
 - ❌ Installing Python-based CLIs via `brew` when `uv tool install <cli>`
   works (e.g. `httpie`, `yt-dlp`, `aws-cli`, `platformio`). Brew formulas
   pin a specific brew Python and force a parallel Python stack.
+- ❌ Apple's `/usr/bin/python3` for development — frozen at 3.9.6,
+  EOL Oct 2025, PEP 668 lockdown blocks system-wide `pip`.
+- ❌ System `pip` / `pip3` on PATH — superseded by `uv add` and
+  `uv pip` inside venvs.
 
 How to apply: when adding/upgrading a runtime or a Python CLI, default
 to the row above. If a brew formula hard-depends on a brew Python

--- a/.config/fish/conf.d/00-env.fish
+++ b/.config/fish/conf.d/00-env.fish
@@ -23,7 +23,7 @@ if command -q bat
     set -gx MANROFFOPT -c
 end
 
-fish_add_path -gP $HOME/.local/bin $HOME/.cargo/bin
+fish_add_path -gPm $HOME/.local/bin $HOME/.cargo/bin
 
 # Force Claude Code truecolor inside tmux. Single env line; the only tmux
 # integration that survives B-scope.

--- a/Brewfile
+++ b/Brewfile
@@ -21,7 +21,7 @@ brew "worktrunk"
 
 # Runtime version manager (Node + Ruby) + Python package runner
 brew "mise"
-brew "uv"  # fast Python package manager + ephemeral-venv runner; "uv run --with pyyaml script.py" without polluting global Python
+brew "uv"  # owns the Python lifecycle: interpreters (`uv python install --default`), projects (`uv add`/`run`/`sync`), CLIs (`uv tool`), pip-shim (`uv pip`)
 
 # Editor — neovim IDE (LazyVim)
 brew "neovim"

--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ operational checklist.
    clone this repo to `$PROJECTS_HOME/dotfiles`.
 3. Install brew packages: `brew bundle --file=$PROJECTS_HOME/dotfiles/Brewfile`.
 4. Run the symlinker: `$PROJECTS_HOME/dotfiles/bootstrap.sh` (idempotent;
-   safe to re-run).
+   safe to re-run). Also installs uv-managed CPython 3.13 as the global
+   `python3` (`~/.local/bin/python3`); Apple's stays at `/usr/bin/python3`
+   for system use.
 5. Apply the **manual extras** below — `bootstrap.sh` cannot automate these.
 6. Open tmux and press `<prefix> I` (capital I, prefix = `C-a`) to install
    TPM plugins.

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -168,6 +168,15 @@ fi
 link "mise.global.toml" "$HOME/.config/mise/config.toml"
 mise install
 
+# --- uv-managed Python (global default)
+# `--default` drops python/python3/python3.13 symlinks into ~/.local/bin
+# so bare `python3` resolves to a current interpreter (Apple's 3.9.6 is
+# EOL Oct 2025). Idempotent: re-running is a no-op once installed.
+# `--preview-features python-install-default` silences uv's "experimental"
+# warning on the --default flag (uv 0.11.x). Drop the flag once Astral
+# graduates --default out of preview.
+uv python install 3.13 --default --preview-features python-install-default
+
 # --- nvim
 # ~/.config/nvim/ is a real dir; tracked entries are individually symlinked.
 # LazyVim's lazy/, mason/, site/, lazyvim.json stay outside the repo.


### PR DESCRIPTION
## 📋 Summary

Closes #164. Applies the user-global "Python → uv" rule end-to-end on this machine and locks it in via the dotfiles repo. Original issue scope was cleanup-only; brainstorming expanded it once it became clear that without a uv-managed `python3` on PATH the bare command falls through to Apple's 3.9.6 (EOL Oct 2025).

- 🍺 **Cleanup**: `brew cleanup` swept the orphan `/opt/homebrew/opt/{python@3,python-certifi}` aliases (Cellar formulae were already gone — the issue's audit was stale).
- 🐍 **Forward path**: `bootstrap.sh` now runs `uv python install 3.13 --default` after `mise install`, dropping `python` / `python3` / `python3.13` symlinks into `~/.local/bin`. Idempotent (`--preview-features python-install-default` silences uv's experimental warning).
- 🛤️ **PATH-ordering fix**: `fish_add_path -gP` was a no-op when the path was already in `$PATH` (added earlier by macOS's `path_helper`), leaving `~/.local/bin` at PATH position 21 — *after* `/usr/bin`. The `-m` (move) flag forces it to the front so the new `python3` symlink isn't shadowed.
- 📚 **Docs**: `.claude/CLAUDE.md` Python rule expanded to record the three new conventions (`--default`, Apple's interpreter is system-only, no system `pip`); two matching anti-patterns added. `Brewfile` comment + `README.md` Setup item 4 updated to match.

## 🔗 Refs

- Issue: #164
- Spec: `.superpowers/specs/2026-05-08-python-cleanup-and-uv-default-design.md` (gitignored)
- Plan: `.superpowers/plans/2026-05-08-python-cleanup-and-uv-default-plan.md` (gitignored)

## ✅ Acceptance evidence

**Original issue criteria:**

- ✅ `brew list --formula | grep -E '^python'` — empty
- ✅ `ls /opt/homebrew/opt | grep -i python` — empty
- ✅ `which python3` resolves; `python3 -V` works
- ✅ `uv --version` works (`uv 0.11.11`); `uv tool list` returns `No tools installed`
- ✅ `brew bundle check --file=Brewfile --verbose` — "The Brewfile's dependencies are satisfied."

**New criteria (uv-default + PATH fix):**

- ✅ `~/.local/bin/{python,python3,python3.13}` all symlink into `~/.local/share/uv/python/cpython-3.13-…/bin/`
- ✅ `/usr/bin/python3 --version` → `Python 3.9.6` (Apple's, untouched)
- ✅ Simulated post-merge fish: `which python3` → `~/.local/bin/python3`, `python3 -V` → `Python 3.13.13`, `~/.local/bin` PATH position 4 (≤ 4 required)
- ✅ Idempotent: re-running `bootstrap.sh` reports `Python 3.13 is already installed` and exits 0; all symlinks ✅

**Live-shell caveat:** `which python3` from the live shell still returns `/usr/bin/python3` because `~/.config/fish/conf.d/00-env.fish` symlinks to the *primary* checkout (where this PR's PATH fix isn't merged yet). Once this PR merges to `main`, the live shell flips automatically — no manual re-bootstrap needed (the symlink already points at the right file; the file's content updates).

## 🧪 Test plan

- [ ] `scripts/test-fish-loads.sh` — ✅ already passes locally
- [ ] `scripts/test-helpers.sh` — ✅ 29/29 passing locally
- [ ] After merge: open a fresh fish shell, confirm `which python3` → `~/.local/bin/python3`
- [ ] After merge: confirm `python3 -V` → `Python 3.13.13`
- [ ] After merge: confirm `/usr/bin/python3 --version` still works (Apple's, untouched)
- [ ] After merge on a fresh machine: `bootstrap.sh` installs Python 3.13 from scratch in one shot

## ⚠️ Risk notes

- **PATH precedence change.** After merge, every binary in `~/.local/bin` shadows `/usr/bin` and `/opt/homebrew/bin`. Walked the directory contents during brainstorming — only `s` and `dashboard` are user scripts there, neither collides with a system binary. No regression expected.
- **`uv python install --default` is experimental.** The flag works (uv 0.11.x) but is gated behind `--preview-features python-install-default` to silence the warning. If Astral renames or splits the flag in a future uv version, the symptom is `bootstrap.sh` succeeding but `which python3` regressing — comment in `bootstrap.sh` flags this for future-self.
- **No CLAUDE.md changes were planned originally.** The issue explicitly said "No CLAUDE.md changes — the rule is already documented." That assumption held for cleanup-only scope; once `--default` joined the work, the rule needed to name the mechanism. Documented in the spec's "Goal" section.