### PR TITLE
 tmux: add Claude usage status pins (5h + 7d)

### DIFF
--- a/.config/tmux/bin/tmux-claude-usage
+++ b/.config/tmux/bin/tmux-claude-usage
@@ -9,6 +9,34 @@
 # Called from tmux.conf via #(...) on the 5s status-interval. Bench:
 # ccpulse json round-trip is ~33ms; no bash-level cache needed.
 
+# Function definitions live above the runtime block so the test suite
+# can `source` this script and call format_reset directly without
+# triggering the full ccpulse pipeline.
+format_reset() {
+  local m=$1
+  if [ "$m" -eq 0 ]; then
+    printf 'now'
+  elif [ "$m" -lt 60 ]; then
+    printf '%dm' "$m"
+  elif [ "$m" -lt 1440 ]; then
+    local h=$((m / 60))
+    local mm=$((m % 60))
+    if [ "$mm" -eq 0 ]; then
+      printf '%dh' "$h"
+    else
+      printf '%dh%dm' "$h" "$mm"
+    fi
+  else
+    local d=$((m / 1440))
+    local h=$(( (m % 1440) / 60 ))
+    printf '%dd %dh' "$d" "$h"
+  fi
+}
+
+# When sourced for testing, return early without running the chip
+# pipeline.
+[ "${TMUX_CLAUDE_USAGE_NO_RUN:-}" = "1" ] && return 0 2>/dev/null
+
 set -e
 
 # Hide if ccpulse is not on PATH.

