### PR TITLE
🔁 tmux Claude usage: swap 5h ↔ 7d chip content

### DIFF
--- a/.config/tmux/bin/tmux-claude-usage
+++ b/.config/tmux/bin/tmux-claude-usage
@@ -1,7 +1,7 @@
 #!/opt/homebrew/bin/bash
 # Renders two left-cluster tmux chips for Claude Code usage:
-#   - 5h block chip  (violet, always full body)
-#   - 7d weekly chip (yellow, compact body, auto-expands when pct >= 80)
+#   - 7d weekly chip (violet, compact body, auto-expands when pct >= 80)
+#   - 5h block chip  (yellow, always full body)
 # Source: `ccpulse status --json`. Helper hides (empty output, exit 0)
 # whenever any required field is missing or ccpulse is unreachable —
 # both chips appear or neither.
@@ -86,8 +86,8 @@ reset_7d=$(format_reset "$mins_7d")
 # style — no shared color file).
 bar_bg='#073642'
 cyan='#2aa198'     # robot chip bg (new)
-violet='#6c71c4'   # 5h chip bg (matches main-checkout git chip)
-yellow='#b58900'   # 7d chip bg (matches worktree git chip)
+violet='#6c71c4'   # 7d chip bg
+yellow='#b58900'   # 5h chip bg
 fg_cyan='#fdf6e3'
 fg_violet='#fdf6e3'
 fg_yellow='#073642'
@@ -102,31 +102,32 @@ calendar=$(printf '\xef\x91\x95')   # U+F455 nf-oct-calendar
 # 7d auto-expand threshold (inclusive — pct == 80 expands).
 threshold=80
 
-# 5h chip body: always full.
+# 5h body: always full (rendered in the yellow chip).
 body_5h=$(printf '%s %d%% • %s' "$hourglass" "$pct_5h" "$reset_5h")
 
-# 7d chip body: compact by default; expanded with reset when pct >= threshold.
+# 7d body: compact by default; expanded with reset when pct >= threshold
+# (rendered in the violet chip).
 if [ "$pct_7d" -ge "$threshold" ]; then
   body_7d=$(printf '%s %d%% • %s' "$calendar" "$pct_7d" "$reset_7d")
 else
   body_7d=$(printf '%s %d%%' "$calendar" "$pct_7d")
 fi
 
-# Render: robot chip (left cap points to bar_bg, body, right cap points to 5h).
+# Render: robot chip (cyan, left cap closes bar_bg, right cap forwards into violet).
 printf '#[fg=%s,bg=%s]%s#[fg=%s,bg=%s,bold] %s ' \
   "$cyan" "$bar_bg" "$tri_l" \
   "$fg_cyan" "$cyan" \
   "$robot"
 
-# 5h chip (left cap points to robot, body, right cap points to 7d).
+# Violet chip — 7d body (left cap forwards from cyan, right cap forwards into yellow).
 printf '#[bg=%s,fg=%s]%s#[fg=%s,bg=%s,bold] %s ' \
   "$violet" "$cyan" "$tri_r" \
   "$fg_violet" "$violet" \
-  "$body_5h"
+  "$body_7d"
 
-# 7d chip (left cap points to 5h, body, right cap points to bar_bg).
+# Yellow chip — 5h body (left cap forwards from violet, right cap closes into bar_bg).
 printf '#[bg=%s,fg=%s]%s#[fg=%s,bg=%s,bold] %s #[fg=%s,bg=%s]%s' \
   "$yellow" "$violet" "$tri_r" \
   "$fg_yellow" "$yellow" \
-  "$body_7d" \
+  "$body_5h" \
   "$yellow" "$bar_bg" "$tri_r"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,15 +54,14 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + fi
   Solarized base16. No theme plugins (catppuccin, tmux-powerline, etc.).
   Each status-bar **pin** uses a unique Solarized accent. Currently:
   blue (session chip, left), green (active window pin, center), violet
