### PR TITLE
🔤 Ghostty font-set: 5 switchable Nerd Fonts with ligatures

### DIFF
--- a/.config/fish/completions/font-set.fish
+++ b/.config/fish/completions/font-set.fish
@@ -1,0 +1,5 @@
+complete -c font-set -f -n '__fish_is_first_token' -a jetbrains -d 'JetBrains Mono Nerd Font (default)'
+complete -c font-set -f -n '__fish_is_first_token' -a fira      -d 'FiraCode Nerd Font'
+complete -c font-set -f -n '__fish_is_first_token' -a cascadia  -d 'Cascadia Code (CaskaydiaCove Nerd Font)'
+complete -c font-set -f -n '__fish_is_first_token' -a monaspace -d 'GitHub Monaspace (Neon variant)'
+complete -c font-set -f -n '__fish_is_first_token' -a iosevka   -d 'Iosevka Nerd Font'

--- a/.config/fish/functions/font-set.fish
+++ b/.config/fish/functions/font-set.fish
@@ -1,0 +1,18 @@
+function font-set --description 'Switch Ghostty font between installed Nerd Fonts'
+    set -l name $argv[1]
+    switch $name
+        case jetbrains fira cascadia monaspace iosevka
+            # OK
+        case '*'
+            echo "Usage: font-set <jetbrains|fira|cascadia|monaspace|iosevka>" >&2
+            return 1
+    end
+
+    # Flip symlink. -sfn replaces the link atomically.
+    ln -sfn font-$name.ghostty ~/.config/ghostty/font.ghostty
+
+    # Live reload. Swallowed silently because ghostty may not be running.
+    ghostty +reload 2>/dev/null
+
+    echo "font → $name"
+end

--- a/.config/ghostty/config.ghostty
+++ b/.config/ghostty/config.ghostty
@@ -8,7 +8,10 @@
 config-file = theme.ghostty
 
 # ─── Font ─────────────────────────────────────
-font-family = JetBrainsMono Nerd Font Mono
+# Font family lives in font.ghostty (machine-local symlink →
+# font-{jetbrains,fira,cascadia,monaspace,iosevka}.ghostty). Swap via
+# `font-set <name>`; reload via cmd+ctrl+shift+r or `ghostty +reload`.
+config-file = font.ghostty
 font-size = 14
 # Slightly bolder strokes on macOS retina.
 font-thicken = true

--- a/.config/ghostty/font-cascadia.ghostty
+++ b/.config/ghostty/font-cascadia.ghostty
@@ -1,0 +1,3 @@
+# Cascadia Code (Nerd Fonts ships it as "Caskaydia Cove" due to license).
+# Active when ~/.config/ghostty/font.ghostty → this file (font-set cascadia).
+font-family = CaskaydiaCove Nerd Font Mono

--- a/.config/ghostty/font-fira.ghostty
+++ b/.config/ghostty/font-fira.ghostty
@@ -1,0 +1,3 @@
+# Fira Code Nerd Font.
+# Active when ~/.config/ghostty/font.ghostty → this file (font-set fira).
+font-family = FiraCode Nerd Font Mono

--- a/.config/ghostty/font-iosevka.ghostty
+++ b/.config/ghostty/font-iosevka.ghostty
@@ -1,0 +1,3 @@
+# Iosevka Nerd Font — narrow, ligatures by default.
+# Active when ~/.config/ghostty/font.ghostty → this file (font-set iosevka).
+font-family = Iosevka Nerd Font Mono

--- a/.config/ghostty/font-jetbrains.ghostty
+++ b/.config/ghostty/font-jetbrains.ghostty
@@ -1,0 +1,3 @@
+# JetBrains Mono Nerd Font — default.
+# Active when ~/.config/ghostty/font.ghostty → this file (font-set jetbrains).
+font-family = JetBrainsMono Nerd Font Mono

--- a/.config/ghostty/font-monaspace.ghostty
+++ b/.config/ghostty/font-monaspace.ghostty
@@ -1,0 +1,3 @@
+# GitHub Monaspace — Neon variant (the neo-grotesque, most general-purpose).
+# Active when ~/.config/ghostty/font.ghostty → this file (font-set monaspace).
+font-family = MonaspiceNe Nerd Font Mono

--- a/Brewfile
+++ b/Brewfile
@@ -59,5 +59,9 @@ brew "duf"                      # modern df replacement (grouped, color-coded)
 brew "dust"                     # tree-style du replacement (largest-first, bar graphs)
 brew "hyperfine"                # command benchmarking (warmups, multi-run stats)
 
