### PR TITLE
☕ themes: add Catppuccin Latte as first (partial-coverage) light theme

### DIFF
--- a/.config/fish/completions/theme-set.fish
+++ b/.config/fish/completions/theme-set.fish
@@ -3,3 +3,4 @@ complete -c theme-set -f -n 'test (count (commandline -opc)) -eq 1' -a mocha    
 complete -c theme-set -f -n 'test (count (commandline -opc)) -eq 1' -a dracula     -d 'Dracula'
 complete -c theme-set -f -n 'test (count (commandline -opc)) -eq 1' -a gruvbox     -d 'Gruvbox Dark Medium'
 complete -c theme-set -f -n 'test (count (commandline -opc)) -eq 1' -a tokyo-night -d 'Tokyo Night Storm'
+complete -c theme-set -f -n 'test (count (commandline -opc)) -eq 1' -a latte       -d 'Catppuccin Latte (light)'

--- a/.config/fish/functions/theme-set.fish
+++ b/.config/fish/functions/theme-set.fish
@@ -1,10 +1,10 @@
-function theme-set --description 'Switch colour scheme between solarized, mocha, dracula, gruvbox, and tokyo-night'
+function theme-set --description 'Switch colour scheme between solarized, mocha, dracula, gruvbox, tokyo-night, and latte'
     set -l name $argv[1]
     switch $name
-        case solarized mocha dracula gruvbox tokyo-night
+        case solarized mocha dracula gruvbox tokyo-night latte
             # OK
         case '*'
-            echo "Usage: theme-set <solarized|mocha|dracula|gruvbox|tokyo-night>" >&2
+            echo "Usage: theme-set <solarized|mocha|dracula|gruvbox|tokyo-night|latte>" >&2
             return 1
     end
 
@@ -25,26 +25,46 @@ function theme-set --description 'Switch colour scheme between solarized, mocha,
             # Catppuccin Mocha (closest pastel-on-dark in bat's catalogue).
             set bat_theme "Catppuccin Mocha"
             set vivid_theme "tokyonight-storm"
+        case latte
+            set bat_theme "Catppuccin Latte"
+            set vivid_theme "catppuccin-latte"
         case '*'
             set bat_theme "Solarized (dark)"
             set vivid_theme "solarized-dark"
     end
 
-    # Flip symlinks. -sfn replaces the link atomically.
-    ln -sfn $name.tmux              ~/.config/themes/current.tmux
-    ln -sfn delta-$name.gitconfig   ~/.config/themes/delta-current.gitconfig
-    ln -sfn theme-$name.ghostty     ~/.config/ghostty/theme.ghostty
-    ln -sfn starship-$name.toml     ~/.config/starship.toml
-    ln -sfn glamour-$name.json      ~/.config/glow/glamour.json
-    ln -sfn theme-$name.json        ~/.config/lnav/configs/installed/theme.json
+    # Flip symlinks. -sfn replaces the link atomically. Each flip is
+    # existence-guarded on the source: partial-coverage themes (e.g. Latte
+    # ships only ghostty/tmux/starship) coexist with full-coverage ones
+    # without a bespoke `case` branch. Five themes have every variant present
+    # and pass every guard; Latte has four guards fail and those tools keep
+    # their previous symlinks pointing at the most-recent dark theme.
+    # Future tier-1 extensions for Latte are purely additive — drop the
+    # variant file in, the guard auto-engages, no theme-set changes.
+    test -f ~/.config/themes/$name.tmux \
+        ; and ln -sfn $name.tmux ~/.config/themes/current.tmux
+    test -f ~/.config/themes/delta-$name.gitconfig \
+        ; and ln -sfn delta-$name.gitconfig ~/.config/themes/delta-current.gitconfig
+    test -f ~/.config/ghostty/theme-$name.ghostty \
+        ; and ln -sfn theme-$name.ghostty ~/.config/ghostty/theme.ghostty
+    test -f ~/.config/starship-$name.toml \
+        ; and ln -sfn starship-$name.toml ~/.config/starship.toml
+    test -f ~/.config/glow/glamour-$name.json \
+        ; and ln -sfn glamour-$name.json ~/.config/glow/glamour.json
+    test -f ~/.config/lnav/configs/installed/theme-$name.json \
+        ; and ln -sfn theme-$name.json ~/.config/lnav/configs/installed/theme.json
 
     # gh-dash live config is a generated real file, not a symlink.
     # base.yml has no `theme:` key; theme-colors-$name.yml has only `theme:` —
     # plain concatenation produces valid YAML, no merge engine needed.