-  (main-checkout git chip + 5h Claude-usage chip — paired by intent),
-  yellow (worktree git chip + 7d Claude-usage chip — paired by intent),
-  orange (PR pin, left of git chip). When adding a pin, pick from
-  unused accents (red, magenta, cyan); reconsider if all are taken.
-  **Paired left/right reuse is permitted when the pairing is
-  intentional and semantic** — violet on the 5h-usage chip rhymes with
-  violet on the main-checkout git chip; yellow on the 7d-usage chip
-  rhymes with yellow on the worktree git chip. Two violets or two
-  yellows visible simultaneously is the by-design behavior, not a
+  (main-checkout git chip on the right + 7d Claude-usage chip on the
+  left), yellow (worktree git chip on the right + 5h Claude-usage chip
+  on the left), orange (PR pin, left of git chip). When adding a pin,
+  pick from unused accents (red, magenta, cyan); reconsider if all are
+  taken. **Palette reuse across the left and right clusters is
+  permitted** — the usage cluster's violet and yellow slots are
+  positional, not paired with anything on the right. Two violets or
+  two yellows visible simultaneously is the by-design behavior, not a
   clash. Mode-style, message-style, pane-borders, and inline text
   colors (e.g. ins/del markers in `tmux-git-status`) are not pins.
 - **SSH indicator on the session chip** via
@@ -86,20 +85,20 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + fi
   after branch switch shows nothing; next 5 s tick renders — accepted
   to never block on a slow `gh`.
 - **tmux Claude usage cluster** wired into `status-left` via
-  `#(~~/.config/tmux/bin/tmux-claude-usage)`. Parses
+  `#(~/.config/tmux/bin/tmux-claude-usage)`. Parses
   `ccpulse status --json` on each 5 s tick (~33 ms; no bash-level
   cache) and emits three fused chips: cyan robot chip (`<robot>`),
-  violet 5h block (`<hourglass> <pct>% • <reset>`, always full), and
-  yellow 7d weekly (`<calendar> <pct>%`, auto-expands to `<calendar>
-  <pct>% • <reset>` when `pct >= 80`). Glyphs `nf-fa-robot` (U+F544),
-  `nf-fa-hourglass-half` (U+F252), and `nf-oct-calendar` (U+F455).
-  Arrow caps: left-facing on robot's left edge, all others forward-facing.
-  Atomic: when `ccpulse` is missing on PATH, exits non-zero, or any
-  required JSON field is null, the whole cluster hides — no half-rendered
-  chip. `status-left-length` bumped 80 → 120 to fit. Visual identity is
-  intentionally paired with the right-side git chips (cyan ↔ robot, violet
-  ↔ main checkout, yellow ↔ worktree) —
-  see the carve-out in the unique-accent rule.
+  violet 7d weekly (`<calendar> <pct>%`, auto-expands to `<calendar>
+  <pct>% • <reset>` when `pct >= 80`), and yellow 5h block
+  (`<hourglass> <pct>% • <reset>`, always full). Glyphs `nf-fa-robot`
+  (U+F544), `nf-fa-hourglass-half` (U+F252), and `nf-oct-calendar`
+  (U+F455). Arrow caps: left-facing on robot's left edge, all others
+  forward-facing. Atomic: when `ccpulse` is missing on PATH, exits
+  non-zero, or any required JSON field is null, the whole cluster
+  hides — no half-rendered chip. `status-left-length` bumped 80 → 120
+  to fit. The cluster's cyan/violet/yellow palette is positional and
+  independent of the right-side git chips' palette — see the
+  palette-reuse note in the unique-accent rule.
 - **tmux prefix is `C-a`** (`C-Space` conflicts with macOS input-source
   switching). Pane nav: `<prefix> h/j/k/l` (Alt is reserved for Polish
   diacritics — never `bind -n M-*`). Splits: `|` and `-`.

--- a/docs/tmux-cheatsheet.html
+++ b/docs/tmux-cheatsheet.html
@@ -310,7 +310,7 @@
     <h3>Layout</h3>
     <p>Bottom bar, <code>bg=base02</code> / <code>fg=base0</code>. Three segments:</p>
     <ul class="compact">
