### PR TITLE
🐟 fish: convert completions/ to mixed-dir

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,12 +19,16 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + fi
   bundle` runs before `bootstrap.sh`. Don't reintroduce bash-3 shims.
 - **Fish module layout.** Fish is the primary interactive shell. Config
   in `.config/fish/`. `~/.config/fish/` is a real dir (mixed-dir pattern):
-  `config.fish`, `completions/`, `functions/` are symlinked from the
-  repo; `conf.d/` is itself a real dir with per-file symlinks for the
-  tracked `*.fish` modules and **real files** for `15-local.fish` +
-  `99-secrets.fish` (seeded from `.template` companions on first
-  bootstrap, untouched after). `fish_variables`, `fish_history`,
-  `generated_completions/` are real and stay outside the repo.
+  `config.fish` and `functions/` are symlinked from the repo. `conf.d/`
+  is itself a real dir with per-file symlinks for the tracked `*.fish`
+  modules and **real files** for `15-local.fish` + `99-secrets.fish`
+  (seeded from `.template` companions on first bootstrap, untouched
+  after). `completions/` is also a real dir: tracked `s.fish` and
+  `wt.fish` are symlinked from the repo, and machine-specific
+  completions (fish's man-page auto-generation, OrbStack's `kubectl`/
+  `orbctl`, etc.) live as real files alongside, never entering the
+  repo. `fish_variables`, `fish_history`, `generated_completions/` are
+  real and stay outside the repo.
   `config.fish` is empty; concerns in `conf.d/<NN>-<concern>.fish`,
   numeric prefix pins load order:
   `00-env`, `10-colors`, `15-local` (per-machine, untracked), `20-mise`,

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -197,8 +197,44 @@ link ".config/starship.toml" "$HOME/.config/starship.toml"
 # --- fish (only interactive shell)
 # ~/.config/fish/ is a real dir; tracked entries are individually symlinked.
 # 15-local.fish + 99-secrets.fish + fish runtime state stay outside the repo.
+# completions/ is also a real dir — installers (e.g. OrbStack) and fish's
+# own man-page auto-generation drop machine-specific completions there;
+# only the tracked entries (s.fish, wt.fish) come from the repo.
+
+# Migration: while ~/.config/fish/completions is still the legacy whole-dir
+# symlink into the repo, untracked completions live physically in the repo
+# working tree. Stash them to a temp dir, flip the symlink to a real dir,
+# move them back. Drops *.barnybug-backup-* (OrbStack installer cruft).
+COMPLETIONS_HOME="$HOME/.config/fish/completions"
+if [ -L "$COMPLETIONS_HOME" ]; then
+  STASH=$(mktemp -d)
+  while IFS= read -r rel; do
+    [ -n "$rel" ] || continue
+    name="$(basename "$rel")"
+    case "$name" in
+      *.barnybug-backup-*)
+        rm -f "$DOTFILES/$rel"
+        echo "🗑️  $rel (installer backup)"
+        continue
+        ;;
+    esac
+    mv "$DOTFILES/$rel" "$STASH/$name"
+  done < <(git -C "$DOTFILES" ls-files --others --exclude-standard \
+                 ".config/fish/completions/")
+  rm "$COMPLETIONS_HOME"
+  mkdir -p "$COMPLETIONS_HOME"
+  for f in "$STASH"/*; do
+    [ -e "$f" ] || continue
+    mv "$f" "$COMPLETIONS_HOME/$(basename "$f")"
+    echo "🚚  $(basename "$f") → $COMPLETIONS_HOME/"
+  done
+  rmdir "$STASH" 2>/dev/null || true
+fi
+unset COMPLETIONS_HOME
+
 prepare_real_dir "$HOME/.config/fish"
 prepare_real_dir "$HOME/.config/fish/conf.d"
+prepare_real_dir "$HOME/.config/fish/completions"
 for f in 15-local.fish 99-secrets.fish; do
   rescue_in_repo "$DOTFILES/.config/fish/conf.d/$f" \
                  "$HOME/.config/fish/conf.d/$f"
@@ -206,8 +242,9 @@ done
 for f in fish_variables fish_history generated_completions; do
   rescue_in_repo "$DOTFILES/.config/fish/$f" "$HOME/.config/fish/$f"
 done
-link_tracked_entries ".config/fish"        "$HOME/.config/fish"
-link_tracked_entries ".config/fish/conf.d" "$HOME/.config/fish/conf.d"
+link_tracked_entries ".config/fish"             "$HOME/.config/fish"
+link_tracked_entries ".config/fish/conf.d"      "$HOME/.config/fish/conf.d"
+link_tracked_entries ".config/fish/completions" "$HOME/.config/fish/completions"
 seed_local ".config/fish/conf.d/15-local.fish.template" \
            "$HOME/.config/fish/conf.d/15-local.fish"
 seed_local ".config/fish/conf.d/99-secrets.fish.template" \


### PR DESCRIPTION
## 🎯 Summary

- 🪲 `~/.config/fish/completions/` was a whole-dir symlink into the repo. OrbStack's brew install (and fish's own man-page auto-generation for `docker`/`docker-compose`) drops files there — so installer cruft kept showing up as untracked files in the repo working tree.
- 🩹 Convert `completions/` to the mixed-dir pattern already used for `conf.d/`, `nvim/`, `lnav/`, `worktrunk/`, `sesh/`. Only the tracked `s.fish` and `wt.fish` are symlinked from the repo; machine-specific completions live as real files (or symlinks into `/Applications/OrbStack.app/...`) alongside.
- 🧹 `bootstrap.sh` migration: while the legacy whole-dir symlink is still in place, stash untracked completions to a temp dir, flip to a real dir, move them back. Explicitly drops `*.barnybug-backup-*` (OrbStack installer cruft from when it detects an existing `docker.fish`).
- 📚 `CLAUDE.md` updated to describe the new layout.

## 🧪 Test plan

- ✅ `scripts/test-fish-loads.sh` passes
- ✅ `fish -c 'complete -C "docker "'` returns docker subcommands → autoload from the new real dir works
- ✅ `git status` clean after migration on a machine that had OrbStack pollution
- 🔁 Re-running `bootstrap.sh` is a no-op (the migration block is gated on `[ -L "$COMPLETIONS_HOME" ]`)
- ➕ New machines: bootstrap creates `~/.config/fish/completions/` as a real dir from scratch, no migration path needed

## 🔄 Affected files

- 📜 `bootstrap.sh` — migration block + `prepare_real_dir` / `link_tracked_entries` for `completions/`
- 📚 `CLAUDE.md` — fish module layout description updated