### PR TITLE
🔡 font-set: add 7 more Nerd Fonts (departure, bigblue, 0xproto, 3270, hurmit, monofur, dyslexic)

### DIFF
--- a/.config/fish/completions/font-set.fish
+++ b/.config/fish/completions/font-set.fish
@@ -9,6 +9,13 @@ complete -c font-set -f -n 'test (count (commandline -opc)) -eq 1' -a meslo     
 complete -c font-set -f -n 'test (count (commandline -opc)) -eq 1' -a sauce       -d 'SauceCodePro / Source Code Pro (no ligatures)'
 complete -c font-set -f -n 'test (count (commandline -opc)) -eq 1' -a ubuntu      -d 'UbuntuMono (no ligatures)'
 complete -c font-set -f -n 'test (count (commandline -opc)) -eq 1' -a inconsolata -d 'Inconsolata (no ligatures)'
+complete -c font-set -f -n 'test (count (commandline -opc)) -eq 1' -a departure   -d 'DepartureMono (pixel display; no ligatures)'
+complete -c font-set -f -n 'test (count (commandline -opc)) -eq 1' -a bigblue     -d 'BigBlueTermPlus (IBM CP437 pixel bitmap)'
+complete -c font-set -f -n 'test (count (commandline -opc)) -eq 1' -a 0xproto     -d '0xProto (ligatures)'
+complete -c font-set -f -n 'test (count (commandline -opc)) -eq 1' -a 3270        -d '3270 (IBM mainframe terminal; tall, narrow)'
+complete -c font-set -f -n 'test (count (commandline -opc)) -eq 1' -a hurmit      -d 'Hurmit / Hermit (minimalist humanist; no ligatures)'
+complete -c font-set -f -n 'test (count (commandline -opc)) -eq 1' -a monofur     -d 'Monofur (hand-drawn curves; no ligatures)'
+complete -c font-set -f -n 'test (count (commandline -opc)) -eq 1' -a dyslexic    -d 'OpenDyslexicM (weighted bottoms; dyslexia-aware)'
 
 # 2nd positional: weight — depends on font picked in arg 1.
 complete -c font-set -f -n 'test (count (commandline -opc)) -eq 2' \

--- a/.config/fish/functions/__font_set_weights_for.fish
+++ b/.config/fish/functions/__font_set_weights_for.fish
@@ -18,5 +18,12 @@ function __font_set_weights_for --argument-names name \
             printf '%s\n' ExtraLight Light Regular Medium SemiBold Bold Black
         case hack meslo ubuntu inconsolata
             printf '%s\n' Regular Bold
+        case hurmit
+            printf '%s\n' Light Regular Bold
+        case 0xproto monofur
+            printf '%s\n' Regular Bold
+        case departure bigblue 3270 dyslexic
+            # Nerd Fonts ships only Regular for these — no weight choices.
+            printf '%s\n' Regular
     end
 end

--- a/.config/fish/functions/font-set.fish
+++ b/.config/fish/functions/font-set.fish
@@ -4,11 +4,13 @@ function font-set --description 'Switch Ghostty font (and optionally weight, siz
     set -l size $argv[3]
     switch $name
         case jetbrains fira cascadia monaspace iosevka \
-             hack meslo sauce ubuntu inconsolata
+             hack meslo sauce ubuntu inconsolata \
+             departure bigblue 0xproto 3270 hurmit monofur dyslexic
             # OK
         case '*'
             echo "Usage: font-set <name> [<weight>] [<size>]" >&2
             echo "  name:   jetbrains|fira|cascadia|monaspace|iosevka|hack|meslo|sauce|ubuntu|inconsolata" >&2
+            echo "          departure|bigblue|0xproto|3270|hurmit|monofur|dyslexic" >&2
             echo "  weight: per-font style name (Tab to discover); omit to keep current weight" >&2
             echo "  size:   positive number; omit to keep current size" >&2
             return 1

--- a/.config/ghostty/font-0xproto.ghostty
+++ b/.config/ghostty/font-0xproto.ghostty
@@ -1,0 +1,3 @@
+# 0xProto Nerd Font — 0xType's programming-focused face, with ligatures.
+# Active when ~/.config/ghostty/font.ghostty → this file (font-set 0xproto).
+font-family = 0xProto Nerd Font Mono

