### PR TITLE
install(ccstatusline): via mise, document settings.json swap

### DIFF
--- a/mise.global.toml
+++ b/mise.global.toml
@@ -2,6 +2,7 @@
 node = "lts"
 ruby = "3.4.8"
 "npm:@mermaid-js/mermaid-cli" = "latest"
+"npm:ccstatusline" = "latest"
 
 [settings]
 legacy_version_file = true


### PR DESCRIPTION
Closes #209

## What

Installs ccstatusline globally via mise instead of `npx -y ccstatusline@latest`.
Matches the existing mmdc pattern.

## Changes

- `mise.global.toml`: added `"npm:ccstatusline" = "latest"`

bootstrap.sh already runs `mise install` (line 248) so ccstatusline is picked up
automatically post-merge — no bootstrap change needed.

## Post-merge manual steps (this machine)

1. `mise install`
2. Edit `~/.claude/settings.json` — swap the three `npx -y ccstatusline@latest`
   commands to `ccstatusline` / `ccstatusline --hook`:
   - `hooks.PreToolUse[0].hooks[0].command`
   - `hooks.UserPromptSubmit[0].hooks[0].command`
   - `statusLine.command`
3. Restart Claude Code

## Test plan

- [ ] `mise install` succeeds and `command -v ccstatusline` resolves
- [ ] Claude Code hooks render the status line without npx errors
- [ ] `ccstatusline --version` prints the version

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Session stats

| | |
|---|---|
| **Start** | 2026-05-13 05:20 UTC |
| **End** | 2026-05-13 06:45 UTC |
| **Elapsed** | 1h 24m |
| **Working** | 26m 19s (31% of elapsed) |
| **Total billed tokens** | 31.4M |
| **Total cost (USD, public rates)** | $83.63 |
| **Effective rate** | $190.61/hr |

| Model | Messages | Input | Output | Cache Read | Cache Write 1h | Cost |
|---|---|---|---|---|---|---|
| Opus 4.7 | 232 | 14.9k | 239k | 30.5M | 656k | $83.63 |

> Public-rate estimate. Cost is computed against published Anthropic API prices
> which change. Claude Max/Pro/Team/Enterprise plans bundle usage — your incremental
> cost may be effectively zero. Cache reads dominate (30.5M) — normal for sessions
> with large prompt reuse.