-    cat \
-        ~/.config/gh-dash/config-base.yml \
-        ~/.config/gh-dash/theme-colors-$name.yml \
-        > ~/.config/gh-dash/config.yml
+    # Existence-guarded like the symlink flips above: when no Latte variant
+    # exists, gh-dash keeps its previous config.yml.
+    if test -f ~/.config/gh-dash/theme-colors-$name.yml
+        cat \
+            ~/.config/gh-dash/config-base.yml \
+            ~/.config/gh-dash/theme-colors-$name.yml \
+            > ~/.config/gh-dash/config.yml
+    end
 
     # Persisted env vars; survive shell restarts. Open shells need new
     # session to pick up the values. BAT_THEME is read by bat at startup;

--- a/.config/ghostty/theme-latte.ghostty
+++ b/.config/ghostty/theme-latte.ghostty
@@ -1,0 +1,5 @@
+# Catppuccin Latte theme. Selection colours intentionally omitted —
+# Latte's defaults are well-tuned. Revisit if selections read poorly
+# in practice. Active when ~/.config/ghostty/theme.ghostty → this
+# file (theme-set latte). First light theme in the collection.
+theme = Catppuccin Latte

--- a/.config/starship-latte.toml
+++ b/.config/starship-latte.toml
@@ -1,0 +1,72 @@
+"$schema" = "https://starship.rs/config-schema.json"
+
+palette = "catppuccin_latte"
+
+format = """$directory[](fg:pastel_rose)
+$character"""
+
+right_format = "$status$cmd_duration"
+
+[palettes.catppuccin_latte]
+# Catppuccin Latte palette — see ../themes/latte.tmux for the same
+# semantic roles as tmux options. Names mirror Catppuccin's spec.
+# First light theme in the collection.
+crust    = "#dce0e8"
+mantle   = "#e6e9ef"
+base     = "#eff1f5"
+surface0 = "#ccd0da"
+surface1 = "#bcc0cc"
+surface2 = "#acb0be"
+overlay0 = "#9ca0b0"
+overlay1 = "#8c8fa1"
+overlay2 = "#7c7f93"
+subtext0 = "#6c6f85"
+subtext1 = "#5c5f77"
+text     = "#4c4f69"
+yellow   = "#df8e1d"
+peach    = "#fe640b"
+red      = "#d20f39"
+maroon   = "#e64553"
+pink     = "#ea76cb"
+mauve    = "#8839ef"
+lavender = "#7287fd"
+blue     = "#1e66f5"
+sapphire = "#209fb5"
+sky      = "#04a5e5"
+teal     = "#179299"
+green    = "#40a02b"
+flamingo = "#dd7878"
+rosewater = "#dc8a78"
+frame    = "#9ca0b0"   # overlay0 — muted frame
+# Personal accent — per-theme equivalent of Solarized's #DA627D pastel rose.
+# Catppuccin canonical "personal" accent is pink.
+pastel_rose = "#ea76cb"
+# Alias so the prompt format below stays portable across themes.
+# base3 here is dark (#4c4f69 text) — chip-text inversion for
+# pastel chip bgs (pastel_rose). Latte mirrors Mocha's dark-on-pink
+# choice; tmux uses light-on-saturated separately (chip bgs differ).
+base3       = "#4c4f69"
+
+[directory]
+format = "[ $path ]($style)"
+style  = "fg:base3 bg:pastel_rose"
+truncation_length = 3
+truncation_symbol = "…/"
+
+[character]
+success_symbol = "[❯](bold fg:pastel_rose)"
+error_symbol   = "[❯](bold fg:pastel_rose)"
+vicmd_symbol   = "[❮](bold fg:pastel_rose)"
+
+[cmd_duration]
+min_time = 2000
+format   = "[ $duration]($style) "
+style    = "fg:pastel_rose"
+
+[status]
+disabled = false
+format   = "[✘ $status]($style) "
+style    = "fg:pastel_rose"
+
+[jobs]
+disabled = true

