### PR TITLE
⌨️ tmux: prefix Tab / S-Tab cycle sessions, Space toggles last

### DIFF
--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -23,6 +23,10 @@ set -g renumber-windows on
 set -g escape-time 10
 set -g focus-events on
 set -g history-limit 50000
+# Longer repeat window (default 500ms) so `-r` bindings — Tab/S-Tab for
+# session cycling, mainly — keep accepting taps without re-prefixing
+# during a brief pause.
+set -g repeat-time 1000
 
 # When the last pane in a session exits (Ctrl-D, `exit`, kill-session),
 # switch to the most-recently-used other session instead of detaching.
@@ -82,6 +86,20 @@ bind h select-pane -L
 bind j select-pane -D
 bind k select-pane -U
 bind l select-pane -R
+
+# ─── Session cycling ────────────────────────
+# Unshifted alternatives to the default <prefix> L / ( / ).
+#   <prefix> Space  → last (most-recently-used) session
+#   <prefix> Tab    → next session   (repeatable — hold prefix once,
+#                                     tap Tab to keep cycling)
+#   <prefix> S-Tab  → previous session (repeatable; BTab = back-tab)
+# Overrides:
+#   - default <prefix> Space (next-layout) — pane layouts unused here
+#     (prefix h/j/k/l + | / - cover splits).
+#   - Tab / BTab are unbound by default.
+bind    Space switch-client -l
+bind -r Tab   switch-client -n
+bind -r BTab  switch-client -p
 
 # ─── Reload ─────────────────────────────────
 bind r source-file ~/.config/tmux/tmux.conf \; display "config reloaded"


### PR DESCRIPTION
## 🎯 Summary

- `prefix Space` → last session (the `prefix L` toggle without the shift). Replaces default `next-layout`, which is unused here (`prefix h/j/k/l` + `|` / `-` cover splits).
- `prefix Tab` → next session, `prefix S-Tab` → previous session. Both `-r` repeatable — hold prefix once, tap to keep cycling. `Tab` / `BTab` are unbound by default, so no useful default lost.
- `repeat-time` bumped 500ms → 1000ms so `-r` cycling tolerates a brief pause without re-prefixing.

Defaults still work: `prefix L` (last), `prefix (` / `)` (prev/next).

## 🧪 Test plan

- [ ] Reload config: `prefix r` (or `tmux source-file ~/.config/tmux/tmux.conf`)
- [ ] `prefix Space` jumps to the most-recently-used session
- [ ] `prefix Tab` cycles forward; repeated `Tab` taps within ~1s keep cycling without re-prefixing
- [ ] `prefix Shift-Tab` cycles backward, same repeat behavior
- [ ] Default `prefix L` / `prefix (` / `prefix )` still work
- [ ] `prefix Space` no longer triggers `next-layout` (acceptable — layouts unused)

## 📝 Notes

- `Tab` and `C-i` share the same byte (0x09) at the terminal layer; `bind Tab` therefore also claims `C-i`. Config doesn't reference `C-i` elsewhere — checked.
- `Shift-Tab` maps to tmux's canonical `BTab` (back-tab), which is what's wired in the config.