### PR TITLE
📊 gh-dash: widen preview, delta pager, hide author icons

### DIFF
--- a/.config/gh-dash/config.yml
+++ b/.config/gh-dash/config.yml
@@ -65,9 +65,9 @@ defaults:
             updatedAt:
                 width: 5
             createdAt:
-                width: 5
-            repo:
-                width: 15
+                hidden: true
+            reactions:
+                hidden: true
             creator:
                 width: 10
             creatorIcon:
@@ -98,7 +98,7 @@ theme:
         sectionsShowCount: true
         table:
             showSeparator: true
-            compact: false
+            compact: true
 pager:
     diff: ""
 confirmQuit: false

--- a/.config/gh-dash/config.yml
+++ b/.config/gh-dash/config.yml
@@ -35,7 +35,7 @@ repo:
 defaults:
     preview:
         open: true
-        width: 0.45
+        width: 0.6
     prsLimit: 20
     prApproveComment: LGTM
     issuesLimit: 20
@@ -100,8 +100,8 @@ theme:
             showSeparator: true
             compact: true
 pager:
-    diff: ""
+    diff: delta
 confirmQuit: false
-showAuthorIcons: true
+showAuthorIcons: false
 smartFilteringAtLaunch: true
 includeReadNotifications: true


### PR DESCRIPTION
## ✨ Summary

- 📐 Widen the default preview pane from 45% to 60% so diffs have room
  to breathe without manual resizing.
- 🎨 Set the pager to `delta`, matching the rest of the Solarized-Dark
  toolchain instead of falling back to plain text in the preview.
- 🧹 Hide author icons in list rows — extra glyphs that didn't earn
  their column width.

## ✅ Test plan

- [ ] `gh dash` opens with a visibly wider preview pane.
- [ ] Focusing a PR shows a delta-formatted diff (Solarized colours,
      file headers, ins/del markers) in the preview.
- [ ] Author-icon column no longer renders in the PR / issue lists.
- [ ] Existing keybindings and section layout unchanged.