### PR TITLE
🐟 fish: add wt-primary helper + path-expanding wtp abbreviation

### DIFF
--- a/.config/fish/conf.d/35-abbreviations.fish
+++ b/.config/fish/conf.d/35-abbreviations.fish
@@ -38,5 +38,8 @@ abbr -a ghd   gh dash
 # Function-based abbr: `wtp` + space expands to the primary worktree's
 # absolute path (re-evaluated per use). Lets tab-completion work on paths
 # underneath, e.g. `ls wtp<space>/.sup<tab>` → `ls /.../.superpowers/`.
+# `--position anywhere` is essential — without it the abbr would only fire
+# when `wtp` is in command position, but our use case is argument position
+# (`ls wtp`, `cd wtp`, etc.).
 # Non-zero exit from wt-primary (outside a git repo) leaves `wtp` unexpanded.
-abbr -a wtp --function wt-primary
+abbr -a wtp --position anywhere --function wt-primary

--- a/.config/fish/conf.d/35-abbreviations.fish
+++ b/.config/fish/conf.d/35-abbreviations.fish
@@ -33,3 +33,6 @@ abbr -a grb   git rebase
 
 # GitHub TUI dashboard (gh extension; installed by bootstrap.sh)
 abbr -a ghd   gh dash
+
+# Git worktrees (companion to the `wt` CLI)
+abbr -a wtp   wt-primary

--- a/.config/fish/conf.d/35-abbreviations.fish
+++ b/.config/fish/conf.d/35-abbreviations.fish
@@ -34,5 +34,9 @@ abbr -a grb   git rebase
 # GitHub TUI dashboard (gh extension; installed by bootstrap.sh)
 abbr -a ghd   gh dash
 
-# Git worktrees (companion to the `wt` CLI)
-abbr -a wtp   wt-primary
+# Git worktrees (companion to the `wt` CLI).
+# Function-based abbr: `wtp` + space expands to the primary worktree's
+# absolute path (re-evaluated per use). Lets tab-completion work on paths
+# underneath, e.g. `ls wtp<space>/.sup<tab>` → `ls /.../.superpowers/`.
+# Non-zero exit from wt-primary (outside a git repo) leaves `wtp` unexpanded.
+abbr -a wtp --function wt-primary

--- a/.config/fish/functions/wt-primary.fish
+++ b/.config/fish/functions/wt-primary.fish
@@ -1,0 +1,9 @@
+function wt-primary --description 'Print the primary worktree root (works from any worktree of the current repo)'
+    # Bulletproof against --separate-git-dir: the first entry in
+    # `git worktree list --porcelain` is always the primary checkout.
+    set -l primary (git worktree list --porcelain 2>/dev/null | awk '/^worktree /{print $2; exit}')
+    if test -z "$primary"
+        return 1
+    end
+    echo $primary
+end


### PR DESCRIPTION
## 🐟 Summary

- New `wt-primary` fish function: prints the primary worktree's absolute path from any worktree of the current repo (uses `git worktree list --porcelain`, bulletproof against `--separate-git-dir`).
- New `wtp` abbreviation: expands inline to the primary's path so tab-completion works on paths underneath — e.g. typing `ls wtp<space>/.con<TAB>` expands `wtp` to the repo root, then completes against `.config/`.
- `--position anywhere` so the abbr fires in argument position (`ls wtp`, `cd wtp`), not just command position. Without it, the default `--position command` would only fire when `wtp` is the first token.
- Outside a git repo, `wt-primary` exits non-zero and fish leaves the abbr unexpanded — the literal `wtp` stays on the line so you see something is off.

## ✅ Test plan

- [ ] `wt-primary` from the primary checkout → prints the primary's path
- [ ] `wt-primary` from a secondary worktree → prints the primary's path (not the worktree's)
- [ ] `wtp<space>` in command position → expands to the path
- [ ] `ls wtp<space>` (argument position) → expands to the path
- [ ] `ls /Users/.../.con<TAB>` after expansion → completes to `.config/`
- [ ] Outside a git repo → `wt-primary` exits non-zero, `wtp` stays literal

## 📂 Files

- `.config/fish/functions/wt-primary.fish` (new)
- `.config/fish/conf.d/35-abbreviations.fish` (`wtp` abbr added)