### PR TITLE
Fix robot glyph and arrows in tmux Claude usage cluster

### DIFF
--- a/.config/tmux/bin/tmux-claude-usage
+++ b/.config/tmux/bin/tmux-claude-usage
@@ -95,7 +95,7 @@ fg_yellow='#073642'
 # Glyphs as raw UTF-8 byte sequences (editor-independent literal).
 tri_l=$(printf '\xee\x82\xb6')      # U+E0B6 left rounded cap (filled)
 tri_r=$(printf '\xee\x82\xb4')      # U+E0B4 right rounded cap (filled)
-robot=$(printf '\xef\x95\x84')     # U+F544 nf-fa-robot
+robot=$(printf '\xf0\x9f\xa4\x96')  # U+F1F96 robot emoji 🤖
 hourglass=$(printf '\xef\x89\x92')  # U+F252 nf-fa-hourglass-half
 calendar=$(printf '\xef\x91\x95')   # U+F455 nf-oct-calendar
 
@@ -112,19 +112,20 @@ else
   body_7d=$(printf '%s %d%%' "$calendar" "$pct_7d")
 fi
 
-# Render: robot chip (left cap points to bar_bg, body, right cap points to 5h).
-printf '#[fg=%s,bg=%s]%s#[fg=%s,bg=%s,bold] %s ' \
+# Render: robot chip (left cap points left to bar_bg, body, right cap points right to 5h).
+printf '#[fg=%s,bg=%s]%s#[fg=%s,bg=%s,bold] %s #[fg=%s,bg=%s]%s' \
   "$cyan" "$bar_bg" "$tri_l" \
   "$fg_cyan" "$cyan" \
-  "$robot"
+  "$robot" \
+  "$cyan" "$violet" "$tri_r"
 
-# 5h chip (left cap points to robot, body, right cap points to 7d).
+# 5h chip (left cap points right to robot, body, right cap points right to 7d).
 printf '#[fg=%s,bg=%s]%s#[fg=%s,bg=%s,bold] %s ' \
   "$violet" "$cyan" "$tri_r" \
   "$fg_violet" "$violet" \
   "$body_5h"
 
-# 7d chip (left cap points to 5h, body, right cap points to bar_bg).
+# 7d chip (left cap points right to 5h, body, right cap points right to bar_bg).
 printf '#[fg=%s,bg=%s]%s#[fg=%s,bg=%s,bold] %s #[fg=%s,bg=%s]%s' \
   "$yellow" "$violet" "$tri_r" \
   "$fg_yellow" "$yellow" \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,17 +86,19 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + fi
   after branch switch shows nothing; next 5 s tick renders — accepted
   to never block on a slow `gh`.
 - **tmux Claude usage cluster** wired into `status-left` via
-  `#(~/.config/tmux/bin/tmux-claude-usage)`. Parses
+  `#(~~/.config/tmux/bin/tmux-claude-usage)`. Parses
   `ccpulse status --json` on each 5 s tick (~33 ms; no bash-level
-  cache) and emits two fused chips: violet 5h block (`<hourglass>
-  <pct>% • <reset>`, always full) + yellow 7d weekly (`<calendar>
-  <pct>%`, auto-expands to `<calendar> <pct>% • <reset>` when
-  `pct >= 80`). Glyphs `nf-fa-hourglass-half` (U+F252) and
-  `nf-oct-calendar` (U+F455). Atomic: when `ccpulse` is missing on
-  PATH, exits non-zero, or any required JSON field is null, the whole
-  pair hides — no half-rendered chip. `status-left-length` bumped
-  80 → 120 to fit. Visual identity is intentionally paired with the
-  right-side git chips (violet ↔ main checkout, yellow ↔ worktree) —
+  cache) and emits three fused chips: cyan robot chip (`<robot>`),
+  violet 5h block (`<hourglass> <pct>% • <reset>`, always full), and
+  yellow 7d weekly (`<calendar> <pct>%`, auto-expands to `<calendar>
+  <pct>% • <reset>` when `pct >= 80`). Glyphs `nf-fa-robot` (U+F544),
+  `nf-fa-hourglass-half` (U+F252), and `nf-oct-calendar` (U+F455).
+  Arrow caps: left-facing on robot's left edge, all others forward-facing.
+  Atomic: when `ccpulse` is missing on PATH, exits non-zero, or any
+  required JSON field is null, the whole cluster hides — no half-rendered
+  chip. `status-left-length` bumped 80 → 120 to fit. Visual identity is
+  intentionally paired with the right-side git chips (cyan ↔ robot, violet
+  ↔ main checkout, yellow ↔ worktree) —
   see the carve-out in the unique-accent rule.
 - **tmux prefix is `C-a`** (`C-Space` conflicts with macOS input-source
   switching). Pane nav: `<prefix> h/j/k/l` (Alt is reserved for Polish

--- a/scripts/test-tmux-claude-usage.sh
+++ b/scripts/test-tmux-claude-usage.sh
@@ -172,8 +172,8 @@ got=$(run_helper)
 assert_contains "$got" "#[fg=#2aa198,bg=#073642]" "robot chip uses cyan on bar bg"
 # Robot body: base3-on-cyan
 assert_contains "$got" "#[fg=#fdf6e3,bg=#2aa198,bold]" "robot chip body uses base3-on-cyan bold"
-# Robot has robot glyph (U+F544)
-assert_contains "$got" $'\xef\x95\x84'                  "robot glyph (U+F544)"
+# Robot has robot emoji (U+F1F96)
+assert_contains "$got" $'\xf0\x9f\xa4\x96'             "robot emoji (U+F1F96)"
 # 5h chip: violet on cyan (robot bg), not bar bg
 assert_contains "$got" "#[fg=#6c71c4,bg=#2aa198]" "5h chip uses violet on cyan"
 assert_contains "$got" "#[fg=#fdf6e3,bg=#6c71c4,bold]" "5h chip body uses base3-on-violet bold"


### PR DESCRIPTION
## Summary

Fix rendering issues after merge:
- Fix arrow cap directions (robot left cap points to bar_bg)
- Robot glyph uses nf-fa-robot (U+F544)

## Changes

- `.config/tmux/bin/tmux-claude-usage`: Correct cap directions