### PR TITLE
nvim: Ruby LSP, endwise, rails/projectionist plugins

### DIFF
--- a/.config/nvim/lua/config/options.lua
+++ b/.config/nvim/lua/config/options.lua
@@ -46,6 +46,10 @@ opt.undofile = true
 opt.termguicolors = true
 opt.background = "dark"
 
+-- Trust per-project .nvim.lua files (`:h exrc`)
+vim.o.exrc = true
+vim.o.secure = false
+
 -- Never descend into worktree directories from built-in completion (`:e <Tab>`,
 -- `:find`, netrw, wildmenu). Snacks pickers are handled separately in
 -- lua/plugins/snacks.lua.

--- a/.config/nvim/lua/plugins/treesitter.lua
+++ b/.config/nvim/lua/plugins/treesitter.lua
@@ -6,4 +6,12 @@ return {
       vim.list_extend(opts.ensure_installed, { "python", "sql" })
     end,
   },
+  {
+    "RRethy/nvim-treesitter-endwise",
+    event = "InsertEnter",
+    dependencies = { "nvim-treesitter/nvim-treesitter" },
+    config = function()
+      require("nvim-treesitter.configs").setup({ endwise = { enable = true } })
+    end,
+  },
 }

--- a/.config/nvim/lua/plugins/vim-rails.lua
+++ b/.config/nvim/lua/plugins/vim-rails.lua
@@ -1,0 +1,4 @@
+return {
+  { "tpope/vim-rails", ft = "ruby" },
+  { "tpope/vim-projectionist" },
+}

--- a/.gitignore_global
+++ b/.gitignore_global
@@ -20,5 +20,11 @@ bin/complexity_changes.sh
 bin/reek_changes.sh
 reports/
 
+# Neovim per-project config
+.nvim.lua
+
+# Ruby LSP cache
+.ruby-lsp/
+
 # Python
 __pycache__/


### PR DESCRIPTION
## Summary
- Enable `exrc` + `secure=false` for per-project `.nvim.lua` files (LSP config per Ruby project, no trust prompts in worktrees)
- Add `nvim-treesitter-endwise` for auto-inserting `end` after Ruby/Lua/Bash block keywords
- Add `vim-rails` (Rails navigation, `:A`) and `vim-projectionist` (`:A` for non-Rails Ruby projects)
- Global gitignore: `.nvim.lua` (machine-local nvim config) and `.ruby-lsp/` (LSP index cache)

## Test plan
- [ ] Open nvim in a Ruby project with `.nvim.lua` — LSP auto-starts without trust prompt
- [ ] Type `def foo` + Enter — `end` auto-inserted
- [ ] `:A` in a Rails project (chopin) — jumps to spec
- [ ] `:A` in a non-Rails project (rater) with `.projections.json` — jumps to spec
- [ ] `gr` on a symbol — references work after LSP indexes