--- a/.config/themes/latte.tmux
+++ b/.config/themes/latte.tmux
@@ -1,0 +1,32 @@
+# Catppuccin Latte palette — same role keys as mocha.tmux, Latte hex.
+# First light theme: bar bg is mantle (#e6e9ef), not a dark surface.
+# Designed for light-on-saturated chip text — Latte's accents are
+# saturated enough to carry light text (cf. Mocha's pastel
+# accents + dark text).
+
+# Bases
+set -g @color_bar_bg          "#e6e9ef"
+set -g @color_deep_bg         "#dce0e8"
+set -g @color_default_fg      "#4c4f69"
+set -g @color_muted_fg        "#8c8fa1"
+# Chip-text inversion: light on saturated. Same role name as
+# Solarized/Mocha, theme-tuned value (#eff1f5 = base).
+set -g @color_light_fg        "#eff1f5"
+
+# Accents — Catppuccin Latte spec
+set -g @color_accent_yellow   "#df8e1d"
+set -g @color_accent_orange   "#fe640b"
+set -g @color_accent_red      "#d20f39"
+set -g @color_accent_magenta  "#ea76cb"
+set -g @color_accent_violet   "#8839ef"
+set -g @color_accent_blue     "#1e66f5"
+set -g @color_accent_cyan     "#04a5e5"
+set -g @color_accent_green    "#40a02b"
+
+# Derived chip values — hand-derived for light-bar contrast.
+# Main chip bg is mauve (#8839ef), wt chip bg is yellow (#df8e1d).
+set -g @color_chip_main_ins_fg     "#a6e3a1"
+set -g @color_chip_main_del_fg     "#eba0ac"
+set -g @color_chip_main_neutral_fg "#cdd6f4"
+set -g @color_chip_wt_ins_fg       "#40620d"
+set -g @color_chip_wt_del_fg       "#7a1f2a"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # dotfiles — Claude Code instructions
 
-Personal multi-theme, multi-font setup for Ghostty + tmux + vim + fish. `theme-set` swaps between 5 themes (Solarized Dark / Mocha / Dracula / Gruvbox / Tokyo Night Storm) and `font-set` between 17 Nerd Fonts; both switch live. Solarized Dark and JetBrains Mono are the bootstrap defaults. See "Switchable themes" and "Switchable Ghostty fonts" below.
+Personal multi-theme, multi-font setup for Ghostty + tmux + vim + fish. `theme-set` swaps between 6 themes (Solarized Dark / Mocha / Dracula / Gruvbox / Tokyo Night Storm / Catppuccin Latte) and `font-set` between 17 Nerd Fonts; both switch live. Solarized Dark and JetBrains Mono are the bootstrap defaults. See "Switchable themes" and "Switchable Ghostty fonts" below.
 
 ## Conventions — don't drift from these
 
@@ -209,21 +209,30 @@ Personal multi-theme, multi-font setup for Ghostty + tmux + vim + fish. `theme-s
   were noise, not signal. Run `:Lazy restore` against the working
   tree's own lockfile when you need reproducibility on a single
   machine.
-- **Switchable themes — Solarized Dark ↔ Catppuccin Mocha ↔ Dracula ↔ Gruvbox ↔ Tokyo Night Storm.**
-  Solarized Dark is the canonical default. `theme-set <name>` (fish function in
+- **Switchable themes — Solarized Dark ↔ Catppuccin Mocha ↔ Dracula ↔ Gruvbox ↔ Tokyo Night Storm ↔ Catppuccin Latte.**
+  Solarized Dark is the canonical default. Catppuccin Latte is the **first
+  and only light theme** and ships with **partial tier-1 coverage**: only
+  Ghostty, tmux, and starship have Latte variants — delta, glow, gh-dash,
+  lnav, and nvim keep their previous (dark) theme during a Latte session
+  by design. This is enforced by existence-guarded `test -f` checks inside
+  `theme-set.fish` rather than a bespoke `case latte` branch — future
+  tier-1 extensions are purely additive (drop a variant file in, the guard
+  auto-engages, no `theme-set` changes). Issue #215 tracks the
+  full-coverage follow-up. `theme-set <name>` (fish function in
   `.config/fish/functions/`) flips active-theme symlinks across the
   hot-path + file-viewer tools. Palette files live in `.config/themes/`
   (mixed-dir: tracked `*.tmux` palettes + tracked `delta-*.gitconfig`;
   machine-local `current.tmux` and `delta-current.gitconfig` symlinks).
   Per-tool variant files use the naming convention `*-solarized.<ext>`
   / `*-mocha.<ext>` / `*-dracula.<ext>` / `*-gruvbox.<ext>` /
-  `*-tokyo-night.<ext>` and live alongside their tool's config —
-  `.config/ghostty/theme-{solarized,mocha,dracula,gruvbox,tokyo-night}.ghostty`,
+  `*-tokyo-night.<ext>` / `*-latte.<ext>` (where present — Latte is
+  partial-coverage, see above) and live alongside their tool's config —
+  `.config/ghostty/theme-{solarized,mocha,dracula,gruvbox,tokyo-night,latte}.ghostty`,
   `.config/glow/glamour-{solarized,mocha,dracula,gruvbox,tokyo-night}.json`,
   `.config/gh-dash/theme-colors-{solarized,mocha,dracula,gruvbox,tokyo-night}.yml`
   (alongside the shared `.config/gh-dash/config-base.yml`),
   `.config/lnav/configs/installed/theme-{solarized,mocha,dracula,gruvbox,tokyo-night}.json`,
-  `.config/starship-{solarized,mocha,dracula,gruvbox,tokyo-night}.toml`. The active
+  `.config/starship-{solarized,mocha,dracula,gruvbox,tokyo-night,latte}.toml`. The active
   variant is picked via a machine-local symlink at the tool's normal
   config path. gh-dash is the one exception: its live `config.yml` is a
   generated real file (`cat config-base.yml theme-colors-<name>.yml > config.yml`)
@@ -271,7 +280,17 @@ Personal multi-theme, multi-font setup for Ghostty + tmux + vim + fish. `theme-s
   Night**, so `.config/lnav/configs/installed/tokyo-night.json` is a
   second vendored theme-defs (same shape as `gruvbox.json`, hex from
   `folke/tokyonight.nvim` MIT). Night / Moon / Day variants of Tokyo
