### PR TITLE
🦇 Switchable theme: add Dracula as third option

### DIFF
--- a/.config/fish/functions/theme-set.fish
+++ b/.config/fish/functions/theme-set.fish
@@ -1,18 +1,21 @@
-function theme-set --description 'Switch colour scheme between solarized and mocha'
+function theme-set --description 'Switch colour scheme between solarized, mocha, and dracula'
     set -l name $argv[1]
     switch $name
-        case solarized mocha
+        case solarized mocha dracula
             # OK
         case '*'
-            echo "Usage: theme-set <solarized|mocha>" >&2
+            echo "Usage: theme-set <solarized|mocha|dracula>" >&2
             return 1
     end
 
     set -l bat_theme
-    if test $name = mocha
-        set bat_theme "Catppuccin Mocha"
-    else
-        set bat_theme "Solarized (dark)"
+    switch $name
+        case mocha
+            set bat_theme "Catppuccin Mocha"
+        case dracula
+            set bat_theme "Dracula"
+        case '*'
+            set bat_theme "Solarized (dark)"
     end
 
     # Flip symlinks. -sfn replaces the link atomically.

--- a/.config/gh-dash/config-dracula.yml
+++ b/.config/gh-dash/config-dracula.yml
@@ -1,0 +1,107 @@
+prSections:
+    - title: My Pull Requests
+      filters: is:open author:@me
+    - title: Needs My Review
+      filters: is:open review-requested:@me
+    - title: Involved
+      filters: is:open involves:@me -author:@me
+issuesSections:
+    - title: My Issues
+      filters: is:open author:@me
+    - title: Assigned
+      filters: is:open assignee:@me
+    - title: Involved
+      filters: is:open involves:@me -author:@me
+notificationsSections:
+    - title: All
+      filters: ""
+    - title: Created
+      filters: reason:author
+    - title: Participating
+      filters: reason:participating
+    - title: Mentioned
+      filters: reason:mention
+    - title: Review Requested
+      filters: reason:review-requested
+    - title: Assigned
+      filters: reason:assign
+    - title: Subscribed
+      filters: reason:subscribed
+    - title: Team Mentioned
+      filters: reason:team-mention
+repo:
+    branchesRefetchIntervalSeconds: 30
+    prsRefetchIntervalSeconds: 60
+defaults:
+    preview:
+        open: true
+        width: 0.6
+    prsLimit: 20
+    prApproveComment: LGTM
+    issuesLimit: 20
+    notificationsLimit: 20
+    view: prs
+    layout:
+        prs:
+            updatedAt:
+                width: 5
+            createdAt:
+                width: 5
+            repo:
+                width: 20
+            author:
+                width: 15
+            authorIcon:
+                hidden: false
+            assignees:
+                width: 20
+                hidden: true
+            base:
+                width: 15
+                hidden: true
+            lines:
+                width: 15
+        issues:
+            updatedAt:
+                width: 5
+            createdAt:
+                hidden: true
+            reactions:
+                hidden: true
+            creator:
+                width: 10
+            creatorIcon:
+                hidden: false
+            assignees:
+                width: 20
+                hidden: true
+    refetchIntervalMinutes: 30
+keybindings: {}
+repoPaths: {}
+theme:
+    colors:
+        text:
+            primary: "#f8f8f2"
+            secondary: "#bd93f9"
+            inverted: "#282a36"
+            faint: "#6272a4"
+            warning: "#f1fa8c"
+            success: "#50fa7b"
+            error: "#ff5555"
+        background:
+            selected: "#44475a"
+        border:
+            primary: "#6272a4"
+            secondary: "#44475a"
+            faint: "#44475a"
+    ui:
+        sectionsShowCount: true
+        table:
+            showSeparator: true
+            compact: true
+pager:
+    diff: delta
+confirmQuit: false
+showAuthorIcons: false
+smartFilteringAtLaunch: true
+includeReadNotifications: true

--- a/.config/ghostty/theme-dracula.ghostty
+++ b/.config/ghostty/theme-dracula.ghostty
@@ -1,0 +1,4 @@
+# Dracula theme. Selection colours intentionally omitted — Dracula's
+# defaults are well-tuned. Revisit if selections read poorly in practice.
+# Active when ~/.config/ghostty/theme.ghostty → this file (theme-set dracula).
+theme = Dracula

