### PR TITLE
📊 Add gh dash for PR/issue TUI dashboard

### DIFF
--- a/.config/fish/conf.d/35-abbreviations.fish
+++ b/.config/fish/conf.d/35-abbreviations.fish
@@ -30,3 +30,6 @@ abbr -a gl    git log
 abbr -a glo   git log --oneline
 abbr -a gss   git stash
 abbr -a grb   git rebase
+
+# GitHub TUI dashboard (gh extension; installed by bootstrap.sh)
+abbr -a ghd   gh dash

--- a/.config/gh-dash/config.yml
+++ b/.config/gh-dash/config.yml
@@ -1,0 +1,107 @@
+prSections:
+    - title: My Pull Requests
+      filters: is:open author:@me
+    - title: Needs My Review
+      filters: is:open review-requested:@me
+    - title: Involved
+      filters: is:open involves:@me -author:@me
+issuesSections:
+    - title: My Issues
+      filters: is:open author:@me
+    - title: Assigned
+      filters: is:open assignee:@me
+    - title: Involved
+      filters: is:open involves:@me -author:@me
+notificationsSections:
+    - title: All
+      filters: ""
+    - title: Created
+      filters: reason:author
+    - title: Participating
+      filters: reason:participating
+    - title: Mentioned
+      filters: reason:mention
+    - title: Review Requested
+      filters: reason:review-requested
+    - title: Assigned
+      filters: reason:assign
+    - title: Subscribed
+      filters: reason:subscribed
+    - title: Team Mentioned
+      filters: reason:team-mention
+repo:
+    branchesRefetchIntervalSeconds: 30
+    prsRefetchIntervalSeconds: 60
+defaults:
+    preview:
+        open: true
+        width: 0.45
+    prsLimit: 20
+    prApproveComment: LGTM
+    issuesLimit: 20
+    notificationsLimit: 20
+    view: prs
+    layout:
+        prs:
+            updatedAt:
+                width: 5
+            createdAt:
+                width: 5
+            repo:
+                width: 20
+            author:
+                width: 15
+            authorIcon:
+                hidden: false
+            assignees:
+                width: 20
+                hidden: true
+            base:
+                width: 15
+                hidden: true
+            lines:
+                width: 15
+        issues:
+            updatedAt:
+                width: 5
+            createdAt:
+                width: 5
+            repo:
+                width: 15
+            creator:
+                width: 10
+            creatorIcon:
+                hidden: false
+            assignees:
+                width: 20
+                hidden: true
+    refetchIntervalMinutes: 30
+keybindings: {}
+repoPaths: {}
+theme:
+    colors:
+        text:
+            primary: "#839496"
+            secondary: "#93a1a1"
+            inverted: "#fdf6e3"
+            faint: "#586e75"
+            warning: "#b58900"
+            success: "#859900"
+            error: "#dc322f"
+        background:
+            selected: "#073642"
+        border:
+            primary: "#586e75"
+            secondary: "#073642"
+            faint: "#073642"
+    ui:
+        sectionsShowCount: true
+        table:
+            showSeparator: true
+            compact: false
+pager:
+    diff: ""
+confirmQuit: false
+showAuthorIcons: true
+smartFilteringAtLaunch: true
+includeReadNotifications: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -308,6 +308,19 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + fi
   `.config/lnav/formats/installed/<name>.json`; one tracked:
   `inngest.json` for `inngest-cli dev` JSON-per-line stdout. `lnav -i`
   writes into `installed/` and therefore the repo (intended).
+- **`gh dash` is the GitHub TUI** (raw command; `ghd` abbr in
+  `35-abbreviations.fish`). Solarized Dark via `theme.colors` in
+  `.config/gh-dash/config.yml`, standard base16 semantic mapping
+  (`text.primary` = base0, `background.selected` = base02, etc.).
+  Whole-dir symlink (matches btop/glow/xh shape). Bootstrap auto-installs
+  the extension idempotently (`gh extension list | grep -q '^gh dash'`
+  guard); install failure prints a warning, doesn't abort. No `gh auth`
+  required — `gh extension install` clones a public repo. Sections
+  (PRs / issues / notifications), layout, refetch intervals adopted
+  verbatim from the prior machine-local config — don't bikeshed them
+  here. If gh-dash ever starts writing cache/state inside
+  `~/.config/gh-dash/`, switch to the mixed-dir pattern (cf.
+  fish/nvim/worktrunk).
 - **`diff` aliased to `difft`** (guarded). For ad-hoc, non-git
   comparisons. Git diffs unaffected (still `delta`); `vimdiff`
   unaffected (separate alias). Escape: `command diff`, `\diff`,
@@ -346,8 +359,8 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + fi
 ## Where things live
 
 - Sources in `$PROJECTS_HOME/dotfiles/`: `.config/` (whole-dir per tool:
-  `btop`, `ccstatusline`, `fish`, `ghostty`, `glow`, `nvim`, `procs`,
-  `tailspin`, `tmux`, `worktrunk`, `xh`; plus `starship.toml`,
+  `btop`, `ccstatusline`, `fish`, `gh-dash`, `ghostty`, `glow`, `nvim`,
+  `procs`, `tailspin`, `tmux`, `worktrunk`, `xh`; plus `starship.toml`,
   partial links for `sesh/sesh.toml` and `lnav/{configs,formats}/installed`),
   `.vimrc`, `.vim/colors`, `.gitignore_global`, `.claude/CLAUDE.md`.
   `bin/` files symlink to `~/.local/bin/`.

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -128,6 +128,16 @@ link ".config/procs"   "$HOME/.config/procs"
 # --- xh (modern HTTP client; Solarized via default_options)
 link ".config/xh"      "$HOME/.config/xh"
 