-  Night are out of v1.
+  Night are out of v1. **Catppuccin Latte is the first light theme**
+  and inverts a few assumptions baked into the dark-only collection:
+  bar bg is mantle `#e6e9ef` (not a dark surface), and tmux chips
+  use **light-on-saturated** chip text (`@color_light_fg = "#eff1f5"`)
+  while starship uses **dark-on-pastel**
+  (`base3 = "#4c4f69"`) — different chip-bg palettes drive different
+  inversion choices. Latte ships only ghostty/tmux/starship + bat/vivid
+  env vars; delta/glow/gh-dash/lnav/nvim stay on the previous
+  (dark) theme during a Latte session. bat 0.26+ ships
+  `Catppuccin Latte` built-in; vivid 0.11+ ships
+  `catppuccin-latte`; Ghostty 1.0+ ships the preset.
   Delta is included from `~/.gitconfig` via
   `[include] path = ~/.config/themes/delta-current.gitconfig` (one-time
   setup, see README). nvim picks its colorscheme at startup via the

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotfiles
 
-Personal config for Ghostty + fish + tmux + vim — multi-theme (Solarized Dark / Mocha / Dracula / Gruvbox / Tokyo Night Storm via `theme-set`) and multi-font (17 Nerd Fonts via `font-set`). Solarized Dark and JetBrains Mono are the defaults.
+Personal config for Ghostty + fish + tmux + vim — multi-theme (Solarized Dark / Mocha / Dracula / Gruvbox / Tokyo Night Storm / Catppuccin Latte via `theme-set`) and multi-font (17 Nerd Fonts via `font-set`). Solarized Dark and JetBrains Mono are the defaults.
 
 <p align="center">
   <a href="docs/images/example_terminal.png"><img src="docs/images/example_terminal-thumb.png" alt="terminal" width="32%" /></a>
