### PR TITLE
🎨 themes: add Catppuccin Frappé (lifted dark with mauve accent)

### DIFF
--- a/.config/fish/functions/theme-set.fish
+++ b/.config/fish/functions/theme-set.fish
@@ -1,10 +1,10 @@
-function theme-set --description 'Switch colour scheme between solarized, mocha, dracula, gruvbox, tokyo-night, and latte'
+function theme-set --description 'Switch colour scheme between solarized, mocha, frappe, dracula, gruvbox, tokyo-night, and latte'
     set -l name $argv[1]
     switch $name
-        case solarized mocha dracula gruvbox tokyo-night latte
+        case solarized mocha frappe dracula gruvbox tokyo-night latte
             # OK
         case '*'
-            echo "Usage: theme-set <solarized|mocha|dracula|gruvbox|tokyo-night|latte>" >&2
+            echo "Usage: theme-set <solarized|mocha|frappe|dracula|gruvbox|tokyo-night|latte>" >&2
             return 1
     end
 
@@ -14,6 +14,9 @@ function theme-set --description 'Switch colour scheme between solarized, mocha,
         case mocha
             set bat_theme "Catppuccin Mocha"
             set vivid_theme "catppuccin-mocha"
+        case frappe
+            set bat_theme "Catppuccin Frappé"
+            set vivid_theme "catppuccin-frappe"
         case dracula
             set bat_theme "Dracula"
             set vivid_theme "dracula"

--- a/.config/gh-dash/theme-colors-frappe.yml
+++ b/.config/gh-dash/theme-colors-frappe.yml
@@ -1,0 +1,21 @@
+theme:
+    colors:
+        text:
+            primary: "#c6d0f5"
+            secondary: "#b5bfe2"
+            inverted: "#303446"
+            faint: "#737994"
+            warning: "#e5c890"
+            success: "#a6d189"
+            error: "#e78284"
+        background:
+            selected: "#414559"
+        border:
+            primary: "#737994"
+            secondary: "#414559"
+            faint: "#414559"
+    ui:
+        sectionsShowCount: true
+        table:
+            showSeparator: true
+            compact: true

--- a/.config/ghostty/theme-frappe.ghostty
+++ b/.config/ghostty/theme-frappe.ghostty
@@ -1,0 +1,5 @@
+# Catppuccin Frappé theme. Selection colours intentionally omitted —
+# Frappé's defaults are well-tuned. Revisit if selections read poorly in
+# practice. Active when ~/.config/ghostty/theme.ghostty → this file
+# (theme-set frappe).
+theme = Catppuccin Frappe

--- a/.config/glow/glamour-frappe.json
+++ b/.config/glow/glamour-frappe.json
@@ -1,0 +1,114 @@
+{
+  "document": {
+    "block_suffix": "\n",
+    "color": "#c6d0f5",
+    "margin": 2
+  },
+  "block_quote": {
+    "indent": 1,
+    "indent_token": "│ ",
+    "color": "#e5c890",
+    "italic": true
+  },
+  "paragraph": {},
+  "list": {
+    "level_indent": 2
+  },
+  "heading": {
+    "block_suffix": "\n",
+    "color": "#8caaee",
+    "bold": true
+  },
+  "h1": {
+    "prefix": "# ",
+    "suffix": "",
+    "color": "#8caaee",
+    "bold": true
+  },
+  "h2": {
+    "prefix": "## ",
+    "color": "#81c8be",
+    "bold": true
+  },
+  "h3": {
+    "prefix": "### ",
+    "color": "#a6d189",
+    "bold": true
+  },
+  "h4": {
+    "prefix": "#### ",
+    "color": "#e5c890",
+    "bold": true
+  },
+  "h5": {
+    "prefix": "##### ",
+    "color": "#ca9ee6"
+  },
+  "h6": {
+    "prefix": "###### ",
+    "color": "#737994"
+  },
+  "text": {},
+  "strikethrough": {
+    "crossed_out": true
+  },
+  "emph": {
+    "italic": true
+  },
+  "strong": {
+    "bold": true
+  },
+  "hr": {
+    "color": "#737994",
+    "format": "\n──────\n"
+  },
+  "item": {
+    "block_prefix": "• "
+  },
+  "enumeration": {
+    "block_prefix": ". ",
+    "color": "#81c8be"
+  },
+  "task": {
+    "ticked": "[✓] ",
+    "unticked": "[ ] "
+  },
+  "link": {
+    "color": "#ca9ee6",
+    "underline": true
+  },
+  "link_text": {
+    "color": "#ca9ee6",
+    "bold": true
+  },
+  "image": {
+    "color": "#ca9ee6",
+    "underline": true
+  },
+  "image_text": {
+    "color": "#ca9ee6",
+    "format": "Image: {{.text}} →"
+  },
+  "code": {
+    "prefix": " ",
+    "suffix": " ",
+    "color": "#ef9f76",
+    "background_color": "#303446"
+  },
+  "code_block": {
+    "margin": 2,
+    "theme": "catppuccin-frappe"
+  },
+  "table": {
+    "center_separator": "│",
+    "column_separator": "│",
+    "row_separator": "─"
+  },
+  "definition_list": {},
+  "definition_term": {},
+  "definition_description": {
+    "indent": 2
+  },
+  "html_block": {},
+  "html_span": {}
+}

