### PR TITLE
⌨️ tmux: prefix , / . cycle windows, < / > swap left/right

### DIFF
--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -101,6 +101,27 @@ bind    Space switch-client -l
 bind -r Tab   switch-client -n
 bind -r BTab  switch-client -p
 
+# ─── Window cycling ─────────────────────────
+# Unshifted neighbours on the US layout for rapid window-hop.
+#   <prefix> ,  → previous window (repeatable)
+#   <prefix> .  → next window     (repeatable)
+# Default `n`/`p` still work. Overrides the default `,` rename-window: with
+# `automatic-rename on` (above) manual rename is overwritten on the next
+# preexec stamp anyway — fall back to `:rename-window <name>` from the
+# command prompt if you need to pin a name.
+unbind ,
+unbind .
+bind -r , previous-window
+bind -r . next-window
+
+# ─── Window reordering ──────────────────────
+# Shove the current window left/right by one index. Repeatable so a single
+# prefix press lets you keep nudging until placed. Default `swap-window`
+# (without `-d`) follows the moved window, so the next tap keeps acting on
+# the same window.
+bind -r "<" swap-window -t -1
+bind -r ">" swap-window -t +1
+
 # ─── Reload ─────────────────────────────────
 bind r source-file ~/.config/tmux/tmux.conf \; display "config reloaded"
 

--- a/docs/tmux-cheatsheet.html
+++ b/docs/tmux-cheatsheet.html
@@ -197,17 +197,18 @@
     <h3>Manage</h3>
     <table>
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">c</span></td><td class="desc">create window — opens at session root (<code>@session_root</code>, set by <code>s</code>) when present, else inherits pane cwd</td></tr>
-      <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">,</span></td><td class="desc">rename window</td></tr>
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">&amp;</span></td><td class="desc">kill window (confirm)</td></tr>
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">w</span></td><td class="desc">window picker (tree)</td></tr>
-      <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">.</span></td><td class="desc">move window (renumber)</td></tr>
+      <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">&lt;</span> / <span class="k">&gt;</span></td><td class="desc">swap window left / right <span class="muted">(repeatable; follows the window)</span></td></tr>
+      <tr><td class="key"><code>:rename-window &lt;name&gt;</code></td><td class="desc">force a name <span class="muted">(no keybind — <code>automatic-rename</code> would clobber it anyway)</span></td></tr>
     </table>
   </div>
 
   <div class="card">
     <h3>Switch</h3>
     <table>
-      <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">n</span> / <span class="k">p</span></td><td class="desc">next / prev window</td></tr>
+      <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">.</span> / <span class="k">,</span></td><td class="desc">next / prev window <span class="muted">(repeatable)</span></td></tr>
+      <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">n</span> / <span class="k">p</span></td><td class="desc">next / prev window <span class="muted">(tmux default; same as <code>.</code>/<code>,</code>)</span></td></tr>
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">1</span>…<span class="k">9</span></td><td class="desc">window 1–9 by number</td></tr>
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">l</span></td><td class="desc">last window <span class="muted">(but <code>l</code> is also pane-right here — see "Quirks")</span></td></tr>
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">f</span></td><td class="desc">find by name (search)</td></tr>
@@ -423,7 +424,7 @@
 </table>
 
 <footer>
-  Built from <code>~/.config/tmux/tmux.conf</code> on 2026-05-10. Refresh after meaningful config changes.
+  Built from <code>~/.config/tmux/tmux.conf</code> on 2026-05-13. Refresh after meaningful config changes.
   <br>
   When in doubt: <span class="k prefix">C-a</span> <span class="k">?</span> for the live keymap list.
 </footer>


### PR DESCRIPTION
## ✨ Summary

- ⌨️ Adds `<prefix> ,` / `<prefix> .` for fast previous/next window cycling (repeatable) — unshifted US-layout neighbours, pairs one tier below the existing `Tab` / `S-Tab` session cycling.
- 🔀 Adds `<prefix> <` / `<prefix> >` for `swap-window` left/right (repeatable; follows the window so the next tap keeps acting on the same window).
- 🗒️ Cheatsheet (`docs/tmux-cheatsheet.html`) updated to match — new rows under **Manage** / **Switch** and footer date bumped to 2026-05-13.

## ⚠️ Trade-offs

- 🪧 Overrides the default `<prefix> ,` rename-window. With `automatic-rename on` (driven by the fish preexec `@last_cmd` stamp) a manual rename gets overwritten on the next prompt anyway. `:rename-window <name>` from the command prompt is the fallback for the rare pin-a-name case (documented in the cheatsheet).
- 🧹 Replaces the default `<prefix> .` prompted move-window. `<` / `>` covers the common case (nudge by one index); jump-to-index lives at `:swap-window -t :N` (already in the cheatsheet's CLI commands).

## 🧪 Test plan

- [ ] \`<prefix> r\` reload, then \`<prefix> .\` / \`<prefix> ,\` cycles next/prev window; repeats while prefix-armed.
- [ ] \`<prefix> <\` / \`<prefix> >\` swaps the current window left/right and keeps focus on it across repeats.
- [ ] \`<prefix> ?\` (list-keys) shows the new bindings; default \`,\` rename and \`.\` move-window are gone.
- [ ] \`open docs/tmux-cheatsheet.html\` shows the updated **Manage** / **Switch** rows and the 2026-05-13 footer date.