--- a/.config/glow/glamour-dracula.json
+++ b/.config/glow/glamour-dracula.json
@@ -1,0 +1,114 @@
+{
+  "document": {
+    "block_suffix": "\n",
+    "color": "#f8f8f2",
+    "margin": 2
+  },
+  "block_quote": {
+    "indent": 1,
+    "indent_token": "│ ",
+    "color": "#f1fa8c",
+    "italic": true
+  },
+  "paragraph": {},
+  "list": {
+    "level_indent": 2
+  },
+  "heading": {
+    "block_suffix": "\n",
+    "color": "#bd93f9",
+    "bold": true
+  },
+  "h1": {
+    "prefix": "# ",
+    "suffix": "",
+    "color": "#bd93f9",
+    "bold": true
+  },
+  "h2": {
+    "prefix": "## ",
+    "color": "#8be9fd",
+    "bold": true
+  },
+  "h3": {
+    "prefix": "### ",
+    "color": "#50fa7b",
+    "bold": true
+  },
+  "h4": {
+    "prefix": "#### ",
+    "color": "#f1fa8c",
+    "bold": true
+  },
+  "h5": {
+    "prefix": "##### ",
+    "color": "#ff79c6"
+  },
+  "h6": {
+    "prefix": "###### ",
+    "color": "#6272a4"
+  },
+  "text": {},
+  "strikethrough": {
+    "crossed_out": true
+  },
+  "emph": {
+    "italic": true
+  },
+  "strong": {
+    "bold": true
+  },
+  "hr": {
+    "color": "#6272a4",
+    "format": "\n──────\n"
+  },
+  "item": {
+    "block_prefix": "• "
+  },
+  "enumeration": {
+    "block_prefix": ". ",
+    "color": "#8be9fd"
+  },
+  "task": {
+    "ticked": "[✓] ",
+    "unticked": "[ ] "
+  },
+  "link": {
+    "color": "#ff79c6",
+    "underline": true
+  },
+  "link_text": {
+    "color": "#ff79c6",
+    "bold": true
+  },
+  "image": {
+    "color": "#ff79c6",
+    "underline": true
+  },
+  "image_text": {
+    "color": "#ff79c6",
+    "format": "Image: {{.text}} →"
+  },
+  "code": {
+    "prefix": " ",
+    "suffix": " ",
+    "color": "#ffb86c",
+    "background_color": "#282a36"
+  },
+  "code_block": {
+    "margin": 2,
+    "theme": "dracula"
+  },
+  "table": {
+    "center_separator": "│",
+    "column_separator": "│",
+    "row_separator": "─"
+  },
+  "definition_list": {},
+  "definition_term": {},
+  "definition_description": {
+    "indent": 2
+  },
+  "html_block": {},
+  "html_span": {}
+}

--- a/.config/lnav/configs/installed/theme-dracula.json
+++ b/.config/lnav/configs/installed/theme-dracula.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://lnav.org/schemas/config-v1.schema.json",
+  "ui": {
+    "theme": "dracula"
+  }
+}

--- a/.config/nvim/lua/config/theme.lua
+++ b/.config/nvim/lua/config/theme.lua
@@ -2,12 +2,17 @@
 -- decide which colorscheme nvim should load at startup. Returns one of:
 --   "solarized"        (default, when symlink missing or unreadable)
 --   "catppuccin-mocha"
+--   "dracula"
 local M = {}
 
 function M.current()
   local link = vim.uv.fs_readlink(vim.fn.expand("~/.config/themes/current.tmux"))
-  if link and link:match("mocha") then
-    return "catppuccin-mocha"
+  if link then
+    if link:match("mocha") then
+      return "catppuccin-mocha"
+    elseif link:match("dracula") then
+      return "dracula"
+    end
   end
   return "solarized"
 end

--- a/.config/nvim/lua/plugins/colorscheme.lua
+++ b/.config/nvim/lua/plugins/colorscheme.lua
@@ -43,6 +43,22 @@ return {
       end
     end,
   },
