### PR TITLE
🤫 theme-set/font-set: drop the printed 'ghostty: …' how-to line

### DIFF
--- a/.config/fish/functions/font-set.fish
+++ b/.config/fish/functions/font-set.fish
@@ -41,5 +41,9 @@ function font-set --description 'Switch Ghostty font (and optionally weight, siz
     set -q argv[2]; and test -n "$weight"; and set msg "$msg (weight $weight)"
     set -q argv[3]; and test -n "$size";   and set msg "$msg (size $size)"
     echo $msg
-    echo "  ghostty: "(__ghostty_reload)
+
+    # Fire the ghostty config reload (cmd+ctrl+shift+r via System Events when
+    # Ghostty is frontmost). Discard the helper's info line — the reload still
+    # happens as a side effect; the printed "how to" was just noise.
+    __ghostty_reload >/dev/null
 end

--- a/.config/fish/functions/theme-set.fish
+++ b/.config/fish/functions/theme-set.fish
@@ -61,6 +61,10 @@ function theme-set --description 'Switch colour scheme between solarized, mocha,
 
     echo "theme → $name"
     echo "  live:    tmux + helpers, starship (next prompt), glow, delta"
-    echo "  ghostty: "(__ghostty_reload)
     echo "  restart: bat + ls colors (new shells for \$BAT_THEME / \$VIVID_THEME), nvim, gh-dash, lnav"
+
+    # Fire the ghostty config reload (cmd+ctrl+shift+r via System Events when
+    # Ghostty is frontmost). Discard the helper's info line — the reload still
+    # happens as a side effect; the printed "how to" was just noise.
+    __ghostty_reload >/dev/null
 end


### PR DESCRIPTION
## ✨ Summary

Every `theme-set` / `font-set` invocation printed a trailing
`ghostty: …` line that was either a confirmation
(`cmd+ctrl+shift+r sent to focused window …`) or a manual-action
hint (`hit cmd+ctrl+shift+r per window (frontmost is X, not Ghostty)`).
Drop that echo.

The **reload itself stays.** Both commands still call
`__ghostty_reload` for its side effect (the AppleScript keystroke when
Ghostty is frontmost); stdout is just routed to `/dev/null`.

## 🛠️ What changed

- 🔁 `.config/fish/functions/theme-set.fish` — replace
  `echo "  ghostty: "(__ghostty_reload)` with `__ghostty_reload >/dev/null`
- 🔁 `.config/fish/functions/font-set.fish` — same swap

`__ghostty_reload.fish` is kept as-is — its echo is useful when invoked
directly from the shell.

## 🧭 Behaviour matrix (unchanged for the reload action)

| State | Outcome |
|-------|---------|
| Ghostty frontmost | `cmd+ctrl+shift+r` keystroke sent → live reload |
| Ghostty backgrounded | No-op (helper bails, as before) |
| `FISH_DOTFILES_TEST=1` | Early return (the #206 guard) |

## ✅ Test plan

- [x] 🧪 `scripts/test-theme-switch.sh` — 31 passed, 0 failed
- [x] 👀 Manual: `theme-set mocha` / `theme-set solarized` prints only
  the `theme → …`, `live: …`, `restart: …` triple — no `ghostty:` line
- [x] ↩️ Restored to the starting theme after testing