--- a/.config/tmux/bin/tmux-claude-usage
+++ b/.config/tmux/bin/tmux-claude-usage
@@ -61,3 +61,22 @@ read -r pct_5h mins_5h pct_7d resets_7d < <(printf '%s' "$json" | jq -r '
 [ -z "${mins_5h:-}" ]   && exit 0
 [ -z "${pct_7d:-}" ]    && exit 0
 [ -z "${resets_7d:-}" ] && exit 0
+
+# Compute minutes-until-reset for the 7d window from the ISO timestamp.
+# resets_at is RFC3339 with fractional seconds (e.g. "...032404Z");
+# strip from the first '.' because BSD `date -j` does not understand
+# %N. UTC wall clock is used regardless of $TZ.
+resets_short="${resets_7d%.*}"
+# Drop the trailing 'Z' if present (the format string below covers
+# the literal time-portion only).
+resets_short="${resets_short%Z}"
+
+resets_epoch=$(TZ=UTC date -j -f '%Y-%m-%dT%H:%M:%S' \
+                  "$resets_short" '+%s' 2>/dev/null) || exit 0
+now_epoch=$(date '+%s')
+mins_7d=$(( (resets_epoch - now_epoch) / 60 ))
+[ "$mins_7d" -lt 0 ] && mins_7d=0
+
+# Format both reset strings via the formatter from Task 4.
+reset_5h=$(format_reset "$mins_5h")
+reset_7d=$(format_reset "$mins_7d")

--- a/.config/tmux/bin/tmux-claude-usage
+++ b/.config/tmux/bin/tmux-claude-usage
@@ -18,4 +18,18 @@ command -v ccpulse >/dev/null 2>&1 || exit 0
 json=$(ccpulse status --json 2>/dev/null) || exit 0
 [ -z "$json" ] && exit 0
 
-# (Parsing & rendering added in subsequent tasks.)
+# Parse the four required fields with jq. Any null/missing field -> empty
+# string here, then we abort. Atomic: both chips render or neither.
+read -r pct_5h mins_5h pct_7d resets_7d < <(printf '%s' "$json" | jq -r '
+  [
+    (.percent                       // empty),
+    (.minutes_to_reset              // empty),
+    (.quota.seven_day.utilization   // empty),
+    (.quota.seven_day.resets_at     // empty)
+  ] | @tsv
+') || exit 0
+
+[ -z "${pct_5h:-}" ]    && exit 0
+[ -z "${mins_5h:-}" ]   && exit 0
+[ -z "${pct_7d:-}" ]    && exit 0
+[ -z "${resets_7d:-}" ] && exit 0

--- a/.config/tmux/bin/tmux-claude-usage
+++ b/.config/tmux/bin/tmux-claude-usage
@@ -80,3 +80,44 @@ mins_7d=$(( (resets_epoch - now_epoch) / 60 ))
 # Format both reset strings via the formatter from Task 4.
 reset_5h=$(format_reset "$mins_5h")
 reset_7d=$(format_reset "$mins_7d")
+
+# ── Chip rendering ──────────────────────────
+# Solarized base16 hexes, kept inline here (matches existing helpers'
+# style — no shared color file).
+bar_bg='#073642'
+violet='#6c71c4'   # 5h chip bg (matches main-checkout git chip)
+yellow='#b58900'   # 7d chip bg (matches worktree git chip)
+fg_violet='#fdf6e3'
+fg_yellow='#073642'
+
+# Glyphs as raw UTF-8 byte sequences (editor-independent literal).
+tri_l=$(printf '\xee\x82\xb6')      # U+E0B6 left rounded cap (filled)
+tri_r=$(printf '\xee\x82\xb4')      # U+E0B4 right rounded cap (filled)
+hourglass=$(printf '\xef\x89\x92')  # U+F252 nf-fa-hourglass-half
+calendar=$(printf '\xef\x91\x95')   # U+F455 nf-oct-calendar
+
+# 7d auto-expand threshold (inclusive — pct == 80 expands).
+threshold=80
+
+# 5h chip body: always full.
+body_5h=$(printf '%s %d%% • %s' "$hourglass" "$pct_5h" "$reset_5h")
+
+# 7d chip body: compact by default; expanded with reset when pct >= threshold.
+if [ "$pct_7d" -ge "$threshold" ]; then
+  body_7d=$(printf '%s %d%% • %s' "$calendar" "$pct_7d" "$reset_7d")
+else
+  body_7d=$(printf '%s %d%%' "$calendar" "$pct_7d")
+fi
+
+# Render: 5h chip (left cap on bar bg, body, no right cap — fuses into 7d).
+printf '#[fg=%s,bg=%s]%s#[fg=%s,bg=%s,bold] %s ' \
+  "$violet" "$bar_bg" "$tri_l" \
+  "$fg_violet" "$violet" \
+  "$body_5h"
+
+# 7d chip (left cap fuses on violet, body, right cap on bar bg closes the cluster).
+printf '#[fg=%s,bg=%s]%s#[fg=%s,bg=%s,bold] %s #[fg=%s,bg=%s]%s' \
+  "$yellow" "$violet" "$tri_l" \
+  "$fg_yellow" "$yellow" \
+  "$body_7d" \
+  "$yellow" "$bar_bg" "$tri_r"

--- a/.config/tmux/bin/tmux-claude-usage
+++ b/.config/tmux/bin/tmux-claude-usage
@@ -1,0 +1,21 @@
+#!/opt/homebrew/bin/bash
+# Renders two left-cluster tmux chips for Claude Code usage:
+#   - 5h block chip  (violet, always full body)
+#   - 7d weekly chip (yellow, compact body, auto-expands when pct >= 80)
+# Source: `ccpulse status --json`. Helper hides (empty output, exit 0)
+# whenever any required field is missing or ccpulse is unreachable —
+# both chips appear or neither.
+#
+# Called from tmux.conf via #(...) on the 5s status-interval. Bench:
+# ccpulse json round-trip is ~33ms; no bash-level cache needed.
+
+set -e
+
+# Hide if ccpulse is not on PATH.
+command -v ccpulse >/dev/null 2>&1 || exit 0
+
+# Capture ccpulse output. Non-zero exit -> hide.
+json=$(ccpulse status --json 2>/dev/null) || exit 0
+[ -z "$json" ] && exit 0
+
+# (Parsing & rendering added in subsequent tasks.)

--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -157,9 +157,14 @@ set -g status-style "bg=#073642,fg=#839496"
 # remaining gap and — given asymmetric content — sit visually off-center.
 set -g status-justify absolute-centre
 
-# Left: session name on a blue chip; gains a leading globe glyph when any attached tmux client is SSH-rooted (drives tmux-ssh-indicator).
-set -g status-left "#[fg=#fdf6e3,bg=#268bd2,bold]  #(~/.config/tmux/bin/tmux-ssh-indicator)#S #[fg=#268bd2,bg=#073642] "
-set -g status-left-length 80
+# Left: session chip + the Claude-usage cluster.
+#   - Session: name on a blue chip; gains a leading globe glyph when any
+#     attached tmux client is SSH-rooted (drives tmux-ssh-indicator).
+#   - Claude usage: violet 5h chip + yellow 7d chip pair, fused. Drives
+#     tmux-claude-usage (parses ccpulse status --json on each tick).
+#     Hides cleanly when ccpulse is missing or the JSON lacks fields.
+set -g status-left "#[fg=#fdf6e3,bg=#268bd2,bold]  #(~/.config/tmux/bin/tmux-ssh-indicator)#S #[fg=#268bd2,bg=#073642] #(~/.config/tmux/bin/tmux-claude-usage)"
+set -g status-left-length 120
 
 # Windows
 setw -g window-status-format         "#[fg=#586e75,bg=#073642] #I:#W "

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,11 +54,17 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + fi
   Solarized base16. No theme plugins (catppuccin, tmux-powerline, etc.).
   Each status-bar **pin** uses a unique Solarized accent. Currently:
   blue (session chip, left), green (active window pin, center), violet
-  (main-checkout git chip), yellow (worktree git chip), orange (PR pin,
-  left of git chip). When adding a pin, pick from unused accents (red,
-  magenta, cyan); reconsider if all are taken. Mode-style, message-style,
-  pane-borders, and inline text colors (e.g. ins/del markers in
-  `tmux-git-status`) are not pins.
+  (main-checkout git chip + 5h Claude-usage chip — paired by intent),
+  yellow (worktree git chip + 7d Claude-usage chip — paired by intent),
+  orange (PR pin, left of git chip). When adding a pin, pick from
+  unused accents (red, magenta, cyan); reconsider if all are taken.
+  **Paired left/right reuse is permitted when the pairing is
+  intentional and semantic** — violet on the 5h-usage chip rhymes with
+  violet on the main-checkout git chip; yellow on the 7d-usage chip
+  rhymes with yellow on the worktree git chip. Two violets or two
+  yellows visible simultaneously is the by-design behavior, not a
+  clash. Mode-style, message-style, pane-borders, and inline text
+  colors (e.g. ins/del markers in `tmux-git-status`) are not pins.
 - **SSH indicator on the session chip** via
   `#(~/.config/tmux/bin/tmux-ssh-indicator)`. Walks each attached
   client's parent-process chain via `ps -p <pid> -o ppid=,ucomm=`,
@@ -79,6 +85,19 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + fi
   `git-common-dir` so worktrees share per-branch entries. First call
   after branch switch shows nothing; next 5 s tick renders — accepted
   to never block on a slow `gh`.
+- **tmux Claude usage cluster** wired into `status-left` via
+  `#(~/.config/tmux/bin/tmux-claude-usage)`. Parses
+  `ccpulse status --json` on each 5 s tick (~33 ms; no bash-level
+  cache) and emits two fused chips: violet 5h block (`<hourglass>
+  <pct>% • <reset>`, always full) + yellow 7d weekly (`<calendar>
+  <pct>%`, auto-expands to `<calendar> <pct>% • <reset>` when
+  `pct >= 80`). Glyphs `nf-fa-hourglass-half` (U+F252) and
+  `nf-oct-calendar` (U+F455). Atomic: when `ccpulse` is missing on
+  PATH, exits non-zero, or any required JSON field is null, the whole
+  pair hides — no half-rendered chip. `status-left-length` bumped
+  80 → 120 to fit. Visual identity is intentionally paired with the
+  right-side git chips (violet ↔ main checkout, yellow ↔ worktree) —
+  see the carve-out in the unique-accent rule.
 - **tmux prefix is `C-a`** (`C-Space` conflicts with macOS input-source
   switching). Pane nav: `<prefix> h/j/k/l` (Alt is reserved for Polish
   diacritics — never `bind -n M-*`). Splits: `|` and `-`.
@@ -350,6 +369,7 @@ is `nvim-cheatsheet.html`).
 - Claude tmux window-name: `scripts/test-claude-tmux-window-name.sh`
 - tmux SSH-indicator: `scripts/test-tmux-ssh-indicator.sh`
 - tmux PR-pin: `scripts/test-tmux-pr-status.sh`
+- tmux Claude usage: `scripts/test-tmux-claude-usage.sh`
 - Session-root binding: `scripts/test-s-session-root.sh`
 - Dashboard smoke + integration: `scripts/test-dashboard.sh`
 - Fish config smoke: `scripts/test-fish-loads.sh`

--- a/docs/tmux-cheatsheet.html
+++ b/docs/tmux-cheatsheet.html
@@ -310,7 +310,7 @@
     <h3>Layout</h3>
     <p>Bottom bar, <code>bg=base02</code> / <code>fg=base0</code>. Three segments:</p>
     <ul class="compact">
-      <li><strong>Left:</strong> session name on a blue chip with a powerline arrow. Gains a leading globe glyph (<code></code> <code>nf-fa-globe</code>) when any attached tmux client is SSH-rooted (drives <code>tmux-ssh-indicator</code>).</li>
+      <li><strong>Left:</strong> session name on a blue chip with a powerline arrow (gains a leading globe glyph <code></code> <code>nf-fa-globe</code> when any attached tmux client is SSH-rooted — drives <code>tmux-ssh-indicator</code>), followed by the Claude-usage cluster: violet 5h chip (<code></code> <code>nf-fa-hourglass-half</code>, always shows <code>&lt;pct&gt;% • &lt;reset&gt;</code>) fused with the yellow 7d chip (<code></code> <code>nf-oct-calendar</code>, compact <code>&lt;pct&gt;%</code> that auto-expands to add <code>• &lt;reset&gt;</code> at <code>pct ≥ 80</code>). Whole pair hides cleanly when <code>ccpulse</code> is missing. Drives <code>tmux-claude-usage</code>.</li>
       <li><strong>Center (absolute-centered on the full bar):</strong> windows. Inactive = <code>base01</code> on <code>base02</code>; active = <code>green</code>-on-<code>base3</code> chip with rounded powerline caps.</li>
       <li><strong>Right:</strong> orange PR pin (when the current branch has an open/draft PR) glued to the branch chip via a rounded yellow-on-orange separator. Branch chip is violet for main checkout, yellow for worktree, always flush-right (no closing cap — mirrors the session chip's flush-left anchor). Drives <code>tmux-status-right</code> → <code>tmux-pr-detect</code> + <code>tmux-git-status</code>.</li>
     </ul>
@@ -346,8 +346,10 @@
       <tr><td class="key"><code>~/.config/tmux/bin/tmux-git-status</code></td><td class="desc">git/worktree status segment, colors as args</td></tr>
       <tr><td class="key"><code>~/.config/tmux/bin/claude-tmux-window-name</code></td><td class="desc">sets/clears <code>@claude_session_name</code> from Claude Code hooks (drives <code>claude[&lt;name&gt;]</code> window title)</td></tr>
       <tr><td class="key"><code>~/.config/tmux/bin/tmux-ssh-indicator</code></td><td class="desc">walks each attached client's <code>ps</code> ancestry; prints <code></code> + space when any ancestor is <code>sshd</code>/<code>sshd-session</code> — prepended inside the session chip</td></tr>
+      <tr><td class="key"><code>~/.config/tmux/bin/tmux-claude-usage</code></td><td class="desc">parses <code>ccpulse status --json</code> and emits the violet 5h + yellow 7d fused chip pair on the left of the status bar; atomic hide when <code>ccpulse</code> is missing or fields are null</td></tr>
       <tr><td class="key"><code>scripts/test-helpers.sh</code></td><td class="desc">smoke-tests for the helpers</td></tr>
       <tr><td class="key"><code>scripts/test-tmux-pr-status.sh</code></td><td class="desc">smoke tests for <code>tmux-pr-detect</code> + <code>tmux-status-right</code> (uses a PATH-shimmed <code>gh</code>)</td></tr>
+      <tr><td class="key"><code>scripts/test-tmux-claude-usage.sh</code></td><td class="desc">smoke tests for <code>tmux-claude-usage</code> (PATH-shimmed <code>ccpulse</code> stub; covers hide cases, formatter, threshold boundaries)</td></tr>
     </table>
     <p class="note">Worktree detection uses <code>git rev-parse --git-dir</code> vs <code>--git-common-dir</code> so it works for <code>.claude/worktrees/*</code>, worktrunk paths, and sibling worktrees alike.</p>
   </div>
@@ -421,7 +423,7 @@
 </table>
 
 <footer>
-  Built from <code>~/.config/tmux/tmux.conf</code> on 2026-05-07. Refresh after meaningful config changes.
+  Built from <code>~/.config/tmux/tmux.conf</code> on 2026-05-09. Refresh after meaningful config changes.
   <br>
   When in doubt: <span class="k prefix">C-a</span> <span class="k">?</span> for the live keymap list.
 </footer>

--- a/scripts/test-tmux-claude-usage.sh
+++ b/scripts/test-tmux-claude-usage.sh
@@ -154,6 +154,49 @@ got=$(run_helper)
 assert_eq "$?" "0" "resets_at in past does not abort the helper"
 teardown_sandbox
 
+# Case: happy path, both pcts low. 5h shows pct + reset; 7d shows
+# pct only (compact). Verify each visible substring.
+setup_sandbox
+# Use a future-far seven_day reset (large minutes_until value) so that
+# format_reset returns a multi-day string we can spot-check.
+cat > "$TEST_BIN/ccpulse" <<'STUB'
+#!/opt/homebrew/bin/bash
+cat <<'JSON'
+{"percent":8,"minutes_to_reset":217,"quota":{"five_hour":{"utilization":8,"resets_at":"2026-05-09T21:10:00Z"},"seven_day":{"utilization":21,"resets_at":"2099-12-31T00:00:00Z"}}}
+JSON
+STUB
+chmod +x "$TEST_BIN/ccpulse"
+got=$(run_helper)
+
+assert_contains "$got" "#[fg=#6c71c4,bg=#073642]" "5h chip uses violet on bar bg"
+assert_contains "$got" "#[fg=#fdf6e3,bg=#6c71c4,bold]" "5h chip body uses base3-on-violet bold"
+assert_contains "$got" "8%"                            "5h pct visible"
+assert_contains "$got" "3h37m"                         "5h reset visible"
+assert_contains "$got" "#[fg=#b58900,bg=#6c71c4]"      "7d chip cap fuses yellow on violet"
+assert_contains "$got" "#[fg=#073642,bg=#b58900,bold]" "7d chip body uses base02-on-yellow bold"
+assert_contains "$got" "21%"                            "7d pct visible"
+assert_not_contains "$got" "21% • "                     "7d compact: no • reset suffix when low"
+# Bolt for 5h, calendar (oct) for 7d — UTF-8 byte sequences as in helper.
+assert_contains "$got" $'\xef\x89\x92'                  "5h hourglass glyph (U+F252)"
+assert_contains "$got" $'\xef\x91\x95'                  "7d calendar glyph (U+F455)"
+# Powerline rounded caps: left U+E0B6, right U+E0B4.
+assert_contains "$got" $'\xee\x82\xb6'                  "left rounded cap"
+assert_contains "$got" $'\xee\x82\xb4'                  "right rounded cap (closes 7d)"
+teardown_sandbox
+
+# Carryover: past resets_at + low 7d pct -> compact body still renders pct.
+setup_sandbox
+cat > "$TEST_BIN/ccpulse" <<'STUB'
+#!/opt/homebrew/bin/bash
+cat <<'JSON'
+{"percent":6,"minutes_to_reset":237,"quota":{"five_hour":{"utilization":6,"resets_at":"2026-05-09T21:10:00Z"},"seven_day":{"utilization":21,"resets_at":"2020-01-01T00:00:00Z"}}}
+JSON
+STUB
+chmod +x "$TEST_BIN/ccpulse"
+got=$(run_helper)
+assert_contains "$got" "21%" "past resets_at: helper renders normally (compact)"
+teardown_sandbox
+
 # ─── Summary ────────────────────────────────
 echo
 echo "─────────────────"

--- a/scripts/test-tmux-claude-usage.sh
+++ b/scripts/test-tmux-claude-usage.sh
@@ -197,6 +197,60 @@ got=$(run_helper)
 assert_contains "$got" "21%" "past resets_at: helper renders normally (compact)"
 teardown_sandbox
 
+# Case: 7d high (94%) -> expanded body with • <reset>.
+setup_sandbox
+cat > "$TEST_BIN/ccpulse" <<'STUB'
+#!/opt/homebrew/bin/bash
+cat <<'JSON'
+{"percent":8,"minutes_to_reset":217,"quota":{"five_hour":{"utilization":8,"resets_at":"2026-05-09T21:10:00Z"},"seven_day":{"utilization":94,"resets_at":"2099-12-31T00:00:00Z"}}}
+JSON
+STUB
+chmod +x "$TEST_BIN/ccpulse"
+got=$(run_helper)
+assert_contains "$got" "94%"        "7d high: pct visible"
+assert_contains "$got" "94% • "     "7d high: auto-expanded with • separator"
+teardown_sandbox
+
+# Case: 7d at exactly threshold (80) -> expanded (>= is the rule).
+setup_sandbox
+cat > "$TEST_BIN/ccpulse" <<'STUB'
+#!/opt/homebrew/bin/bash
+cat <<'JSON'
+{"percent":8,"minutes_to_reset":217,"quota":{"five_hour":{"utilization":8,"resets_at":"2026-05-09T21:10:00Z"},"seven_day":{"utilization":80,"resets_at":"2099-12-31T00:00:00Z"}}}
+JSON
+STUB
+chmod +x "$TEST_BIN/ccpulse"
+got=$(run_helper)
+assert_contains "$got" "80% • " "7d at boundary 80: auto-expanded (>= rule)"
+teardown_sandbox
+
+# Case: 7d just below threshold (79) -> compact (no • separator after pct).
+setup_sandbox
+cat > "$TEST_BIN/ccpulse" <<'STUB'
+#!/opt/homebrew/bin/bash
+cat <<'JSON'
+{"percent":8,"minutes_to_reset":217,"quota":{"five_hour":{"utilization":8,"resets_at":"2026-05-09T21:10:00Z"},"seven_day":{"utilization":79,"resets_at":"2099-12-31T00:00:00Z"}}}
+JSON
+STUB
+chmod +x "$TEST_BIN/ccpulse"
+got=$(run_helper)
+assert_contains      "$got" "79%"      "7d below boundary 79: pct visible"
+assert_not_contains  "$got" "79% • "   "7d below boundary 79: compact (no • separator)"
+teardown_sandbox
+
+# Case: resets_at in past + 7d high pct -> mins_7d=0 -> "now" in expanded body.
+setup_sandbox
+cat > "$TEST_BIN/ccpulse" <<'STUB'
+#!/opt/homebrew/bin/bash
+cat <<'JSON'
+{"percent":8,"minutes_to_reset":217,"quota":{"five_hour":{"utilization":8,"resets_at":"2026-05-09T21:10:00Z"},"seven_day":{"utilization":95,"resets_at":"2020-01-01T00:00:00Z"}}}
+JSON
+STUB
+chmod +x "$TEST_BIN/ccpulse"
+got=$(run_helper)
+assert_contains "$got" "95% • now" "past resets_at + high pct: clamps to 'now'"
+teardown_sandbox
+
 # ─── Summary ────────────────────────────────
 echo
 echo "─────────────────"

--- a/scripts/test-tmux-claude-usage.sh
+++ b/scripts/test-tmux-claude-usage.sh
@@ -122,6 +122,24 @@ got=$(run_helper)
 assert_eq "$got" "" "hides when top-level percent is missing"
 teardown_sandbox
 
+# Source the helper for direct function testing. The script normally
+# reaches `exit 0` immediately when ccpulse is missing — we set a guard
+# env var so the script defines functions and returns without rendering.
+TMUX_CLAUDE_USAGE_NO_RUN=1 source "$HELPER"
+
+assert_eq "$(format_reset 0)"     "now"     "format_reset(0)"
+assert_eq "$(format_reset 1)"     "1m"      "format_reset(1)"
+assert_eq "$(format_reset 37)"    "37m"     "format_reset(37)"
+assert_eq "$(format_reset 59)"    "59m"     "format_reset(59)"
+assert_eq "$(format_reset 60)"    "1h"      "format_reset(60) — minutes==0 case"
+assert_eq "$(format_reset 65)"    "1h5m"    "format_reset(65)"
+assert_eq "$(format_reset 217)"   "3h37m"   "format_reset(217)"
+assert_eq "$(format_reset 1439)"  "23h59m"  "format_reset(1439) — last sub-day value"
+assert_eq "$(format_reset 1440)"  "1d 0h"   "format_reset(1440) — exactly 24h"
+assert_eq "$(format_reset 5000)"  "3d 11h"  "format_reset(5000)"
+unset -f format_reset
+unset TMUX_CLAUDE_USAGE_NO_RUN
+
 # ─── Summary ────────────────────────────────
 echo
 echo "─────────────────"

--- a/scripts/test-tmux-claude-usage.sh
+++ b/scripts/test-tmux-claude-usage.sh
@@ -96,6 +96,32 @@ got=$(run_helper)
 assert_eq "$got" "" "hides when ccpulse exits non-zero"
 teardown_sandbox
 
+# Case: ccpulse JSON missing seven_day quota -> hide both chips
+setup_sandbox
+cat > "$TEST_BIN/ccpulse" <<'STUB'
+#!/opt/homebrew/bin/bash
+cat <<'JSON'
+{"percent":6,"minutes_to_reset":237,"quota":{"five_hour":{"utilization":6,"resets_at":"2026-05-09T21:10:00Z"},"seven_day":null}}
+JSON
+STUB
+chmod +x "$TEST_BIN/ccpulse"
+got=$(run_helper)
+assert_eq "$got" "" "hides when seven_day quota is null"
+teardown_sandbox
+
+# Case: ccpulse JSON missing top-level percent -> hide
+setup_sandbox
+cat > "$TEST_BIN/ccpulse" <<'STUB'
+#!/opt/homebrew/bin/bash
+cat <<'JSON'
+{"minutes_to_reset":237,"quota":{"seven_day":{"utilization":21,"resets_at":"2026-05-10T09:00:00Z"}}}
+JSON
+STUB
+chmod +x "$TEST_BIN/ccpulse"
+got=$(run_helper)
+assert_eq "$got" "" "hides when top-level percent is missing"
+teardown_sandbox
+
 # ─── Summary ────────────────────────────────
 echo
 echo "─────────────────"

--- a/scripts/test-tmux-claude-usage.sh
+++ b/scripts/test-tmux-claude-usage.sh
@@ -1,0 +1,90 @@
+#!/opt/homebrew/bin/bash
+# Smoke tests for tmux-claude-usage.
+#
+# Strategy: PATH-shim ccpulse with a stub that emits canned JSON
+# (or fails) and assert that the helper renders the chip pair we
+# expect (or hides cleanly).
+set -u
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HELPER="$REPO/.config/tmux/bin/tmux-claude-usage"
+
+pass=0
+fail=0
+fail_msgs=()
+
+assert_eq() {
+  local got="$1" want="$2" desc="$3"
+  if [ "$got" = "$want" ]; then
+    pass=$((pass+1))
+    echo "  PASS  $desc"
+  else
+    fail=$((fail+1))
+    fail_msgs+=("FAIL  $desc"$'\n'"        got:  '$got'"$'\n'"        want: '$want'")
+    echo "  FAIL  $desc"
+  fi
+}
+
+assert_contains() {
+  local got="$1" needle="$2" desc="$3"
+  if printf '%s' "$got" | grep -q -F -- "$needle"; then
+    pass=$((pass+1))
+    echo "  PASS  $desc"
+  else
+    fail=$((fail+1))
+    fail_msgs+=("FAIL  $desc"$'\n'"        got:  '$got'"$'\n'"        needle: '$needle'")
+    echo "  FAIL  $desc"
+  fi
+}
+
+assert_not_contains() {
+  local got="$1" needle="$2" desc="$3"
+  if printf '%s' "$got" | grep -q -F -- "$needle"; then
+    fail=$((fail+1))
+    fail_msgs+=("FAIL  $desc"$'\n'"        got: '$got'"$'\n'"        unwanted: '$needle'")
+    echo "  FAIL  $desc"
+  else
+    pass=$((pass+1))
+    echo "  PASS  $desc"
+  fi
+}
+
+# Build a sandbox: a bin/ holding a ccpulse stub. Caller writes the
+# desired stub body and exit code into $TEST_BIN/ccpulse before
+# running the helper with PATH=$TEST_BIN:$PATH.
+setup_sandbox() {
+  TEST_BIN=$(mktemp -d)
+}
+
+teardown_sandbox() {
+  [ -n "${TEST_BIN:-}" ] && rm -rf "$TEST_BIN"
+}
+
+# Run the helper with PATH-shimmed ccpulse. Emits stdout.
+run_helper() {
+  PATH="$TEST_BIN:$PATH" bash "$HELPER" 2>/dev/null
+}
+
+# ─── tmux-claude-usage: harness sanity ──────
+echo
+echo "tmux-claude-usage"
+echo "─────────────────"
+
+# Sanity: helper exists at expected path
+if [ -e "$HELPER" ]; then
+  pass=$((pass+1)); echo "  PASS  helper exists at $HELPER"
+else
+  fail=$((fail+1)); fail_msgs+=("FAIL  helper missing at $HELPER")
+  echo "  FAIL  helper missing at $HELPER"
+fi
+
+# ─── Summary ────────────────────────────────
+echo
+echo "─────────────────"
+echo "  Summary: $pass passed, $fail failed"
+if [ "$fail" -gt 0 ]; then
+  echo
+  for msg in "${fail_msgs[@]}"; do echo "$msg"; done
+  exit 1
+fi
+exit 0

--- a/scripts/test-tmux-claude-usage.sh
+++ b/scripts/test-tmux-claude-usage.sh
@@ -78,6 +78,24 @@ else
   echo "  FAIL  helper missing at $HELPER"
 fi
 
+# Case: ccpulse missing on PATH (TEST_BIN intentionally has nothing in it,
+# and PATH contains only TEST_BIN — so command -v ccpulse fails).
+setup_sandbox
+got=$(PATH="$TEST_BIN" bash "$HELPER" 2>/dev/null)
+assert_eq "$got" "" "hides when ccpulse is missing on PATH"
+teardown_sandbox
+
+# Case: ccpulse on PATH but exits non-zero
+setup_sandbox
+cat > "$TEST_BIN/ccpulse" <<'STUB'
+#!/opt/homebrew/bin/bash
+exit 1
+STUB
+chmod +x "$TEST_BIN/ccpulse"
+got=$(run_helper)
+assert_eq "$got" "" "hides when ccpulse exits non-zero"
+teardown_sandbox
+
 # ─── Summary ────────────────────────────────
 echo
 echo "─────────────────"

--- a/scripts/test-tmux-claude-usage.sh
+++ b/scripts/test-tmux-claude-usage.sh
@@ -140,6 +140,20 @@ assert_eq "$(format_reset 5000)"  "3d 11h"  "format_reset(5000)"
 unset -f format_reset
 unset TMUX_CLAUDE_USAGE_NO_RUN
 
+# Case: resets_at already past -> mins_7d clamps to 0; helper still runs
+# (positive output asserted in Task 6's "now" rendering test).
+setup_sandbox
+cat > "$TEST_BIN/ccpulse" <<'STUB'
+#!/opt/homebrew/bin/bash
+cat <<'JSON'
+{"percent":6,"minutes_to_reset":237,"quota":{"five_hour":{"utilization":6,"resets_at":"2026-05-09T21:10:00Z"},"seven_day":{"utilization":21,"resets_at":"2020-01-01T00:00:00Z"}}}
+JSON
+STUB
+chmod +x "$TEST_BIN/ccpulse"
+got=$(run_helper)
+assert_eq "$?" "0" "resets_at in past does not abort the helper"
+teardown_sandbox
+
 # ─── Summary ────────────────────────────────
 echo
 echo "─────────────────"


### PR DESCRIPTION
## ✨ Summary

- New left-cluster pins drive `~/.config/tmux/bin/tmux-claude-usage`, which parses `ccpulse status --json` (~33 ms) and emits a violet 5h chip (always shows `<pct>% • <reset>`) fused with a yellow 7d chip (compact `<pct>%`, auto-expands to add `• <reset>` at `pct ≥ 80`).
- 🚪 Atomic hide when `ccpulse` is missing on PATH, exits non-zero, or any required JSON field is null — the whole pair appears or neither chip does.
- 🎨 Color choice intentionally pairs the new chips with the right-side git chips: violet rhymes with the main-checkout chip; yellow rhymes with the worktree chip. CLAUDE.md's "unique accent per pin" rule gets a paired-reuse carve-out.

## 🧪 Test plan

- [x] `scripts/test-tmux-claude-usage.sh` — full smoke suite (35 cases): hide-on-failure, JSON parsing, `format_reset` buckets, resets_at parsing & clamping, happy path, threshold boundaries (79 / 80 / 94), clamp-to-now.
- [x] `scripts/test-helpers.sh`, `scripts/test-tmux-pr-status.sh`, `scripts/test-tmux-ssh-indicator.sh`, `scripts/test-fish-loads.sh` — no regressions.
- [ ] Reload tmux (`<prefix> r`) post-merge and visually confirm the chip pair appears on the left, fused, with correct glyphs and colors.
- [ ] Confirm the by-design color pairing in both states: main checkout (two violets) and worktree (two yellows).

## 📐 Risks & migrations

- 🎨 Visual reuse with `tmux-git-status` chips is by-design; documented in the rule carve-out.
- 🪟 `status-left-length` bumped 80 → 120; long session names previously near the cap could now interact with the new chip width — wide enough headroom in practice.
- 🚪 `ccpulse` is a soft dependency — missing binary just hides the chips, no error noise.

## 🧭 Files touched

- `.config/tmux/bin/tmux-claude-usage` (new helper)
- `scripts/test-tmux-claude-usage.sh` (new smoke test)
- `.config/tmux/tmux.conf` (status-left + length bump)
- `CLAUDE.md` (helper bullet, verify-changes entry, accent carve-out)
- `docs/tmux-cheatsheet.html` (layout bullet, helpers table, footer date)

## 📊 Session stats

| | |
|---|---|
| Start | 2026-05-09 17:11 UTC |
| End | 2026-05-09 18:19 UTC |
| Elapsed | 1h 8m |
| Working | 51m 49s (76% of elapsed) |
| Idle | 15m 11s |
| Total billed tokens | 44.7M |
| Total cost (public rates) | \$103.07 |
| Effective rate | \$119.35 / hr |

### Per-model breakdown

| Model | Messages | Input | Output | Cache Read | Cache Write 1h | Cost |
|---|---:|---:|---:|---:|---:|---:|
| Opus 4.7 (1M context) | 285 | 1.5k | 313k | 43.9M | 456k | \$103.07 |
| **Total** | **285** | **1.5k** | **313k** | **43.9M** | **456k** | **\$103.07** |

### Notes

- 💵 Cost is computed against public Anthropic API rates and is a relative guide, not an invoice — Claude Max bundles usage within plan limits.
- 📦 Cache reads dominate (43.9M of 44.7M total) because prompt caching re-uses the system prompt and prior turns at ~10% of base input price; that's normal.
- 🤖 Single-model session; no subagents fired.