### PR TITLE
📝 docs: reframe README + CLAUDE.md as multi-theme, multi-font

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # dotfiles — Claude Code instructions
 
-Personal Solarized + JetBrainsMono Nerd Font setup for Ghostty + tmux + vim + fish. Catppuccin Mocha is wired as a switchable alternative — see "Switchable themes" below.
+Personal multi-theme, multi-font setup for Ghostty + tmux + vim + fish. `theme-set` swaps between 4 themes (Solarized Dark / Mocha / Dracula / Gruvbox) and `font-set` between 10 Nerd Fonts; both switch live. Solarized Dark and JetBrains Mono are the bootstrap defaults. See "Switchable themes" and "Switchable Ghostty fonts" below.
 
 ## Conventions — don't drift from these
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotfiles
 
-Personal config for Ghostty + fish + tmux + vim, all in Solarized + JetBrainsMono Nerd Font.
+Personal config for Ghostty + fish + tmux + vim — multi-theme (Solarized Dark / Mocha / Dracula / Gruvbox via `theme-set`) and multi-font (10 Nerd Fonts via `font-set`). Solarized Dark and JetBrains Mono are the defaults.
 
 <p align="center">
   <a href="docs/images/example_terminal.png"><img src="docs/images/example_terminal-thumb.png" alt="terminal" width="32%" /></a>


### PR DESCRIPTION
## Summary

- 📝 Replace the "Solarized + JetBrainsMono Nerd Font" headline framing in `README.md` and `CLAUDE.md` — the repo now ships 4 themes (Solarized Dark / Mocha / Dracula / Gruvbox via `theme-set`) and 10 Nerd Fonts (via `font-set`), all live-switchable.
- 🎯 Both defaults stay called out — Solarized Dark and JetBrains Mono are still what bootstrap seeds — but they live inside their respective switcher lists rather than being framed as the only option.

## Test plan

- [x] 👀 Headline lines read accurately against current `theme-set` / `font-set` content
- [x] 📐 Switchers' default-vs-alternate phrasing matches: defaults named explicitly, alternates not implied to be the only options

🔍 No code changes; docs-only.