-# Fonts
-cask "font-jetbrains-mono-nerd-font"  # Solarized + JetBrainsMono Nerd Font everywhere (CLAUDE.md)
+# Fonts — JetBrains Mono is the default; others are switchable via `font-set`
+cask "font-jetbrains-mono-nerd-font"  # default; Solarized + JetBrainsMono Nerd Font everywhere (CLAUDE.md)
+cask "font-fira-code-nerd-font"       # popular ligature font; widest ligature set
+cask "font-caskaydia-cove-nerd-font"  # Cascadia Code (Nerd Fonts rename); Windows Terminal default
+cask "font-monaspice-nerd-font"       # GitHub Monaspace (Nerd Fonts ships it as "Monaspice"); texture healing, multi-style superfamily
+cask "font-iosevka-nerd-font"         # narrow, sharp on Retina; more columns per window

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,6 +234,21 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + fi
   any prior `theme-set mocha` pick across re-runs. Out of v1:
   `btop`/`procs`/`vivid`/`tailspin`/`xh`/`ccstatusline`, cheatsheet
   HTML toggle, screenshot regeneration, live nvim retheme.
+- **Switchable Ghostty fonts — Nerd Fonts with ligatures.** JetBrains
+  Mono is the default; Fira Code, Cascadia Code (ships as
+  `CaskaydiaCove` from Nerd Fonts), GitHub Monaspace (Neon variant),
+  and Iosevka are installed alongside. `font-set <name>` (fish function)
+  flips a machine-local symlink `~/.config/ghostty/font.ghostty` →
+  one of `font-{jetbrains,fira,cascadia,monaspace,iosevka}.ghostty`
+  (each is a one-liner `font-family = ...`). `config.ghostty` pulls
+  the active family via `config-file = font.ghostty`; `font-size` and
+  `font-thicken` stay there (shared across fonts). `ghostty +reload`
+  fires live. All five casks are pinned in the `Brewfile`. Bootstrap's
+  "don't clobber" guard preserves any prior `font-set` pick across
+  re-runs. Add a new font: drop a new `font-<short>.ghostty` next to
+  the others, append the cask to `Brewfile`, extend the `switch` in
+  `font-set.fish` + its completion. No nvim/tmux/bat coupling — font
+  is a Ghostty-only concern.
 - **Starship pastel accent — per theme.** Solarized keeps the
   `#DA627D` rose; Mocha uses `#f5c2e7` (pink, Catppuccin's canonical
   "personal" accent). Defined in each starship config's

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -98,11 +98,15 @@ seed_local() {
 
 # --- ghostty
 # ~/.config/ghostty/ is a real dir; tracked entries are individually
-# symlinked. Active-theme symlink theme.ghostty is machine-local.
+# symlinked. Active-theme and active-font symlinks (theme.ghostty,
+# font.ghostty) are machine-local — created only if missing so prior
+# `theme-set` / `font-set` picks survive re-running bootstrap.
 prepare_real_dir "$HOME/.config/ghostty"
 link_tracked_entries ".config/ghostty" "$HOME/.config/ghostty"
 [ -L "$HOME/.config/ghostty/theme.ghostty" ] \
     || ln -sfn theme-solarized.ghostty "$HOME/.config/ghostty/theme.ghostty"
+[ -L "$HOME/.config/ghostty/font.ghostty" ] \
+    || ln -sfn font-jetbrains.ghostty "$HOME/.config/ghostty/font.ghostty"
 
 # --- tmux
 link ".config/tmux"    "$HOME/.config/tmux"


### PR DESCRIPTION
## Summary

- 🔤 Add `font-set <name>` (fish function + completion) to swap Ghostty's font family at runtime — mirrors the existing `theme-set` pattern.
- 📦 Install 4 new Nerd Font casks alongside JetBrains Mono: Fira Code, Cascadia Code (`font-caskaydia-cove-nerd-font`), Monaspace (`font-monaspice-nerd-font`), Iosevka.
- 🔗 Refactor `config.ghostty`: `font-family` lifted into machine-local symlink `font.ghostty` → one of `font-{jetbrains,fira,cascadia,monaspace,iosevka}.ghostty` (each a one-liner with the family name).
- 🌱 Bootstrap seeds the default symlink to JetBrains Mono with the same "don't clobber" guard `theme.ghostty` uses, so prior `font-set` picks survive re-runs.
- 📝 CLAUDE.md gains a `Switchable Ghostty fonts` conventions entry.

## Test plan

- [x] 🐟 `fish -n` syntax-checks on `font-set.fish` and its completion
- [x] 🔁 Round-trip: `font-set fira` → readlink → `font-set jetbrains` → readlink (both flip correctly)
- [x] 🍺 `brew bundle check --file=Brewfile --verbose` clean (all five casks present)
- [x] 🪺 `bootstrap.sh` re-run idempotent; new `font.ghostty` symlink seeded; completion linked
- [ ] 👀 Visually verify each font renders in Ghostty (open Ghostty after `font-set <name>` for each)