+  -- Dracula (new — loaded when theme.lua resolves to dracula).
+  {
+    "Mofiqul/dracula.nvim",
+    name = "dracula",
+    lazy = false,
+    priority = 1000,
+    opts = {
+      italic_comment = true,
+    },
+    config = function(_, opts)
+      require("dracula").setup(opts)
+      if current == "dracula" then
+        vim.cmd.colorscheme("dracula")
+      end
+    end,
+  },
   -- Tell LazyVim which colorscheme to default to (matches our resolver).
   {
     "LazyVim/LazyVim",

--- a/.config/starship-dracula.toml
+++ b/.config/starship-dracula.toml
@@ -1,0 +1,58 @@
+"$schema" = "https://starship.rs/config-schema.json"
+
+palette = "dracula"
+
+format = """$directory[](fg:pastel_rose)
+$character"""
+
+right_format = "$status$cmd_duration"
+
+[palettes.dracula]
+# Dracula palette — see ../themes/dracula.tmux for the same semantic roles
+# expressed as tmux user options. Names mirror the Dracula spec.
+bg           = "#282a36"
+bg_darker    = "#21222c"
+bg_lighter   = "#44475a"
+selection    = "#44475a"
+fg           = "#f8f8f2"
+comment      = "#6272a4"
+red          = "#ff5555"
+orange       = "#ffb86c"
+yellow       = "#f1fa8c"
+green        = "#50fa7b"
+cyan         = "#8be9fd"
+purple       = "#bd93f9"
+pink         = "#ff79c6"
+frame        = "#6272a4"   # comment — muted frame
+# Personal accent — per-theme equivalent of Solarized's #DA627D pastel rose.
+# Dracula canonical "personal" accent is pink.
+pastel_rose = "#ff79c6"
+# Alias so the prompt format below stays portable across themes.
+# base3 here is dark (#282a36 bg) — chip-text inversion for pastel-but-
+# saturated chip bgs (pastel_rose). Matches Mocha's inversion; diverges
+# from Solarized's light-on-saturated.
+base3       = "#282a36"
+
+[directory]
+format = "[ $path ]($style)"
+style  = "fg:base3 bg:pastel_rose"
+truncation_length = 3
+truncation_symbol = "…/"
+
+[character]
+success_symbol = "[❯](bold fg:pastel_rose)"
+error_symbol   = "[❯](bold fg:pastel_rose)"
+vicmd_symbol   = "[❮](bold fg:pastel_rose)"
+
+[cmd_duration]
+min_time = 2000
+format   = "[ $duration]($style) "
+style    = "fg:pastel_rose"
+
+[status]
+disabled = false
+format   = "[✘ $status]($style) "
+style    = "fg:pastel_rose"
+
+[jobs]
+disabled = true

--- a/.config/themes/delta-dracula.gitconfig
+++ b/.config/themes/delta-dracula.gitconfig
@@ -1,0 +1,9 @@
+# Dracula delta config. Active when ~/.config/themes/delta-current.gitconfig
+# symlinks to this file. plus/minus emph hex are hand-derived from Dracula's
+# green (#50fa7b) and red (#ff5555).
+[delta]
+    syntax-theme = Dracula
+    plus-style = "syntax #1e3a14"
+    minus-style = "syntax #3a1414"
+    plus-emph-style = "syntax #2d5a1e"
+    minus-emph-style = "syntax #5a2024"

--- a/.config/themes/dracula.tmux
+++ b/.config/themes/dracula.tmux
@@ -1,0 +1,31 @@
+# Dracula palette — same role keys as solarized.tmux / mocha.tmux, Dracula hex.
+# Designed for dark-on-pastel chip text (Mocha pattern). Dracula has no pure
+# blue accent — @color_accent_blue intentionally reuses the comment hex,
+# which collides with @color_muted_fg. Faithful to Dracula; @color_accent_blue
+# is unused by current tmux pins.
+
+# Bases
+set -g @color_bar_bg          "#282a36"
+set -g @color_deep_bg         "#21222c"
+set -g @color_default_fg      "#f8f8f2"
+set -g @color_muted_fg        "#6272a4"
+# light_fg here is dark (#282a36 bg) — chip-text inversion for Dracula's
+# saturated-but-readable accents (pink/purple/cyan/orange/yellow).
+set -g @color_light_fg        "#282a36"
+
+# Accents
+set -g @color_accent_yellow   "#f1fa8c"
+set -g @color_accent_orange   "#ffb86c"
+set -g @color_accent_red      "#ff5555"
+set -g @color_accent_magenta  "#ff79c6"
+set -g @color_accent_violet   "#bd93f9"
+set -g @color_accent_blue     "#6272a4"
+set -g @color_accent_cyan     "#8be9fd"
+set -g @color_accent_green    "#50fa7b"
+
+# Derived chip values (theme-tuned, not 1:1)
+set -g @color_chip_main_ins_fg "#50fa7b"
+set -g @color_chip_main_del_fg "#ff5555"
+set -g @color_chip_main_neutral_fg "#f8f8f2"
+set -g @color_chip_wt_ins_fg   "#1e3a14"
+set -g @color_chip_wt_del_fg   "#5a1414"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,38 +205,47 @@ Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + fi
 - **Mason-managed LSPs are pinned** via `mason-lock.json` (committed).
   `:MasonLock` snapshots; `:MasonLockUpdate` upgrades then snapshots.
   `lazy-lock.json` and `mason-lock.json` both committed.
-- **Switchable themes — Solarized Dark ↔ Catppuccin Mocha.** Solarized
-  Dark is the canonical default. `theme-set <name>` (fish function in
+- **Switchable themes — Solarized Dark ↔ Catppuccin Mocha ↔ Dracula.**
+  Solarized Dark is the canonical default. `theme-set <name>` (fish function in
   `.config/fish/functions/`) flips active-theme symlinks across the
   hot-path + file-viewer tools. Palette files live in `.config/themes/`
   (mixed-dir: tracked `*.tmux` palettes + tracked `delta-*.gitconfig`;
   machine-local `current.tmux` and `delta-current.gitconfig` symlinks).
   Per-tool variant files use the naming convention `*-solarized.<ext>`
-  / `*-mocha.<ext>` and live alongside their tool's config —
-  `.config/ghostty/theme-{solarized,mocha}.ghostty`,
-  `.config/glow/glamour-{solarized,mocha}.json`,
-  `.config/gh-dash/config-{solarized,mocha}.yml`,
-  `.config/lnav/configs/installed/theme-{solarized,mocha}.json`,
-  `.config/starship-{solarized,mocha}.toml`. The active variant is
+  / `*-mocha.<ext>` / `*-dracula.<ext>` and live alongside their tool's
+  config —
+  `.config/ghostty/theme-{solarized,mocha,dracula}.ghostty`,
+  `.config/glow/glamour-{solarized,mocha,dracula}.json`,
+  `.config/gh-dash/config-{solarized,mocha,dracula}.yml`,
+  `.config/lnav/configs/installed/theme-{solarized,mocha,dracula}.json`,
+  `.config/starship-{solarized,mocha,dracula}.toml`. The active variant is
   picked via a machine-local symlink at the tool's normal config path.
   tmux uses `@color_*` user options (set in the palette file, sourced
   by `tmux.conf` via `source-file -F '#{HOME}/.config/themes/current.tmux'`)
   read by both `tmux.conf` (`#{@color_*}` interpolation) and helper
   scripts (`tmux show-option -gv`, with Solarized hex fallback for the
   test harness path). Bat uses `$BAT_THEME` set as a fish universal
-  var; bat 0.26+ ships Catppuccin Mocha built-in (no vendoring).
+  var; bat 0.26+ ships Catppuccin Mocha and Dracula built-in (no
+  vendoring). Dracula uses dark-on-pastel chip text too
+  (`@color_light_fg = "#282a36"`), matching Mocha's inversion rather
+  than Solarized's light-on-saturated. Dracula has no pure blue
+  accent: `@color_accent_blue` reuses the comment hex `#6272a4`,
+  intentionally colliding with `@color_muted_fg` — Dracula-faithful,
+  and no current tmux pin uses `accent_blue`.
   Delta is included from `~/.gitconfig` via
   `[include] path = ~/.config/themes/delta-current.gitconfig` (one-time
   setup, see README). nvim picks its colorscheme at startup via the
   resolver in `lua/config/theme.lua` (reads `readlink` of
-  `current.tmux`); the `catppuccin/nvim` plugin is installed alongside
-  `maxmx03/solarized.nvim`. Bootstrap's "don't clobber" guards preserve
-  any prior `theme-set mocha` pick across re-runs. Out of v1:
+  `current.tmux`); the `catppuccin/nvim` and `Mofiqul/dracula.nvim`
+  plugins are installed alongside `maxmx03/solarized.nvim`. Bootstrap's
+  "don't clobber" guards preserve any prior `theme-set mocha` or
+  `theme-set dracula` pick across re-runs. Out of v1:
   `btop`/`procs`/`vivid`/`tailspin`/`xh`/`ccstatusline`, cheatsheet
   HTML toggle, screenshot regeneration, live nvim retheme.
 - **Starship pastel accent — per theme.** Solarized keeps the
   `#DA627D` rose; Mocha uses `#f5c2e7` (pink, Catppuccin's canonical
-  "personal" accent). Defined in each starship config's
+  "personal" accent); Dracula uses `#ff79c6` (Dracula pink). Defined
+  in each starship config's
   `[palettes.<name>]` block as `pastel_rose`. Chip is flush-left, ends
   with U+E0B4 rounded right cap; prompt char drops to line 2. Single
   chip because starship silently drops `bg:` when both `fg:` and `bg:`

