### PR TITLE
🧪 theme-set test: skip live Ghostty reload via FISH_DOTFILES_TEST

### DIFF
--- a/.config/fish/functions/__ghostty_reload.fish
+++ b/.config/fish/functions/__ghostty_reload.fish
@@ -6,6 +6,10 @@ function __ghostty_reload \
     # frontmost app. Skip when Ghostty isn't frontmost so we don't
     # inject the keystroke into a different app. First call may prompt
     # for Accessibility permission on the terminal hosting fish.
+    if set -q FISH_DOTFILES_TEST
+        echo "skipped (FISH_DOTFILES_TEST set)"
+        return
+    end
     set -l frontmost (osascript -e 'tell application "System Events" to get name of first application process whose frontmost is true' 2>/dev/null)
     if test (string lower -- $frontmost) = ghostty
         osascript -e 'tell application "System Events" to keystroke "r" using {command down, control down, shift down}' 2>/dev/null

--- a/scripts/test-theme-switch.sh
+++ b/scripts/test-theme-switch.sh
@@ -61,6 +61,11 @@ assert_gh_dash_config() {
 REPO="${REPO:-$PROJECTS_HOME/dotfiles}"
 THEME_SET_FN="$REPO/.config/fish/functions/theme-set.fish"
 
+# Suppress the live Ghostty reload (`__ghostty_reload`) — the test runs from
+# a Ghostty window, so without this every theme-set call fires
+# cmd+ctrl+shift+r at the user's real session.
+export FISH_DOTFILES_TEST=1
+
 run_theme_set() {
     # Source the function from the repo so the test works regardless of
     # whether ~/.config/fish/functions/theme-set.fish has been wired yet


### PR DESCRIPTION
## 🐛 Problem

Running `scripts/test-theme-switch.sh` from a Ghostty window hijacked the
user's live session: the test calls `theme-set` six times, each of which
called `__ghostty_reload` and synthesised `cmd+ctrl+shift+r` against the
frontmost app via System Events. Since the test itself ran inside Ghostty,
Ghostty was always frontmost, and every theme flip triggered a real
config reload on the active window.

## 🔧 Fix

Reuse the existing `FISH_DOTFILES_TEST` convention (already used by
`.config/fish/conf.d/50-tmux-hooks.fish` to suppress a tmux side-effect
during tests):

- `__ghostty_reload.fish`: early-return + status echo when
  `FISH_DOTFILES_TEST` is set, before the `osascript` calls.
- `test-theme-switch.sh`: export `FISH_DOTFILES_TEST=1` once before
  the `run_theme_set` calls.

The guard lives in the shared helper, so a future `font-set` test (which
also calls `__ghostty_reload`) inherits it for free.

## ✅ Test plan

- [x] 🧪 `scripts/test-theme-switch.sh` — 31 passed, 0 failed
- [x] 👀 Manual: ran the test from a Ghostty window; no live reload fired,
  no AppleScript Accessibility prompt
- [x] ↩️ Theme restored to starting state at the end (existing `start_theme`
  capture in the test)

## 🧠 Notes

- Ghostty has no OSC sequence or CLI action for config reload — the only
  triggers are the per-surface `reload_config` keybind and external UI
  automation. So suppressing the helper is the only clean way to keep
  tests from touching the live window.
- The new `skipped (FISH_DOTFILES_TEST set)` status line is what the
  test logs in place of the AppleScript output — visible if anyone runs
  the test with verbose stdout.