@@ -117,7 +117,7 @@ These drive the `claude[<name>]` window title (tmux's
 
 ## Switching themes
 
-Five themes are wired: **Solarized Dark** (default), **Catppuccin Mocha**, **Dracula**, **Gruvbox Dark Medium**, and **Tokyo Night Storm**.
+Six themes are wired: **Solarized Dark** (default), **Catppuccin Mocha**, **Dracula**, **Gruvbox Dark Medium**, **Tokyo Night Storm**, and **Catppuccin Latte** (the first and only light theme).
 Swap via the fish function `theme-set`:
 
 ```fish
@@ -125,8 +125,11 @@ theme-set mocha        # switch to Catppuccin Mocha
 theme-set dracula      # switch to Dracula
 theme-set gruvbox      # switch to Gruvbox Dark Medium
 theme-set tokyo-night  # switch to Tokyo Night Storm
+theme-set latte        # switch to Catppuccin Latte (light, partial coverage)
 theme-set solarized    # switch back
 ```
+
+**Latte caveat:** Catppuccin Latte is the only light theme and ships with **partial tier-1 coverage** — only Ghostty, tmux, and starship have Latte variants. delta, glow, gh-dash, lnav, and nvim keep their previous (dark) theme during a Latte session. Issue #215 tracks the full-coverage follow-up.
 
 The function flips per-tool symlinks under `~/.config/themes/`,
 `~/.config/ghostty/theme.ghostty`, `~/.config/starship.toml`,

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -277,6 +277,7 @@ link ".config/starship-mocha.toml"       "$HOME/.config/starship-mocha.toml"
 link ".config/starship-dracula.toml"     "$HOME/.config/starship-dracula.toml"
 link ".config/starship-gruvbox.toml"     "$HOME/.config/starship-gruvbox.toml"
 link ".config/starship-tokyo-night.toml" "$HOME/.config/starship-tokyo-night.toml"
+link ".config/starship-latte.toml"       "$HOME/.config/starship-latte.toml"
 [ -L "$HOME/.config/starship.toml" ] \
     || ln -sfn starship-solarized.toml "$HOME/.config/starship.toml"
 

--- a/scripts/test-theme-switch.sh
+++ b/scripts/test-theme-switch.sh
@@ -120,7 +120,20 @@ assert_link "$HOME/.config/glow/glamour.json"                 "glamour-tokyo-nig
 assert_gh_dash_config "#c0caf5" "gh-dash config.yml ← base + theme-colors-tokyo-night"
 assert_link "$HOME/.config/lnav/configs/installed/theme.json" "theme-tokyo-night.json"         "lnav theme.json → theme-tokyo-night.json"
 
-# Reverse: tokyo-night → solarized
+# Forward: tokyo-night → latte (partial-coverage theme — only ghostty/tmux/starship
+# flip; delta/glow/lnav/gh-dash stay on tokyo-night by design, see spec).
+run_theme_set latte
+# Positive contract — what flips:
+assert_link "$HOME/.config/themes/current.tmux"               "latte.tmux"               "current.tmux → latte.tmux"
+assert_link "$HOME/.config/ghostty/theme.ghostty"             "theme-latte.ghostty"      "ghostty theme.ghostty → theme-latte.ghostty"
+assert_link "$HOME/.config/starship.toml"                     "starship-latte.toml"      "starship.toml → starship-latte.toml"
+# Negative contract — what does NOT flip (partial coverage stays on previous theme):
+assert_link "$HOME/.config/themes/delta-current.gitconfig"    "delta-tokyo-night.gitconfig"    "delta stays on tokyo-night (no delta-latte.gitconfig)"
+assert_link "$HOME/.config/glow/glamour.json"                 "glamour-tokyo-night.json"       "glow stays on tokyo-night (no glamour-latte.json)"
+assert_link "$HOME/.config/lnav/configs/installed/theme.json" "theme-tokyo-night.json"         "lnav stays on tokyo-night (no theme-latte.json)"
+assert_gh_dash_config "#c0caf5" "gh-dash stays on tokyo-night (no theme-colors-latte.yml)"
+
+# Reverse: latte → solarized
 run_theme_set solarized
 assert_link "$HOME/.config/themes/current.tmux"               "solarized.tmux"             "current.tmux → solarized.tmux (reverse)"
 assert_link "$HOME/.config/ghostty/theme.ghostty"             "theme-solarized.ghostty"    "ghostty theme.ghostty → theme-solarized.ghostty (reverse)"


### PR DESCRIPTION
## 🎯 Summary

Adds Catppuccin Latte as the 6th `theme-set` option — the **first
light theme** in the collection. Ships with **partial tier-1
coverage** by design: only Ghostty + tmux + starship have Latte
variants. delta/glow/gh-dash/lnav/nvim keep their previous (dark)
theme during a Latte session. Issue #215 stays open as the tracker
for full coverage; this PR's `theme-set.fish` refactor makes future
extensions purely additive.

Refines #215.

## 🎨 Palette

- bg/surface: base \`#eff1f5\`, mantle \`#e6e9ef\`, crust \`#dce0e8\`
- text: \`#4c4f69\`; muted: overlay1 \`#8c8fa1\`
- accents: blue \`#1e66f5\`, mauve \`#8839ef\`, green \`#40a02b\`,
  yellow \`#df8e1d\`, peach \`#fe640b\`, pink \`#ea76cb\`,
  red \`#d20f39\`, sky \`#04a5e5\`
- **Chip-text inversion (tmux):** light-on-saturated, kept default
  `@color_light_fg = "#eff1f5"` (Latte base) — readable on every chip
  including yellow per live eye-check.
- **`pastel_rose` (starship):** kept default `#ea76cb` (Latte pink) —
  reads well on light bg, no need to fall back to flamingo.

## 🛠️ Changes

- 🎨 `.config/ghostty/theme-latte.ghostty` — Ghostty preset (built-in catalogue)
- 🎨 `.config/themes/latte.tmux` — semantic `@color_*` palette
- 🎨 `.config/starship-latte.toml` — prompt config (cloned via `cp` from
  starship-mocha.toml to preserve U+E0B4 cap byte)
- 🐟 `.config/fish/functions/theme-set.fish` — validation + bat/vivid
  switch + **existence-guarded symlink-flip refactor**
- 🐟 `.config/fish/completions/theme-set.fish` — completion entry
  with `(light)` mode annotation
- 🏗️ `bootstrap.sh` — link line for starship-latte.toml
- ✅ `scripts/test-theme-switch.sh` — Latte positive + negative
  contracts; existing themes still round-trip (38 assertions total)
- 📝 `CLAUDE.md` + `README.md` — theme docs

## 🧩 Architecture choice — partial coverage via existence guards

Instead of a bespoke `case latte:` branch in `theme-set.fish`, each
tier-1 flip is now guarded by `test -f` on the source file:

\`\`\`fish
test -f ~/.config/themes/delta-\$name.gitconfig \\
    ; and ln -sfn delta-\$name.gitconfig ~/.config/themes/delta-current.gitconfig
\`\`\`

Five existing themes have every variant file present → every guard
passes → behavior unchanged. Latte has four guards fail
(delta/glow/lnav/gh-dash) → those tools keep their previous symlinks
pointing at whichever full-coverage theme was last selected.

Future tier-1 extensions for Latte: drop a variant file in, the
guard auto-engages, **zero `theme-set` changes**.

## ⚠️ Probe results + fallbacks

| Probe | Outcome | Branch taken |
|---|---|---|
| 🟢 Ghostty | \`Catppuccin Latte\` ships built-in | Use directly |
| 🟢 bat 0.26.1 | \`Catppuccin Latte\` ships built-in | Use directly |
| 🟢 vivid 0.11+ | \`catppuccin-latte\` ships | Use directly |
| 🟢 Live eye-check | Yellow chip text readable at \`#eff1f5\` | Keep light text |
| 🟢 Live eye-check | \`pastel_rose\` \`#ea76cb\` reads on light bg | Keep pink |
| 🟢 Live eye-check | Saturated chips on mantle bar look deliberate | Ship as-is |

## ✅ Test plan

- [x] \`scripts/test-fish-loads.sh\` passes
- [x] \`scripts/test-theme-switch.sh\` passes — 38/38 assertions
      (Latte round-trip with positive + negative contracts; all 5
      existing themes still round-trip cleanly; run with \`REPO=\$PWD\`
      in worktree)
- [x] Live tmux eye-check — chip text legibility on yellow chip
- [x] starship eye-check — \`pastel_rose\` on light bg
- [x] \`theme-set latte\` flips ghostty + tmux + starship
- [x] \`theme-set latte\` does NOT flip delta/glow/gh-dash/lnav (negative contract pinned)
- [x] Round-trip \`theme-set latte → solarized\` flips everything back

## 🚫 Out of scope (deferred follow-ups under #215)

- Full tier-1 coverage (delta/glow/gh-dash/lnav/nvim variants for Latte)
- Tier-2 (procs/tailspin/xh) dark/light split
- Cheatsheet HTML light variant
- Screenshot regeneration
- A \`\$THEME_MODE\` env var / explicit mode axis

## Session stats

| | |
|---|---|
| start | 2026-05-13 16:35 UTC |
| end | 2026-05-13 17:48 UTC |
| elapsed | 1h 12m |
| working | 29m 51s (41%) |
| idle | 41m 32s |
| total tokens | 34.1M |
| total cost (public rates) | \$104.07 |
| effective rate | \$209.14/hr |

| Model | Messages | Input | Output | Cache Read | Cache Write 1h | Cost |
|---|---|---|---|---|---|---|
| Opus 4.7 | 226 | 506 | 317k | 32.7M | 1.0M | \$104.07 |
| **Total** | **226** | **506** | **317k** | **32.7M** | **1.0M** | **\$104.07** |

Cost is a public-rate estimate; Claude Max/Pro plan billing differs. Cache reads dominate (re-use of system prompt + prior turns at ~10% of base input price).