--- a/.config/ghostty/font-3270.ghostty
+++ b/.config/ghostty/font-3270.ghostty
@@ -1,0 +1,5 @@
+# 3270 Nerd Font — IBM 3270 mainframe terminal font; tall, narrow.
+# Cond / SemCond width variants ship as separate families and are not
+# wired up here — flip to them by hand if needed.
+# Active when ~/.config/ghostty/font.ghostty → this file (font-set 3270).
+font-family = 3270 Nerd Font Mono

--- a/.config/ghostty/font-bigblue.ghostty
+++ b/.config/ghostty/font-bigblue.ghostty
@@ -1,0 +1,5 @@
+# BigBlueTermPlus Nerd Font — IBM PC OEM CP437 pixel bitmap (Plus variant
+# has broader Unicode coverage than the 437 variant; both ship in the
+# same cask). Classic DOS/BIOS look.
+# Active when ~/.config/ghostty/font.ghostty → this file (font-set bigblue).
+font-family = BigBlueTermPlus Nerd Font Mono

--- a/.config/ghostty/font-departure.ghostty
+++ b/.config/ghostty/font-departure.ghostty
@@ -1,0 +1,3 @@
+# Departure Mono Nerd Font — Helena Zhang's 2024 pixel display monospace.
+# Active when ~/.config/ghostty/font.ghostty → this file (font-set departure).
+font-family = DepartureMono Nerd Font Mono

--- a/.config/ghostty/font-dyslexic.ghostty
+++ b/.config/ghostty/font-dyslexic.ghostty
@@ -1,0 +1,5 @@
+# OpenDyslexic Nerd Font — Mono variant (the cask also ships "Alt" with
+# more weights, but the Mono family is what's needed for a terminal grid).
+# Weighted-bottom glyphs are designed to aid dyslexic readers.
+# Active when ~/.config/ghostty/font.ghostty → this file (font-set dyslexic).
+font-family = OpenDyslexicM Nerd Font Mono

--- a/.config/ghostty/font-hurmit.ghostty
+++ b/.config/ghostty/font-hurmit.ghostty
@@ -1,0 +1,4 @@
+# Hurmit Nerd Font — minimalist humanist monospace (Nerd Fonts rename of
+# "Hermit" by Pablo Caro). No ligatures.
+# Active when ~/.config/ghostty/font.ghostty → this file (font-set hurmit).
+font-family = Hurmit Nerd Font Mono

--- a/.config/ghostty/font-monofur.ghostty
+++ b/.config/ghostty/font-monofur.ghostty
@@ -1,0 +1,4 @@
+# Monofur Nerd Font — quirky hand-drawn curves by Tobias Kemmer.
+# No ligatures.
+# Active when ~/.config/ghostty/font.ghostty → this file (font-set monofur).
+font-family = Monofur Nerd Font Mono

--- a/Brewfile
+++ b/Brewfile
@@ -70,3 +70,10 @@ cask "font-meslo-lg-nerd-font"        # Powerlevel10k's recommended default
 cask "font-sauce-code-pro-nerd-font"  # Adobe Source Code Pro (Nerd Fonts rename: SauceCodePro)
 cask "font-ubuntu-mono-nerd-font"     # Canonical's monospace; distinctive curves
 cask "font-inconsolata-nerd-font"     # Raph Levien's humanist classic
+cask "font-departure-mono-nerd-font"  # Helena Zhang's pixel display monospace (2024); retro CRT vibe
+cask "font-bigblue-terminal-nerd-font" # IBM PC OEM CP437 pixel bitmap; classic DOS/BIOS look
+cask "font-0xproto-nerd-font"         # 0xType's "0xProto" — designed for programming, with ligatures
+cask "font-3270-nerd-font"            # IBM 3270 mainframe terminal font; tall, narrow, archival
+cask "font-hurmit-nerd-font"          # Hermit (Nerd Fonts ships as "Hurmit"); minimalist humanist
+cask "font-monofur-nerd-font"         # Monofur — quirky, hand-drawn curves, no ligatures
+cask "font-opendyslexic-nerd-font"    # OpenDyslexic — weighted bottoms; aids dyslexic readers

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # dotfiles — Claude Code instructions
 
-Personal multi-theme, multi-font setup for Ghostty + tmux + vim + fish. `theme-set` swaps between 5 themes (Solarized Dark / Mocha / Dracula / Gruvbox / Tokyo Night Storm) and `font-set` between 10 Nerd Fonts; both switch live. Solarized Dark and JetBrains Mono are the bootstrap defaults. See "Switchable themes" and "Switchable Ghostty fonts" below.
+Personal multi-theme, multi-font setup for Ghostty + tmux + vim + fish. `theme-set` swaps between 5 themes (Solarized Dark / Mocha / Dracula / Gruvbox / Tokyo Night Storm) and `font-set` between 17 Nerd Fonts; both switch live. Solarized Dark and JetBrains Mono are the bootstrap defaults. See "Switchable themes" and "Switchable Ghostty fonts" below.
 
 ## Conventions — don't drift from these
 