--- a/README.md
+++ b/README.md
@@ -117,11 +117,12 @@ These drive the `claude[<name>]` window title (tmux's
 
 ## Switching themes
 
-Two themes are wired: **Solarized Dark** (default) and **Catppuccin Mocha**.
+Three themes are wired: **Solarized Dark** (default), **Catppuccin Mocha**, and **Dracula**.
 Swap via the fish function `theme-set`:
 
 ```fish
 theme-set mocha       # switch to Catppuccin Mocha
+theme-set dracula     # switch to Dracula
 theme-set solarized   # switch back
 ```
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -237,9 +237,10 @@ link ".vim/colors"     "$HOME/.vim/colors"
 mkdir -p "$HOME/.vim/undo" "$HOME/.vim/backup" "$HOME/.vim/swap"
 
 # --- starship (prompt; fish opts into transient prompt — see CLAUDE.md)
-# Two variant configs tracked; active one symlinked machine-locally.
+# Three variant configs tracked; active one symlinked machine-locally.
 link ".config/starship-solarized.toml" "$HOME/.config/starship-solarized.toml"
 link ".config/starship-mocha.toml"     "$HOME/.config/starship-mocha.toml"
+link ".config/starship-dracula.toml"   "$HOME/.config/starship-dracula.toml"
 [ -L "$HOME/.config/starship.toml" ] \
     || ln -sfn starship-solarized.toml "$HOME/.config/starship.toml"
 

--- a/scripts/test-theme-switch.sh
+++ b/scripts/test-theme-switch.sh
@@ -49,7 +49,17 @@ assert_link "$HOME/.config/glow/glamour.json"                 "glamour-mocha.jso
 assert_link "$HOME/.config/gh-dash/config.yml"                "config-mocha.yml"         "gh-dash config.yml → config-mocha.yml"
 assert_link "$HOME/.config/lnav/configs/installed/theme.json" "theme-mocha.json"         "lnav theme.json → theme-mocha.json"
 
-# Reverse: mocha → solarized
+# Forward: mocha → dracula
+run_theme_set dracula
+assert_link "$HOME/.config/themes/current.tmux"               "dracula.tmux"               "current.tmux → dracula.tmux"
+assert_link "$HOME/.config/themes/delta-current.gitconfig"    "delta-dracula.gitconfig"    "delta-current.gitconfig → delta-dracula.gitconfig"
+assert_link "$HOME/.config/ghostty/theme.ghostty"             "theme-dracula.ghostty"      "ghostty theme.ghostty → theme-dracula.ghostty"
+assert_link "$HOME/.config/starship.toml"                     "starship-dracula.toml"      "starship.toml → starship-dracula.toml"
+assert_link "$HOME/.config/glow/glamour.json"                 "glamour-dracula.json"       "glow glamour.json → glamour-dracula.json"
+assert_link "$HOME/.config/gh-dash/config.yml"                "config-dracula.yml"         "gh-dash config.yml → config-dracula.yml"
+assert_link "$HOME/.config/lnav/configs/installed/theme.json" "theme-dracula.json"         "lnav theme.json → theme-dracula.json"
+
+# Reverse: dracula → solarized
 run_theme_set solarized
 assert_link "$HOME/.config/themes/current.tmux"               "solarized.tmux"             "current.tmux → solarized.tmux (reverse)"
 assert_link "$HOME/.config/ghostty/theme.ghostty"             "theme-solarized.ghostty"    "ghostty theme.ghostty → theme-solarized.ghostty (reverse)"


### PR DESCRIPTION
Closes #187.

Drop-in extension of the indirection landed in #185 — palette + per-tool variant configs + `theme-set` switch case. Solarized and Mocha variant files stay byte-identical.

## 🎨 Palette decisions

- **Chip text inversion: dark-on-pastel** (`@color_light_fg = "#282a36"`). Matches Mocha's inversion; diverges from the issue's initial hint of Solarized-style light-on-saturated. Dracula's accents read more as pastels than as deep saturated colors in the bar context.
- **Starship `pastel_rose` = `#ff79c6`** (Dracula pink). Per-theme equivalent of Solarized's `#DA627D` rose and Mocha's `#f5c2e7` pink.
- **`muted_fg` = `#6272a4`** (Dracula comment). Canonical Dracula, bluer than Solarized's slate-green.
- **`accent_blue` = `#6272a4`** (also comment) — intentional collision with `muted_fg`. Dracula has no pure blue accent; staying faithful to the palette over synthesizing one. No current tmux pin uses `accent_blue`.

## 📦 Tooling confirmations

- bat 0.26+ ships `Dracula` built-in (case-sensitive).
- Ghostty 1.0+ ships `Dracula` built-in.
- lnav 0.14+ ships `dracula` built-in (lowercase).

No vendoring needed for any of them.

## 🛠 Changeset

**New (7):** `dracula.tmux`, `delta-dracula.gitconfig`, `theme-dracula.ghostty`, `starship-dracula.toml`, `glamour-dracula.json`, `config-dracula.yml` (gh-dash), `theme-dracula.json` (lnav).

**Modified (6):** `theme-set.fish` (new \`case dracula\` + `bat_theme` branch), `colorscheme.lua` (`Mofiqul/dracula.nvim` plugin spec), `theme.lua` (resolver returns `"dracula"` on symlink match), `test-theme-switch.sh` (Solarized → Mocha → Dracula → Solarized round-trip), `CLAUDE.md`, `README.md`.

## ✅ Test plan

- [x] \`scripts/test-theme-switch.sh\` — 17 passed, 0 failed (was 10; +7 Dracula-forward asserts).
- [x] \`scripts/test-fish-loads.sh\` — clean.
- [x] U+E0B4 powerline cap byte verified present in \`starship-dracula.toml\` (the Write tool stripped it on first pass; surgically reinserted by copying from \`starship-mocha.toml\`).
- [ ] **Manual visual check (deferred to post-merge):** \`theme-set dracula\`, then eyeball tmux status chips (yellow/orange/violet/pink — dark text on each), starship prompt, ghostty palette, gh-dash, lnav, delta, glow, and a fresh nvim restart (Lazy installs \`Mofiqul/dracula.nvim\`). Worktree can't run the visual test cleanly because the new variant files aren't yet linked from \`~/.config/...\` — that happens on the next \`bootstrap.sh\` from primary post-merge.

## 🚦 Open / known

- Dracula's bluer `muted_fg` may read differently than Solarized's slate-green on inactive window labels and pane borders — verify legibility live.
- `light_fg = #282a36` (Mocha pattern) is a deliberate choice; if the visual check shows chip text washing out, the alternate is `#f8f8f2` (Solarized pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)