--- a/.config/lnav/configs/installed/theme-frappe.json
+++ b/.config/lnav/configs/installed/theme-frappe.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://lnav.org/schemas/config-v1.schema.json",
+  "ui": {
+    "theme": "catppuccin-frappe"
+  }
+}

--- a/.config/nvim/lua/config/theme.lua
+++ b/.config/nvim/lua/config/theme.lua
@@ -2,6 +2,7 @@
 -- decide which colorscheme nvim should load at startup. Returns one of:
 --   "solarized"        (default, when symlink missing or unreadable)
 --   "catppuccin-mocha"
+--   "catppuccin-frappe"
 --   "dracula"
 --   "gruvbox"
 --   "tokyonight-storm"
@@ -12,6 +13,8 @@ function M.current()
   if link then
     if link:match("mocha") then
       return "catppuccin-mocha"
+    elseif link:match("frappe") then
+      return "catppuccin-frappe"
     elseif link:match("dracula") then
       return "dracula"
     elseif link:match("gruvbox") then

--- a/.config/starship-frappe.toml
+++ b/.config/starship-frappe.toml
@@ -1,0 +1,71 @@
+"$schema" = "https://starship.rs/config-schema.json"
+
+palette = "catppuccin_frappe"
+
+format = """$directory[](fg:pastel_rose)
+$character"""
+
+right_format = "$status$cmd_duration"
+
+[palettes.catppuccin_frappe]
+# Catppuccin Frappé palette — see ../themes/frappe.tmux for the same
+# semantic roles as tmux options. Names mirror Catppuccin's spec.
+crust    = "#232634"
+mantle   = "#292c3c"
+base     = "#303446"
+surface0 = "#414559"
+surface1 = "#51576d"
+surface2 = "#626880"
+overlay0 = "#737994"
+overlay1 = "#838ba7"
+overlay2 = "#949cbb"
+subtext0 = "#a5adce"
+subtext1 = "#b5bfe2"
+text     = "#c6d0f5"
+yellow   = "#e5c890"
+peach    = "#ef9f76"
+red      = "#e78284"
+maroon   = "#ea999c"
+pink     = "#f4b8e4"
+mauve    = "#ca9ee6"
+lavender = "#babbf1"
+blue     = "#8caaee"
+sapphire = "#85c1dc"
+sky      = "#99d1db"
+teal     = "#81c8be"
+green    = "#a6d189"
+flamingo = "#eebebe"
+rosewater = "#f2d5cf"
+frame    = "#737994"   # overlay0 — muted frame
+# Personal accent — per-theme equivalent of Solarized's #DA627D pastel rose.
+# Frappé picks mauve over pink for visual identity vs Mocha.
+pastel_rose = "#ca9ee6"
+# Alias so the prompt format below stays portable across themes.
+# base3 here is dark (#232634 crust) — chip-text inversion for
+# pastel chip bgs (pastel_rose). Solarized uses light text on its saturated
+# rose; Frappé (like Mocha) needs dark text on its pastel mauve.
+base3       = "#232634"
+
+[directory]
+format = "[ $path ]($style)"
+style  = "fg:base3 bg:pastel_rose"
+truncation_length = 3
+truncation_symbol = "…/"
+
+[character]
+success_symbol = "[❯](bold fg:pastel_rose)"
+error_symbol   = "[❯](bold fg:pastel_rose)"
+vicmd_symbol   = "[❮](bold fg:pastel_rose)"
+
+[cmd_duration]
+min_time = 2000
+format   = "[ $duration]($style) "
+style    = "fg:pastel_rose"
+
+[status]
+disabled = false
+format   = "[✘ $status]($style) "
+style    = "fg:pastel_rose"
+
+[jobs]
+disabled = true

