### PR TITLE
👻 theme-set/font-set: actually reload Ghostty via System Events

### DIFF
--- a/.config/fish/functions/__ghostty_reload.fish
+++ b/.config/fish/functions/__ghostty_reload.fish
@@ -1,0 +1,16 @@
+function __ghostty_reload \
+        --description 'Trigger Ghostty config reload via System Events when Ghostty is frontmost; echo a status line'
+    # Ghostty has no CLI reload action — the only path is the per-surface
+    # `reload_config` keybind (cmd+ctrl+shift+r in this config). We
+    # synthesize that keystroke via System Events, which routes to the
+    # frontmost app. Skip when Ghostty isn't frontmost so we don't
+    # inject the keystroke into a different app. First call may prompt
+    # for Accessibility permission on the terminal hosting fish.
+    set -l frontmost (osascript -e 'tell application "System Events" to get name of first application process whose frontmost is true' 2>/dev/null)
+    if test (string lower -- $frontmost) = ghostty
+        osascript -e 'tell application "System Events" to keystroke "r" using {command down, control down, shift down}' 2>/dev/null
+        echo "cmd+ctrl+shift+r sent to focused window (other windows: manual)"
+    else
+        echo "hit cmd+ctrl+shift+r per window (frontmost is $frontmost, not Ghostty)"
+    end
+end

--- a/.config/fish/functions/font-set.fish
+++ b/.config/fish/functions/font-set.fish
@@ -37,11 +37,9 @@ function font-set --description 'Switch Ghostty font (and optionally weight, siz
     # Flip family symlink. -sfn replaces the link atomically.
     ln -sfn font-$name.ghostty ~/.config/ghostty/font.ghostty
 
-    # Live reload. Swallowed silently because ghostty may not be running.
-    ghostty +reload 2>/dev/null
-
     set -l msg "font → $name"
     set -q argv[2]; and test -n "$weight"; and set msg "$msg (weight $weight)"
     set -q argv[3]; and test -n "$size";   and set msg "$msg (size $size)"
     echo $msg
+    echo "  ghostty: "(__ghostty_reload)
 end

--- a/.config/fish/functions/theme-set.fish
+++ b/.config/fish/functions/theme-set.fish
@@ -43,14 +43,12 @@ function theme-set --description 'Switch colour scheme between solarized, mocha,
     set -Ux BAT_THEME $bat_theme
     set -Ux VIVID_THEME $vivid_theme
 
-    # Live reloads. All swallowed silently because the tool may not be
-    # running (e.g. ghostty in a different session, no tmux server yet).
+    # tmux: re-source config + force status redraw (silent if no server).
     tmux source-file ~/.config/tmux/tmux.conf 2>/dev/null
     tmux refresh-client -S                    2>/dev/null
-    ghostty +reload                           2>/dev/null
 
     echo "theme → $name"
     echo "  live:    tmux + helpers, starship (next prompt), glow, delta"
-    echo "  ghostty: cmd+ctrl+shift+r in Ghostty (ghostty +reload was already attempted)"
+    echo "  ghostty: "(__ghostty_reload)
     echo "  restart: bat + ls colors (new shells for \$BAT_THEME / \$VIVID_THEME), nvim, gh-dash, lnav"
 end


### PR DESCRIPTION
## Summary

- 👻 Drop the bogus `ghostty +reload` calls in both `theme-set` and `font-set` — that's not a valid Ghostty action (see `ghostty +help`); the command was always returning exit 1 and `2>/dev/null` hid the failure. The output's "ghostty +reload was already attempted" was a lie.
- 🆕 New shared helper `__ghostty_reload.fish` synthesizes Ghostty's `reload_config` keybind (`cmd+ctrl+shift+r`) via System Events / osascript when Ghostty is the frontmost app. When it's not, the helper just tells the user to do it manually (otherwise the keystroke would route to whatever app *is* frontmost).
- 🪪 First call may prompt for macOS Accessibility permission on the terminal hosting fish.
- 🔁 Both `theme-set` and `font-set` now emit an honest `ghostty:` status line covering both branches (sent vs. manual).

## Test plan

- [x] 🐟 `fish -n` clean on the new helper + both updated functions
- [x] 🎨 `theme-set solarized` from a Ghostty window: status line reads `cmd+ctrl+shift+r sent to focused window …`
- [x] 🔤 `font-set jetbrains` same path, same status line
- [x] 🔍 `osascript ... frontmost` returns lowercase `ghostty` on this Ghostty build — case-insensitive compare via `string lower` covers it
- [ ] 👀 Visually confirm Ghostty actually reloads after the synthesized keystroke (Accessibility permission granted)
- [ ] 🪤 Run from a non-Ghostty frontmost app (e.g. Safari focused while terminal in background) and confirm the message falls back to the manual hint

## Why this matters

Without this, swapping theme or font required two steps: run the fish function, then manually focus Ghostty and hit `cmd+ctrl+shift+r`. Now step 2 happens automatically for the focused window when Ghostty is already up front — which it almost always is when you run these.