### PR TITLE
🔒 worktrunk: auto-trust mise on new worktrees

### DIFF
--- a/.config/worktrunk/config.toml
+++ b/.config/worktrunk/config.toml
@@ -252,6 +252,7 @@ worktree-path = "{{ repo_path }}/.claude/worktrees/{{ branch | sanitize }}"
 # other gitignored paths automatically — no per-path hooks needed.
 [post-start]
 copy = "wt step copy-ignored"
+trust-mise = "mise trust --yes 2>/dev/null || true"
 
 # Before wt remove deletes a worktree, save any new gitignored
 # content (planning artefacts under .superpowers/, autonomo logs


### PR DESCRIPTION
## ✨ Summary

- Add a `trust-mise` step to worktrunk's `[post-start]` hook that runs `mise trust --yes` in every newly created worktree.
- Errors and stderr are swallowed (`2>/dev/null || true`) so the hook is a no-op when mise isn't installed or there's no config to trust.

## 🤔 Why

New worktrees pick up the project's mise config (either tracked or carried in via `copy-ignored`), but mise treats every fresh path as untrusted and refuses to activate until the user runs `mise trust`. That meant every new worktree greeted me with a trust prompt before anything mise-managed worked. Auto-trusting on creation removes the friction without weakening anything — the worktree is a checkout of a repo I already own.

## ✅ Test plan

- [ ] `wt switch --create test-mise-trust` against a repo with `mise.toml` and confirm mise activates without a trust prompt
- [ ] `wt switch --create test-no-mise` against a repo without mise config and confirm post-start still succeeds (no spurious error)
- [ ] `wt remove` the test worktrees afterwards