--- a/.config/themes/delta-frappe.gitconfig
+++ b/.config/themes/delta-frappe.gitconfig
@@ -1,0 +1,9 @@
+# Catppuccin Frappé delta config. Active when ~/.config/themes/delta-current.gitconfig
+# symlinks to this file. The plus/minus emph hex are carried from Mocha — they
+# read fine against Frappé's lifted base; tune visually if they don't pop.
+[delta]
+    syntax-theme = Catppuccin Frappé
+    plus-style = "syntax #1e3a1e"
+    minus-style = "syntax #3a1e22"
+    plus-emph-style = "syntax #2d5a2d"
+    minus-emph-style = "syntax #5a2d32"

--- a/.config/themes/frappe.tmux
+++ b/.config/themes/frappe.tmux
@@ -1,0 +1,29 @@
+# Catppuccin Frappé palette — same role keys as solarized.tmux, Frappé hex.
+# Designed for dark-on-pastel chip text (like Mocha).
+
+# Bases
+set -g @color_bar_bg          "#303446"
+set -g @color_deep_bg         "#232634"
+set -g @color_default_fg      "#c6d0f5"
+set -g @color_muted_fg        "#737994"
+# light_fg here is dark (#232634 crust) — Frappé's chip-text inversion: pastel
+# chip bgs (mauve/peach/blue/green/yellow) read better with dark text than
+# light. The role name is shared with Solarized, but the value is theme-tuned.
+set -g @color_light_fg        "#232634"
+
+# Accents
+set -g @color_accent_yellow   "#e5c890"
+set -g @color_accent_orange   "#ef9f76"
+set -g @color_accent_red      "#e78284"
+set -g @color_accent_magenta  "#f4b8e4"
+set -g @color_accent_violet   "#ca9ee6"
+set -g @color_accent_blue     "#8caaee"
+set -g @color_accent_cyan     "#81c8be"
+set -g @color_accent_green    "#a6d189"
+
+# Derived chip values (theme-tuned, not 1:1)
+set -g @color_chip_main_ins_fg "#a6d189"
+set -g @color_chip_main_del_fg "#ea999c"
+set -g @color_chip_main_neutral_fg "#b5bfe2"
+set -g @color_chip_wt_ins_fg   "#40620d"
+set -g @color_chip_wt_del_fg   "#7a1f2a"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # dotfiles — Claude Code instructions
 
-Personal multi-theme, multi-font setup for Ghostty + tmux + vim + fish. `theme-set` swaps between 6 themes (Solarized Dark / Mocha / Dracula / Gruvbox / Tokyo Night Storm / Catppuccin Latte) and `font-set` between 17 Nerd Fonts; both switch live. Solarized Dark and JetBrains Mono are the bootstrap defaults. See "Switchable themes" and "Switchable Ghostty fonts" below.
+Personal multi-theme, multi-font setup for Ghostty + tmux + vim + fish. `theme-set` swaps between 7 themes (Solarized Dark / Mocha / Frappé / Dracula / Gruvbox / Tokyo Night Storm / Catppuccin Latte) and `font-set` between 17 Nerd Fonts; both switch live. Solarized Dark and JetBrains Mono are the bootstrap defaults. See "Switchable themes" and "Switchable Ghostty fonts" below.
 
 ## Conventions — don't drift from these
 
@@ -209,7 +209,7 @@ Personal multi-theme, multi-font setup for Ghostty + tmux + vim + fish. `theme-s
   were noise, not signal. Run `:Lazy restore` against the working
   tree's own lockfile when you need reproducibility on a single
   machine.
-- **Switchable themes — Solarized Dark ↔ Catppuccin Mocha ↔ Dracula ↔ Gruvbox ↔ Tokyo Night Storm ↔ Catppuccin Latte.**
+- **Switchable themes — Solarized Dark ↔ Catppuccin Mocha ↔ Catppuccin Frappé ↔ Dracula ↔ Gruvbox ↔ Tokyo Night Storm ↔ Catppuccin Latte.**
   Solarized Dark is the canonical default. Catppuccin Latte is the **first
   and only light theme** and ships with **partial tier-1 coverage**: only
   Ghostty, tmux, and starship have Latte variants — delta, glow, gh-dash,
@@ -256,7 +256,18 @@ Personal multi-theme, multi-font setup for Ghostty + tmux + vim + fish. `theme-s
   (Ctrl-R history, Ctrl-T file picker) use ANSI palette refs (0–15,
   `-1` = terminal default) in `FZF_DEFAULT_OPTS` — auto-adapt to
   whatever Ghostty's 16-color palette is, no per-theme switch
