### PR TITLE
Merge stale ~/.gitignore patterns into .gitignore_global

### DIFF
--- a/.gitignore_global
+++ b/.gitignore_global
@@ -10,6 +10,15 @@
 # (per ~/.claude/CLAUDE.md — never committed in any repo)
 .superpowers/
 .autonomo/
+.scratch
+.secrets
+
+# CI/code-quality tooling state
+.codacy
+.github/instructions/codacy.instructions.md
+bin/complexity_changes.sh
+bin/reek_changes.sh
+reports/
 
 # Python
 __pycache__/


### PR DESCRIPTION
## Summary

- `core.excludesfile` had drifted to `~/.gitignore` (a real file) instead of `~/.gitignore_global` (the dotfiles symlink)
- Patterns that accumulated in the stale file (`.codacy`, `.scratch`, `.secrets`, `reports/`, codacy-injected scripts) were not in the tracked `.gitignore_global`
- Merged the missing patterns into `.gitignore_global` and deleted `~/.gitignore`
- Fixed `core.excludesfile` to point back to `~/.gitignore_global`

## Test plan

- [x] `git status` no longer shows `.claude/scheduled_tasks.lock` as untracked
- [x] `git config --global core.excludesfile` returns `~/.gitignore_global`