### PR TITLE
📜 tmux: unprefixed PageUp enters copy-mode scrollback

### DIFF
--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -86,6 +86,11 @@ bind l select-pane -R
 # ─── Reload ─────────────────────────────────
 bind r source-file ~/.config/tmux/tmux.conf \; display "config reloaded"
 
+# ─── Copy mode: PageUp drops into scrollback ───
+# Unprefixed PageUp enters copy-mode and scrolls one page back, so reading
+# scrollback feels like a normal pager. `q` exits back to the live pane.
+bind -n PageUp copy-mode -u
+
 # ─── PR pin: open in browser ────────────────
 # `<prefix> P` opens the current branch's PR in the default browser via
 # `gh pr view --web`. When no PR exists, gh exits non-zero and run-shell


### PR DESCRIPTION
## 📋 Summary

- Adds `bind -n PageUp copy-mode -u` in `.config/tmux/tmux.conf` so the **PageUp** key at the shell prompt drops into copy-mode and scrolls back one page — scrollback now reads like a normal pager.
- `q` exits copy-mode back to the live pane (vi copy-mode default, unchanged).
- TUIs that consume PageUp themselves (vim, less, btop, glow's pager, lnav) keep owning the keystroke — `-n` bindings only fire when tmux itself receives the key, so there's no regression inside pagers/editors.

## ✅ Test plan

- [x] `tmux source-file ~/.config/tmux/tmux.conf` succeeds (reloaded live).
- [ ] At a shell prompt, **PgUp** enters copy-mode and scrolls back one page; **PgUp** again scrolls another page; **q** exits to live pane.
- [ ] Inside `vim`/`nvim`, **PgUp** still scrolls the buffer (tmux does not intercept).
- [ ] Inside `less` / bat-as-less, **PgUp** still pages backward (tmux does not intercept).
- [ ] No conflict with existing `-n`-prefix bindings (only Dashboard `<prefix> J/K` use `bind-key -N`, both with prefix — unaffected).

## 🎯 Why

Currently scrollback requires `<prefix> [` then PgUp — three keystrokes for an action that's a single key on every other pager. Reading recent command output is the most common copy-mode entry, and the muscle memory mismatch was the friction. `-n` (no-prefix) is safe here because the binding is positionally inert when a TUI is foreground.