+# --- gh-dash (TUI for PRs/issues/notifications; Solarized theme)
+link ".config/gh-dash" "$HOME/.config/gh-dash"
+
+# --- gh extensions (idempotent; needs `gh` from brew, no `gh auth` required)
+if ! gh extension list 2>/dev/null | grep -q '^gh dash'; then
+  echo "🧩 installing gh dash..."
+  gh extension install dlvhdr/gh-dash || \
+    echo "⚠️  gh extension install failed (network?) — re-run bootstrap when online"
+fi
+
 # --- lnav (TUI log navigator; only installed/ subdirs are symlinked from repo)
 # lnav writes its built-in samples (configs/default, formats/default), crash
 # dumps, staging area, log_metadata.db, view-info-*.json, and :config-written

--- a/docs/terminal-cheatsheet.html
+++ b/docs/terminal-cheatsheet.html
@@ -64,6 +64,7 @@
       <tr><td class="key"><a href="https://github.com/bensadeh/tailspin"><code>tailspin</code></a></td><td class="desc">live-log highlighter (<code>tspin</code>); Solarized via <code>~/.config/tailspin/theme.toml</code></td></tr>
       <tr><td class="key"><a href="https://lnav.org/"><code>lnav</code></a></td><td class="desc">TUI log navigator; Solarized via built-in theme (see lnav section)</td></tr>
       <tr><td class="key"><a href="https://github.com/aristocratos/btop"><code>btop</code></a></td><td class="desc">modern <code>top</code> replacement; Solarized via <code>~/.config/btop/btop.conf</code></td></tr>
+      <tr><td class="key"><a href="https://github.com/dlvhdr/gh-dash"><code>gh dash</code></a></td><td class="desc">GitHub TUI for PRs/issues/notifications (<code>ghd</code> abbr); Solarized via <code>~/.config/gh-dash/config.yml</code> — <code>?</code> help, <code>s</code>/<code>S</code> next/prev section, <code>j</code>/<code>k</code> rows, <code>enter</code> preview, <code>o</code> open in browser, <code>r</code> refresh, <code>/</code> filter, <code>q</code> quit</td></tr>
       <tr><td class="key"><a href="https://github.com/Byron/dua-cli"><code>dua</code></a></td><td class="desc">interactive disk-usage analyzer with TUI deleter (<code>dua i</code>; raw, no alias)</td></tr>
       <tr><td class="key"><a href="https://github.com/muesli/duf"><code>duf</code></a></td><td class="desc">modern <code>df</code> replacement (grouped, color-coded; raw, no alias)</td></tr>
       <tr><td class="key"><a href="https://github.com/bootandy/dust"><code>dust</code></a></td><td class="desc">tree-style <code>du</code> replacement (largest-first, bar graphs; raw, no alias)</td></tr>
@@ -610,7 +611,7 @@
 <span class="cmd">git log -p</span> | <span class="cmd">head</span>                 <span class="c"># should look styled</span></pre>
 
 <footer>
-  Built from <code>~/.config/fish/</code>, <code>Brewfile</code>, and project CLAUDE.md on 2026-05-07.
+  Built from <code>~/.config/fish/</code>, <code>Brewfile</code>, and project CLAUDE.md on 2026-05-11.
   Refresh after meaningful color-tooling changes.
 </footer>
 


### PR DESCRIPTION
## 🎯 Summary

- ✨ Tracks `~/.config/gh-dash/config.yml` with Solarized Dark theme — base16 semantic mapping (`text.primary` = base0, `background.selected` = base02, etc.) layered onto the existing sections, layout, and prefs.
- 🔧 `bootstrap.sh` whole-dir-symlinks `~/.config/gh-dash` and idempotently installs the `dlvhdr/gh-dash` extension. Failure prints a warning and doesn't abort (matches the TPM-clone idiom). No `gh auth` required.
- ✨ Fish abbreviation `ghd` → `gh dash` in `35-abbreviations.fish`, in the git-flow abbr style (`gst`/`gco`/`gp`).
- 📝 One row on the terminal cheatsheet next to `btop` with the bindings you actually use (`?`, `s`/`S`, `j`/`k`, `enter`, `o`, `r`, `/`, `q`). Footer date bumped.
- 📝 Convention bullet added to `CLAUDE.md` so future edits don't bikeshed the verbatim-adopted sections.

## 🧪 Test plan

- ✅ YAML parses (`uv run --with pyyaml`); `theme.colors.{text,background,border}` keys at correct depth.
- ✅ `bash -n bootstrap.sh` clean; only pre-existing shellcheck warning (line 28, unrelated).
- ✅ `fish --no-config -c 'source ...; abbr -l'` shows `ghd` from the worktree file.
- ✅ `gh dash --config <repo>/config.yml` parses cleanly (post-parse TTY failure expected from a non-interactive shell).
- ✅ `gh extension list | grep '^gh dash'` returns the existing `v4.23.2` install — bootstrap's guard short-circuits.
- ⏳ Post-merge: re-run `./bootstrap.sh` from the primary checkout to exercise the new link block + idempotency (`📦 → 🔗` on first run, `✅` on second).
- ⏳ Visual: launch `gh dash` interactively and confirm Solarized selected-row (`#073642`) + base0 text (`#839496`).

## 🔗 Related

Closes #179.