### PR TITLE
🧹 ccstatusline: drop session-usage and reset-timer pins

### DIFF
--- a/.config/ccstatusline/settings.json
+++ b/.config/ccstatusline/settings.json
@@ -18,19 +18,6 @@
         "backgroundColor": "bgBrightBlue"
       },
       {
-        "id": "41900a0a-d664-4970-a166-bf3ff25c9ee2",
-        "type": "session-usage",
-        "backgroundColor": "bgBrightYellow",
-        "metadata": {
-          "display": "time"
-        }
-      },
-      {
-        "id": "28da2a14-b3e3-4f1f-8c6d-8b026332be14",
-        "type": "reset-timer",
-        "backgroundColor": "bgCyan"
-      },
-      {
         "id": "86948b16-e4c5-4e03-a960-1d78fcfca471",
         "type": "tokens-total",
         "backgroundColor": "bgRed"


### PR DESCRIPTION
## 📝 Summary
- 🗑️ Remove the `session-usage` (time display) and `reset-timer` items from the ccstatusline config.
- ✂️ Leaves `context-length` and `tokens-total` in place — trims visual noise on the status bar.

## 🧪 Test plan
- [ ] 🔁 Open a fresh Claude Code session and confirm the status line renders without the dropped pins and with no layout regressions on the remaining items.