### PR TITLE
🙈 gitignore_global: ignore .claude/commands/

### DIFF
--- a/.gitignore_global
+++ b/.gitignore_global
@@ -2,6 +2,7 @@
 .claude/settings.local.json
 .claude/todos.json
 .claude/worktrees/
+.claude/commands/
 .claude/logs/
 .claude/.credentials.json
 .claude/scheduled_tasks.lock


### PR DESCRIPTION
## 🙈 Summary

- Add `.claude/commands/` to the global gitignore list.
- Sits next to the other machine-local Claude Code state entries (`settings.local.json`, `todos.json`, `worktrees/`, `logs/`, `.credentials.json`, `scheduled_tasks.lock`).
- `.claude/commands/` holds machine-local custom slash commands; they should never end up committed to any repo on this machine.

## ✅ Test plan

- [ ] In any repo on this machine, `.claude/commands/` is silently ignored by `git status` / `git add .`.
- [ ] Existing repos that had this dir tracked are unaffected (global gitignore only applies to untracked files).