### PR TITLE
🎨 theme-set: fish completion + Ghostty reload hint

### DIFF
--- a/.config/fish/completions/theme-set.fish
+++ b/.config/fish/completions/theme-set.fish
@@ -1,0 +1,3 @@
+complete -c theme-set -f -n 'test (count (commandline -opc)) -eq 1' -a solarized -d 'Solarized Dark (default)'
+complete -c theme-set -f -n 'test (count (commandline -opc)) -eq 1' -a mocha     -d 'Catppuccin Mocha'
+complete -c theme-set -f -n 'test (count (commandline -opc)) -eq 1' -a dracula   -d 'Dracula'

--- a/.config/fish/functions/theme-set.fish
+++ b/.config/fish/functions/theme-set.fish
@@ -38,6 +38,7 @@ function theme-set --description 'Switch colour scheme between solarized, mocha,
     ghostty +reload                           2>/dev/null
 
     echo "theme → $name"
-    echo "  live:    tmux + helpers, ghostty, starship (next prompt), glow, delta"
+    echo "  live:    tmux + helpers, starship (next prompt), glow, delta"
+    echo "  ghostty: cmd+ctrl+shift+r in Ghostty (ghostty +reload was already attempted)"
     echo "  restart: bat (new shells for \$BAT_THEME), nvim, gh-dash, lnav"
 end


### PR DESCRIPTION
## Summary

- 🎨 New `completions/theme-set.fish` — tab-completes `solarized` / `mocha` / `dracula` with one-line descriptions.
- 🔁 `functions/theme-set.fish` output split: Ghostty gets its own line surfacing the `cmd+ctrl+shift+r` keybind as a fallback when the silently-swallowed `ghostty +reload` doesn't catch every window.

## Test plan

- [x] 🐟 `fish -n` syntax-checks pass on both files
- [x] ⌨️ `theme-set <TAB>` lists all three themes with descriptions
- [x] 🖨️ `theme-set solarized` prints the new four-line summary (live / ghostty / restart) with no shell-quoting artifacts
- [x] 👀 Visually confirm theme flip + keybind reload in Ghostty