### PR TITLE
📋 gh-dash: default to issues view on launch

### DIFF
--- a/.config/gh-dash/config-base.yml
+++ b/.config/gh-dash/config-base.yml
@@ -34,7 +34,7 @@ defaults:
     prApproveComment: LGTM
     issuesLimit: 20
     notificationsLimit: 20
-    view: prs
+    view: issues
     layout:
         prs:
             updatedAt:


### PR DESCRIPTION
## 🎯 Summary

- 🔀 Flip `defaults.view` from `prs` → `issues` in `.config/gh-dash/config-base.yml`. `gh dash` opens on the issues view from now on.

## 🧠 Why

Issues are the higher-attention surface in this dotfiles workflow — PRs typically get opened from Claude Code / the CLI and tracked through `gh pr view`/notifications, while the issues view is where active triage lives (`Open` and `v0.1.0` sections landed in #204).

## ✅ Test plan

- [x] `theme-set <current>` regenerates `~/.config/gh-dash/config.yml` and the resulting `view:` line reads `issues`.
- [ ] Open `gh dash` and confirm it lands on the issues view by default; `s`/`S` still cycles through PRs and notifications.

## 📦 Migration

None on disk. Re-run `theme-set <name>` (or the next `bootstrap.sh` on a fresh machine) regenerates the live `config.yml` to pick up the new default.