### PR TITLE
🔢 gh-dash: show issue numbers and trim issue columns

### DIFF
--- a/.config/gh-dash/config.yml
+++ b/.config/gh-dash/config.yml
@@ -65,9 +65,9 @@ defaults:
             updatedAt:
                 width: 5
             createdAt:
-                width: 5
-            repo:
-                width: 15
+                hidden: true
+            reactions:
+                hidden: true
             creator:
                 width: 10
             creatorIcon:
@@ -98,7 +98,7 @@ theme:
         sectionsShowCount: true
         table:
             showSeparator: true
-            compact: false
+            compact: true
 pager:
     diff: ""
 confirmQuit: false


### PR DESCRIPTION
## 📋 Summary

- 🔢 Flip `theme.ui.table.compact` so issue rows show `#N` in the title — gh-dash only renders the number prefix when compact mode is on, and issues (unlike PRs) have no extended title fallback that includes it.
- 🧹 Hide `createdAt` and `reactions` columns in the issues layout — they were noise next to `updatedAt`.
- 🗑️ Drop the explicit `repo: width: 15` override — matches the schema default, so the line was a no-op.

## ⚖️ Tradeoff

- PR rows lose the two-line extended layout (`repo #N by @author · branch` / `title`) and collapse to a single `#N title` line. Repo / author / base still render as their own columns. Accepted in exchange for `#N` finally appearing on issue rows.

## ✅ Test plan

- [ ] Run `gh dash` — issue rows show `#N <title>`.
- [ ] PR rows still readable; state, repo, title (with `#N`), author, comments, review, CI, lines, updatedAt, createdAt all present.
- [ ] `createdAt` and `reactions` columns no longer appear in the issues view.