### PR TITLE
📦 Brewfile: declare tealdeer

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -43,6 +43,7 @@ brew "procs"                    # modern ps replacement (Rust)
 brew "xh"                       # modern HTTP client (HTTPie-compatible CLI, Solarized-aware)
 brew "lnav"                     # TUI log file navigator
 brew "fish"                     # primary interactive shell
+brew "tealdeer"                 # `tldr` — community-driven command examples (Rust, fast)
 
 # Code search & refactoring
 brew "ast-grep"                 # structural code search/rewrite (AST patterns, multi-language)


### PR DESCRIPTION
## 📋 Summary

- ➕ Adds `brew \"tealdeer\"` to `Brewfile` — the Rust `tldr` client was installed manually on 2026-05-07 but never declared, so `brew bundle` on a fresh machine would skip it.
- 📍 Slotted into the user-facing CLI block (next to `lnav`, `fish`) rather than Core, since it's invoked directly at the prompt.

## 🧪 Test plan

- [x] ✅ `brew bundle check --file=Brewfile --verbose` → *The Brewfile's dependencies are satisfied.*