### PR TITLE
⌨️ tmux: require prefix for PageUp copy-mode binding

### DIFF
--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -126,9 +126,7 @@ bind -r ">" swap-window -t +1
 bind r source-file ~/.config/tmux/tmux.conf \; display "config reloaded"
 
 # ─── Copy mode: PageUp drops into scrollback ───
-# Unprefixed PageUp enters copy-mode and scrolls one page back, so reading
-# scrollback feels like a normal pager. `q` exits back to the live pane.
-bind -n PageUp copy-mode -u
+bind PageUp copy-mode -u
 
 # ─── PR pin: open in browser ────────────────
 # `<prefix> P` opens the current branch's PR in the default browser via


### PR DESCRIPTION
## Summary
- Changed PageUp copy-mode binding from unprefixed (`bind -n`) to prefix-required (`bind`), so `C-a PageUp` enters copy-mode scrollback instead of bare PageUp
- Prevents PageUp interception in terminal applications running inside tmux panes

## Test plan
- [ ] `<prefix> PageUp` enters copy mode and scrolls up
- [ ] Bare `PageUp` passes through to the active pane's application