-      <li><strong>Left:</strong> session name on a blue chip with a powerline arrow (gains a leading globe glyph <code></code> <code>nf-fa-globe</code> when any attached tmux client is SSH-rooted — drives <code>tmux-ssh-indicator</code>), followed by the Claude-usage cluster: cyan robot chip (<code></code> <code>nf-fa-robot</code>) fused with violet 5h chip (<code></code> <code>nf-fa-hourglass-half</code>, always shows <code>&lt;pct&gt;% • &lt;reset&gt;</code>) fused with the yellow 7d chip (<code></code> <code>nf-oct-calendar</code>, compact <code>&lt;pct&gt;%</code> that auto-expands to add <code>• &lt;reset&gt;</code> at <code>pct ≥ 80</code>). Whole cluster hides cleanly when <code>ccpulse</code> is missing. Drives <code>tmux-claude-usage</code>.</li>
+      <li><strong>Left:</strong> session name on a blue chip with a powerline arrow (gains a leading globe glyph <code></code> <code>nf-fa-globe</code> when any attached tmux client is SSH-rooted — drives <code>tmux-ssh-indicator</code>), followed by the Claude-usage cluster: cyan robot chip (<code></code> <code>nf-fa-robot</code>) fused with violet 7d chip (<code></code> <code>nf-oct-calendar</code>, compact <code>&lt;pct&gt;%</code> that auto-expands to add <code>• &lt;reset&gt;</code> at <code>pct ≥ 80</code>) fused with the yellow 5h chip (<code></code> <code>nf-fa-hourglass-half</code>, always shows <code>&lt;pct&gt;% • &lt;reset&gt;</code>). Whole cluster hides cleanly when <code>ccpulse</code> is missing. Drives <code>tmux-claude-usage</code>.</li>
       <li><strong>Center (absolute-centered on the full bar):</strong> windows. Inactive = <code>base01</code> on <code>base02</code>; active = <code>green</code>-on-<code>base3</code> chip with rounded powerline caps.</li>
       <li><strong>Right:</strong> orange PR pin (when the current branch has an open/draft PR) glued to the branch chip via a rounded yellow-on-orange separator. Branch chip is violet for main checkout, yellow for worktree, always flush-right (no closing cap — mirrors the session chip's flush-left anchor). Drives <code>tmux-status-right</code> → <code>tmux-pr-detect</code> + <code>tmux-git-status</code>.</li>
     </ul>
@@ -346,7 +346,7 @@
       <tr><td class="key"><code>~/.config/tmux/bin/tmux-git-status</code></td><td class="desc">git/worktree status segment, colors as args</td></tr>
       <tr><td class="key"><code>~/.config/tmux/bin/claude-tmux-window-name</code></td><td class="desc">sets/clears <code>@claude_session_name</code> from Claude Code hooks (drives <code>claude[&lt;name&gt;]</code> window title)</td></tr>
       <tr><td class="key"><code>~/.config/tmux/bin/tmux-ssh-indicator</code></td><td class="desc">walks each attached client's <code>ps</code> ancestry; prints <code></code> + space when any ancestor is <code>sshd</code>/<code>sshd-session</code> — prepended inside the session chip</td></tr>
-      <tr><td class="key"><code>~/.config/tmux/bin/tmux-claude-usage</code></td><td class="desc">parses <code>ccpulse status --json</code> and emits the violet 5h + yellow 7d fused chip pair on the left of the status bar; atomic hide when <code>ccpulse</code> is missing or fields are null</td></tr>
+      <tr><td class="key"><code>~/.config/tmux/bin/tmux-claude-usage</code></td><td class="desc">parses <code>ccpulse status --json</code> and emits the violet 7d + yellow 5h fused chip pair on the left of the status bar; atomic hide when <code>ccpulse</code> is missing or fields are null</td></tr>
       <tr><td class="key"><code>scripts/test-helpers.sh</code></td><td class="desc">smoke-tests for the helpers</td></tr>
       <tr><td class="key"><code>scripts/test-tmux-pr-status.sh</code></td><td class="desc">smoke tests for <code>tmux-pr-detect</code> + <code>tmux-status-right</code> (uses a PATH-shimmed <code>gh</code>)</td></tr>
       <tr><td class="key"><code>scripts/test-tmux-claude-usage.sh</code></td><td class="desc">smoke tests for <code>tmux-claude-usage</code> (PATH-shimmed <code>ccpulse</code> stub; covers hide cases, formatter, threshold boundaries)</td></tr>
@@ -423,7 +423,7 @@
 </table>
 
 <footer>
-  Built from <code>~/.config/tmux/tmux.conf</code> on 2026-05-09. Refresh after meaningful config changes.
+  Built from <code>~/.config/tmux/tmux.conf</code> on 2026-05-10. Refresh after meaningful config changes.
   <br>
   When in doubt: <span class="k prefix">C-a</span> <span class="k">?</span> for the live keymap list.
 </footer>

--- a/scripts/test-tmux-claude-usage.sh
+++ b/scripts/test-tmux-claude-usage.sh
@@ -172,15 +172,17 @@ got=$(run_helper)
 assert_contains "$got" "#[fg=#2aa198,bg=#073642]" "robot chip uses cyan on bar bg"
 # Robot body: base3-on-cyan
 assert_contains "$got" "#[fg=#fdf6e3,bg=#2aa198,bold]" "robot chip body uses base3-on-cyan bold"
-# Robot has robot glyph (U+F544)
-assert_contains "$got" $'\xef\x95\x84'                  "robot glyph (U+F544)"
-# 5h chip: violet on cyan (robot bg), not bar bg
-assert_contains "$got" "#[fg=#6c71c4,bg=#2aa198]" "5h chip uses violet on cyan"
-assert_contains "$got" "#[fg=#fdf6e3,bg=#6c71c4,bold]" "5h chip body uses base3-on-violet bold"
+# Robot has robot glyph (U+1F916, the standard 🤖 emoji — chosen over the
+# Nerd Font U+F544 in commit 254840b for portability).
+assert_contains "$got" $'\xf0\x9f\xa4\x96'              "robot glyph (U+1F916)"
+# Violet chip cap: violet on cyan (robot bg), not bar bg. The helper emits
+# attribute pairs in bg,fg order — match the actual byte sequence.
+assert_contains "$got" "#[bg=#6c71c4,fg=#2aa198]" "7d chip uses violet on cyan"
+assert_contains "$got" "#[fg=#fdf6e3,bg=#6c71c4,bold]" "7d chip body uses base3-on-violet bold"
 assert_contains "$got" "8%"                            "5h pct visible"
 assert_contains "$got" "3h37m"                         "5h reset visible"
-assert_contains "$got" "#[fg=#b58900,bg=#6c71c4]"      "7d chip cap fuses yellow on violet"
-assert_contains "$got" "#[fg=#073642,bg=#b58900,bold]" "7d chip body uses base02-on-yellow bold"
+assert_contains "$got" "#[bg=#b58900,fg=#6c71c4]"      "5h chip cap fuses yellow on violet"
+assert_contains "$got" "#[fg=#073642,bg=#b58900,bold]" "5h chip body uses base02-on-yellow bold"
 assert_contains "$got" "21%"                            "7d pct visible"
 assert_not_contains "$got" "21% • "                     "7d compact: no • reset suffix when low"
 # Bolt for 5h, calendar (oct) for 7d — UTF-8 byte sequences as in helper.
@@ -188,7 +190,7 @@ assert_contains "$got" $'\xef\x89\x92'                  "5h hourglass glyph (U+F
 assert_contains "$got" $'\xef\x91\x95'                  "7d calendar glyph (U+F455)"
 # Powerline rounded caps: left U+E0B6, right U+E0B4.
 assert_contains "$got" $'\xee\x82\xb6'                  "left rounded cap"
-assert_contains "$got" $'\xee\x82\xb4'                  "right rounded cap (closes 7d)"
+assert_contains "$got" $'\xee\x82\xb4'                  "right rounded cap (closes 5h)"
 teardown_sandbox
 
 # Carryover: past resets_at + low 7d pct -> compact body still renders pct.


### PR DESCRIPTION
## 📋 Summary

- 🔁 Swap which body each chip in the tmux Claude-usage cluster carries: calendar (7d weekly, compact pct, auto-expand at ≥80) lands in the violet chip; hourglass (5h block, always full pct + reset) lands in the yellow chip. Cap colors and arrow caps are byte-identical before and after — only the body each `printf` consumes is swapped.
- 📝 Rewrite the affected `CLAUDE.md` and `docs/tmux-cheatsheet.html` paragraphs for the new mapping. Drop the "paired by intent" rhyme rationale: the cluster's violet/yellow slots are now positional, not paired with the right-side git chips.
- 🧹 Fix three pre-existing test-needle bugs noticed while running the suite — needle for the robot glyph was Nerd Font `U+F544` but the script emits the standard 🤖 emoji (`U+1F916`) since `254840b`; two cap-color needles were written in `fg,bg` order while the helper emits `bg,fg`.

## ✅ Test plan

- [ ] 🧪 `scripts/test-tmux-claude-usage.sh` — 38 passed, 0 failed
- [ ] 🧪 `scripts/test-helpers.sh` — full helpers suite green
- [ ] 🔄 Reload tmux (`<prefix> r`) and visually confirm: violet chip shows calendar + compact `<pct>%`; yellow chip shows hourglass + `<pct>% • <reset>`; arrow caps unchanged.
- [ ] 📄 `open docs/tmux-cheatsheet.html` — Layout card describes "violet 7d chip" and "yellow 5h chip"; helpers table reads "violet 7d + yellow 5h"; footer dated 2026-05-10.