@@ -284,13 +284,21 @@ Personal multi-theme, multi-font setup for Ghostty + tmux + vim + fish. `theme-s
   tokyo-night` pick across re-runs. Out of v1:
   `btop`/`procs`/`tailspin`/`xh`/`ccstatusline`, cheatsheet
   HTML toggle, screenshot regeneration, live nvim retheme.
-- **Switchable Ghostty fonts — 10 Nerd Fonts, optional weight + size.**
-  JetBrains Mono is the default. Five with ligatures: `jetbrains`,
+- **Switchable Ghostty fonts — 17 Nerd Fonts, optional weight + size.**
+  JetBrains Mono is the default. Six with ligatures: `jetbrains`,
   `fira`, `cascadia` (ships as `CaskaydiaCove`), `monaspace` (Neon
-  variant, ships as `Monaspice`), `iosevka`. Five classics, no
-  ligatures: `hack`, `meslo` (MesloLGS, Powerlevel10k's default),
-  `sauce` (Source Code Pro, ships as `SauceCodePro`), `ubuntu`
-  (UbuntuMono), `inconsolata`. `font-set <name> [<weight>] [<size>]`
+  variant, ships as `Monaspice`), `iosevka`, `0xproto`. Five
+  classics, no ligatures: `hack`, `meslo` (MesloLGS, Powerlevel10k's
+  default), `sauce` (Source Code Pro, ships as `SauceCodePro`),
+  `ubuntu` (UbuntuMono), `inconsolata`. Six retro / specialty, no
+  ligatures: `departure` (DepartureMono, 2024 pixel display),
+  `bigblue` (BigBlueTermPlus, IBM CP437 pixel bitmap), `3270` (IBM
+  3270 mainframe terminal; Cond/SemCond width variants ship but
+  aren't wired up — flip by hand if needed), `hurmit` (Hermit,
+  Nerd Fonts rename), `monofur` (hand-drawn curves), `dyslexic`
+  (OpenDyslexicM — weighted-bottom glyphs for dyslexic readers; the
+  cask also ships an "Alt" family with more weights, only Mono is
+  wired up). `font-set <name> [<weight>] [<size>]`
   (fish function) flips a machine-local symlink
   `~/.config/ghostty/font.ghostty` → one of the per-font include files
   (each a one-liner `font-family = ...`). When `<weight>` is given
@@ -304,7 +312,7 @@ Personal multi-theme, multi-font setup for Ghostty + tmux + vim + fish. `theme-s
   because it changes more often than size in practice.
   `config.ghostty` pulls family + size + weight via three `config-file
   = ...` directives; `font-thicken` stays there (shared across fonts).
-  `ghostty +reload` fires live. All ten casks are pinned in `Brewfile`.
+  `ghostty +reload` fires live. All seventeen casks are pinned in `Brewfile`.
   Bootstrap seeds `font-size.ghostty` at `font-size = 14` and
   `font-weight.ghostty` as a comment-only file (so Ghostty falls back
   to each font's own Regular) on first run; "don't clobber" guards
@@ -312,11 +320,13 @@ Personal multi-theme, multi-font setup for Ghostty + tmux + vim + fish. `theme-s
   lists live in the fish helper `__font_set_weights_for.fish` (sourced
   by both validation and 3rd-arg completion), populated from
   `ghostty +list-fonts` — FiraCode is the odd one out, advertising
-  abbreviated style names (`Reg`, `Med`, `SemBd`, `Ret`). Add a new
-  font: drop a new `font-<short>.ghostty` next to the others, append
-  the cask to `Brewfile`, extend the `switch` in `font-set.fish` + its
-  1st-arg completion + `__font_set_weights_for`. No nvim/tmux/bat
-  coupling — font is a Ghostty-only concern.
+  abbreviated style names (`Reg`, `Med`, `SemBd`, `Ret`); the four
+  single-weight fonts (`departure`, `bigblue`, `3270`, `dyslexic`)
+  advertise `Regular` only, so the weight arg is effectively cosmetic
+  for them. Add a new font: drop a new `font-<short>.ghostty` next to
+  the others, append the cask to `Brewfile`, extend the `switch` in
+  `font-set.fish` + its 1st-arg completion + `__font_set_weights_for`.
+  No nvim/tmux/bat coupling — font is a Ghostty-only concern.
 - **Starship pastel accent — per theme.** Solarized keeps the
   `#DA627D` rose; Mocha uses `#f5c2e7` (pink, Catppuccin's canonical
   "personal" accent); Dracula uses `#ff79c6` (Dracula pink). Defined

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotfiles
 
