### PR TITLE
Fix tmux-claude-usage failing with GNU coreutils date

### DIFF
--- a/.config/tmux/bin/tmux-claude-usage
+++ b/.config/tmux/bin/tmux-claude-usage
@@ -117,9 +117,9 @@ resets_short="${resets_7d%.*}"
 # the literal time-portion only).
 resets_short="${resets_short%Z}"
 
-resets_epoch=$(TZ=UTC date -j -f '%Y-%m-%dT%H:%M:%S' \
+resets_epoch=$(TZ=UTC /bin/date -j -f '%Y-%m-%dT%H:%M:%S' \
                   "$resets_short" '+%s' 2>/dev/null) || exit 0
-now_epoch=$(date '+%s')
+now_epoch=$(/bin/date '+%s')
 mins_7d=$(( (resets_epoch - now_epoch) / 60 ))
 [ "$mins_7d" -lt 0 ] && mins_7d=0
 


### PR DESCRIPTION
## Summary

- `tmux-claude-usage` uses BSD-specific `date -j -f` syntax to parse the 7-day reset timestamp
- When Homebrew coreutils is installed, GNU `date` shadows `/bin/date` in PATH and doesn't support `-j`
- The command fails silently (`2>/dev/null || exit 0`), causing the entire script to produce no output — the Claude usage chips disappear from the tmux status bar
- Fixed by using `/bin/date` explicitly for both `date` calls

## Test plan

- [x] Verified `tmux-claude-usage` now produces chip output when run directly
- [ ] Confirm chips render in tmux status bar after `tmux source ~/.config/tmux/tmux.conf`