-  needed. Dracula uses dark-on-pastel chip text too
+  needed. Frappé sits between Mocha and Latte on the Catppuccin spectrum (base
+  `#303446`, lifted vs Mocha's `#1e1e2e`). Uses dark-on-pastel chip text
+  like Mocha (`@color_light_fg = "#232634"` = Frappé crust). Starship
+  `pastel_rose` is **mauve `#ca9ee6`** (deliberate divergence from Mocha's
+  pink — Catppuccin's headline accent gives Frappé its own visual
+  identity). bat 0.26+ ships `Catppuccin Frappé` built-in; vivid 0.11+
+  ships `catppuccin-frappe`; Ghostty 1.0+ ships the preset; the vendored
+  `lnav/configs/installed/catppuccin.json` already defines
+  `catppuccin-frappe` (no extra vendoring). The `catppuccin/nvim` plugin
+  (already installed for Mocha) provides the `catppuccin-frappe`
+  colorscheme.
+  Dracula uses dark-on-pastel chip text too
   (`@color_light_fg = "#282a36"`), matching Mocha's inversion rather
   than Solarized's light-on-saturated. Dracula has no pure blue
   accent: `@color_accent_blue` reuses the comment hex `#6272a4`,

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotfiles
 
-Personal config for Ghostty + fish + tmux + vim — multi-theme (Solarized Dark / Mocha / Dracula / Gruvbox / Tokyo Night Storm / Catppuccin Latte via `theme-set`) and multi-font (17 Nerd Fonts via `font-set`). Solarized Dark and JetBrains Mono are the defaults.
+Personal config for Ghostty + fish + tmux + vim — multi-theme (Solarized Dark / Mocha / Frappé / Dracula / Gruvbox / Tokyo Night Storm / Catppuccin Latte via `theme-set`) and multi-font (17 Nerd Fonts via `font-set`). Solarized Dark and JetBrains Mono are the defaults.
 
 <p align="center">
   <a href="docs/images/example_terminal.png"><img src="docs/images/example_terminal-thumb.png" alt="terminal" width="32%" /></a>
@@ -117,11 +117,12 @@ These drive the `claude[<name>]` window title (tmux's
 
 ## Switching themes
 
-Six themes are wired: **Solarized Dark** (default), **Catppuccin Mocha**, **Dracula**, **Gruvbox Dark Medium**, **Tokyo Night Storm**, and **Catppuccin Latte** (the first and only light theme).
+Seven themes are wired: **Solarized Dark** (default), **Catppuccin Mocha**, **Catppuccin Frappé**, **Dracula**, **Gruvbox Dark Medium**, **Tokyo Night Storm**, and **Catppuccin Latte** (the first and only light theme).
 Swap via the fish function `theme-set`:
 
 ```fish
 theme-set mocha        # switch to Catppuccin Mocha
+theme-set frappe       # switch to Catppuccin Frappé (lifted bg, mauve accent)
 theme-set dracula      # switch to Dracula
 theme-set gruvbox      # switch to Gruvbox Dark Medium
 theme-set tokyo-night  # switch to Tokyo Night Storm

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -274,6 +274,7 @@ mkdir -p "$HOME/.vim/undo" "$HOME/.vim/backup" "$HOME/.vim/swap"
 # Five variant configs tracked; active one symlinked machine-locally.
 link ".config/starship-solarized.toml"   "$HOME/.config/starship-solarized.toml"
 link ".config/starship-mocha.toml"       "$HOME/.config/starship-mocha.toml"
+link ".config/starship-frappe.toml"      "$HOME/.config/starship-frappe.toml"
 link ".config/starship-dracula.toml"     "$HOME/.config/starship-dracula.toml"
 link ".config/starship-gruvbox.toml"     "$HOME/.config/starship-gruvbox.toml"
 link ".config/starship-tokyo-night.toml" "$HOME/.config/starship-tokyo-night.toml"

--- a/scripts/test-theme-switch.sh
+++ b/scripts/test-theme-switch.sh
@@ -90,7 +90,17 @@ assert_link "$HOME/.config/glow/glamour.json"                 "glamour-mocha.jso
 assert_gh_dash_config "#cdd6f4" "gh-dash config.yml ← base + theme-colors-mocha"
 assert_link "$HOME/.config/lnav/configs/installed/theme.json" "theme-mocha.json"         "lnav theme.json → theme-mocha.json"
 
-# Forward: mocha → dracula
+# Forward: mocha → frappe
+run_theme_set frappe
+assert_link "$HOME/.config/themes/current.tmux"               "frappe.tmux"                "current.tmux → frappe.tmux"
+assert_link "$HOME/.config/themes/delta-current.gitconfig"    "delta-frappe.gitconfig"     "delta-current.gitconfig → delta-frappe.gitconfig"
+assert_link "$HOME/.config/ghostty/theme.ghostty"             "theme-frappe.ghostty"       "ghostty theme.ghostty → theme-frappe.ghostty"
+assert_link "$HOME/.config/starship.toml"                     "starship-frappe.toml"       "starship.toml → starship-frappe.toml"
+assert_link "$HOME/.config/glow/glamour.json"                 "glamour-frappe.json"        "glow glamour.json → glamour-frappe.json"
+assert_gh_dash_config "#c6d0f5" "gh-dash config.yml ← base + theme-colors-frappe"
+assert_link "$HOME/.config/lnav/configs/installed/theme.json" "theme-frappe.json"          "lnav theme.json → theme-frappe.json"
+
+# Forward: frappe → dracula
 run_theme_set dracula
 assert_link "$HOME/.config/themes/current.tmux"               "dracula.tmux"               "current.tmux → dracula.tmux"
 assert_link "$HOME/.config/themes/delta-current.gitconfig"    "delta-dracula.gitconfig"    "delta-current.gitconfig → delta-dracula.gitconfig"


### PR DESCRIPTION
## 🎨 Summary

- ✨ 7th switchable theme: **Catppuccin Frappé** (`theme-set frappe`), full tier-1 coverage
- 🌗 Lifted dark base `#303446` — sits between Mocha and Latte on the Catppuccin spectrum
- 🟣 Starship accent: **mauve `#ca9ee6`** (deliberate divergence from Mocha's pink — Catppuccin's headline accent gives Frappé its own visual identity)
- 🗂️ New files: `frappe.tmux`, `delta-frappe.gitconfig`, `theme-frappe.ghostty`, `glamour-frappe.json`, `theme-colors-frappe.yml`, `theme-frappe.json` (lnav), `starship-frappe.toml`
- 🔌 Wired into: `theme-set.fish` dispatcher, nvim theme resolver, `bootstrap.sh`, `test-theme-switch.sh`

All theme-variant files are built-in (Ghostty 1.0+, bat 0.26+, vivid 0.11+, vendored lnav catppuccin.json) — no new vendoring needed.

> **Ghostty note:** catalog name is `Catppuccin Frappe` (no accent) — theme file uses that exact string.

## ✅ Test plan

- [x] `REPO=<worktree> bash scripts/test-theme-switch.sh` — **45 passed, 0 failed** (up from 38 before)
- [x] `bash scripts/test-helpers.sh` — 25 passed, 4 failed (pre-existing glow symlink check failures, unrelated to this change)
- [x] `theme-set frappe` flips all 7 symlinks correctly
- [x] starship TOML parses cleanly (`STARSHIP_CONFIG=... starship print-config`)
- [x] U+E0B4 powerline cap glyph confirmed present in starship config (python3 count: 1)

## 📊 Session stats

| | |
|---|---|
| Start | 2026-05-13 20:43 UTC |
| End | 2026-05-13 22:15 UTC |
| Elapsed | 1h 31m |
| Working | 1h 19m (86% of elapsed) |
| Total tokens | 19.0M |
| **Total cost** | **$9.21** (public API rates) |
| Effective rate | $6.99/hr |

| Model | Messages | Input | Output | Cache Read | Cost |
|---|---|---|---|---|---|
| Sonnet 4.6 | 230 | 284 | 76.0k | 18.5M | $9.21 |

> Cost computed at public Anthropic API rates. Claude Max/Pro plan billing differs — incremental cost may be lower within plan limits. Cache reads dominate (normal — prompt caching at ~10% of base input price).