-Personal config for Ghostty + fish + tmux + vim — multi-theme (Solarized Dark / Mocha / Dracula / Gruvbox / Tokyo Night Storm via `theme-set`) and multi-font (10 Nerd Fonts via `font-set`). Solarized Dark and JetBrains Mono are the defaults.
+Personal config for Ghostty + fish + tmux + vim — multi-theme (Solarized Dark / Mocha / Dracula / Gruvbox / Tokyo Night Storm via `theme-set`) and multi-font (17 Nerd Fonts via `font-set`). Solarized Dark and JetBrains Mono are the defaults.
 
 <p align="center">
   <a href="docs/images/example_terminal.png"><img src="docs/images/example_terminal-thumb.png" alt="terminal" width="32%" /></a>


### PR DESCRIPTION
## ✨ Summary

Brings the switchable font roster from **10 → 17** Nerd Fonts. New shorts wired into `font-set`:

| Short | Family (Ghostty Mono) | Vibe |
|-------|----------------------|------|
| `departure` | `DepartureMono Nerd Font Mono`   | 2024 pixel display monospace; retro CRT |
| `bigblue`   | `BigBlueTermPlus Nerd Font Mono` | IBM CP437 pixel bitmap; DOS/BIOS look |
| `0xproto`   | `0xProto Nerd Font Mono`          | Programming face, ligatures |
| `3270`      | `3270 Nerd Font Mono`             | IBM mainframe terminal; tall, narrow |
| `hurmit`    | `Hurmit Nerd Font Mono`           | Minimalist humanist (Nerd Fonts rename of Hermit) |
| `monofur`   | `Monofur Nerd Font Mono`          | Hand-drawn curves |
| `dyslexic`  | `OpenDyslexicM Nerd Font Mono`    | Weighted-bottom glyphs for dyslexic readers |

## 🛠️ What changed

- ➕ **Brewfile** — 7 new `cask "font-…-nerd-font"` lines
- ➕ **.config/ghostty/font-`<short>`.ghostty** — 7 new one-liner include files, mirroring the existing convention
- 🔁 **font-set.fish** — `case` switch + usage string extended
- 🔁 **__font_set_weights_for.fish** — per-font style lists populated from `ghostty +list-fonts`
- 🔁 **font-set completion** — 7 new 1st-arg entries with short descriptions
- 📝 **CLAUDE.md** — "10 Nerd Fonts" → "17 Nerd Fonts", ligature/classic split rewritten to (6 ligature / 5 classic / 6 retro-specialty), all-ten-casks note bumped to seventeen, added a note that four of the new fonts advertise Regular only
- 📝 **README.md** — intro count bumped 10 → 17

## 🎚️ Weight discovery

Populated from `ghostty +list-fonts` after the brew install. Notable:

- **Hurmit** advertises `Light`, `Regular`, `Bold` (italics handled by Ghostty separately).
- **0xProto** and **Monofur** advertise `Regular`, `Bold` only.
- **Departure**, **BigBlueTermPlus**, **3270**, and **OpenDyslexicM** advertise `Regular` only — weight arg is effectively cosmetic for them.

## ✅ Test plan

- [x] 🧪 `brew bundle --file=Brewfile` — 7 new fonts installed cleanly
- [x] 🧪 `font-set <short>` for each of 7 new shorts — symlink flips to the expected `font-<short>.ghostty`
- [x] 🧪 Weight validation: `font-set hurmit Light` accepted; `font-set 3270 Light` rejected with `valid: Regular` message
- [x] 🧪 `scripts/test-fish-loads.sh` — fish config loads clean
- [x] 👀 Used `FISH_DOTFILES_TEST=1` (from #206) to keep the live Ghostty window untouched during smoke runs
- [x] ↩️ Active font restored to the starting selection at the end of testing

## ⚠️ Notes / non-goals

- 3270's `Cond` and `SemCond` width variants ship in the cask but are not wired up here — flip by hand with a custom include if needed.
- OpenDyslexic's `Alt` family (4 weights) is also installed but not wired — the Mono variant is what makes sense for a terminal grid.
- BigBlueTerm has two variants in the same cask: I picked `Plus` over `437` for broader Unicode coverage.