### PR TITLE
🦀 bootstrap: add ~/.dotfiles-extras opt-in for per-machine extras (qmk_hid)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,20 @@ Personal multi-theme, multi-font setup for Ghostty + tmux + vim + fish. `theme-s
 - **`Brewfile` is installed by bootstrap.** `bootstrap.sh` runs
   `brew bundle --file=$DOTFILES/Brewfile` unconditionally at the top,
   before any symlinks. Aborts on failure (`set -euo pipefail`).
+- **`~/.dotfiles-extras` is the per-machine opt-in gate.** Untracked
+  newline-separated list of extras `bootstrap.sh` should install on
+  this machine only. Parsed by `install_extras()`; each known entry
+  (e.g. `qmk_hid`) dispatches to `install_extra_<name>`. Missing
+  file = no-op for the whole block. Unknown entries warn and
+  continue. Per-extra install functions are `command -v`-guarded
+  for idempotency and **warn-don't-abort** on failure (same as the
+  gh-dash extension install) so optional extras can't break
+  whole-machine bootstrap. New extras: add a `case` arm + an
+  `install_extra_<name>` function, document the entry in the
+  README's "Optional extras" table. Don't replace this with a
+  per-machine `Brewfile.local`, env vars, or anything in the repo —
+  the marker file must stay in `$HOME` so the opt-in can't
+  propagate.
 - **Global gitignore is symlinked from `.gitignore_global`.**
   `bootstrap.sh` links it to `~/.gitignore_global` (the path
   `core.excludesfile` already points to). Lists the cross-repo

--- a/README.md
+++ b/README.md
@@ -94,6 +94,31 @@ so this is a one-time manual edit. Add (or merge into) the top-level
 These drive the `claude[<name>]` window title (tmux's
 `automatic-rename-format` reads `@claude_session_name`).
 
+### Optional extras (machine-local opt-in)
+
+`bootstrap.sh` will install extra tools on this machine only if you
+opt in via `~/.dotfiles-extras` — a newline-separated list of extras
+to install. The file is **per-machine**, lives in `$HOME` (not in the
+repo), and is not seeded by bootstrap (opt-in is intentionally
+explicit). `#` comments and blank lines ignored.
+
+Currently supported:
+
+| Entry | Installs | Why opt-in |
+|---|---|---|
+| `qmk_hid` | `rustup` (stable, `--no-modify-path`) + `cargo install --git --tag v0.1.13` of [`FrameworkComputer/qmk_hid`](https://github.com/FrameworkComputer/qmk_hid) | Source build (no macOS release asset). Pulls in ~1 GB Rust toolchain — only worth it on machines with a Framework 16 keyboard. |
+
+Enable on this machine:
+
+```sh
+echo qmk_hid > ~/.dotfiles-extras
+./bootstrap.sh
+```
+
+Re-runs are idempotent (`command -v` guards skip already-installed
+tools). Disable: remove the line; bootstrap stops installing but does
+not uninstall — to undo qmk_hid, run `rustup self uninstall`.
+
 ## What's where
 
 | Tool         | Source path                          | Target              |

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -199,6 +199,46 @@ if ! gh extension list 2>/dev/null | grep -q '^gh dash'; then
     echo "⚠️  gh extension install failed (network?) — re-run bootstrap when online"
 fi
 
+# --- optional extras (per-machine opt-in via ~/.dotfiles-extras)
+# Marker file: ~/.dotfiles-extras, newline-separated list of extras to
+# install. `#` line-comments and blank lines ignored. Missing file = no-op.
+# Each known extra dispatches to install_extra_<name>. Unknown entries
+# warn and continue. Install failures warn and continue (matches the
+# gh-dash extension precedent above — optional extras must not abort
+# whole-machine bootstrap).
+install_extra_qmk_hid() {
+  if ! command -v rustup >/dev/null 2>&1; then
+    echo "🦀 installing rustup (stable toolchain, no PATH edits)..."
+    if ! curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+         | sh -s -- -y --default-toolchain stable --no-modify-path; then
+      echo "⚠️  rustup install failed — skipping qmk_hid"
+      return 0
+    fi
+  fi
+  if ! command -v qmk_hid >/dev/null 2>&1 \
+       && ! [ -x "$HOME/.cargo/bin/qmk_hid" ]; then
+    echo "⌨️  installing qmk_hid v0.1.13 via cargo (source build, ~2 min)..."
+    "$HOME/.cargo/bin/cargo" install \
+      --git https://github.com/FrameworkComputer/qmk_hid \
+      --tag v0.1.13 \
+      --locked \
+      || echo "⚠️  qmk_hid install failed"
+  fi
+}
+
+install_extras() {
+  local marker="$HOME/.dotfiles-extras"
+  [ -f "$marker" ] || return 0
+  while IFS= read -r extra; do
+    case "$extra" in
+      qmk_hid) install_extra_qmk_hid ;;
+      *)       echo "⚠️  unknown extra in ~/.dotfiles-extras: '$extra'" ;;
+    esac
+  done < <(grep -vE '^\s*(#|$)' "$marker")
+}
+
+install_extras
+
 # --- lnav (TUI log navigator)
 # ~/.config/lnav/ is a real dir. formats/installed/ is whole-dir-symlinked to
 # the repo. configs/installed/ is mixed-dir: tracked theme variants


### PR DESCRIPTION
## 🎯 Summary

- ⚙️ Added `install_extras()` + `install_extra_qmk_hid()` to `bootstrap.sh` — gated behind `~/.dotfiles-extras`, a per-machine untracked marker file; missing file is a silent no-op; install failures warn and continue (never aborts bootstrap)
- 📖 Documented the opt-in in `README.md` with a new `### Optional extras` subsection (table, enable/disable commands, idempotency note)
- 📐 Codified `~/.dotfiles-extras` as a convention in `CLAUDE.md` so future extras don't reinvent a different gate

## ✅ Test Plan

- [x] `bash -n bootstrap.sh` — syntax clean
- [x] Negative gate: no marker file → `install_extras` returns silently, no rustup/qmk_hid install attempt
- [x] Positive gate: `echo qmk_hid > ~/.dotfiles-extras` + `./bootstrap.sh` → rustup stable installed (`--no-modify-path`), `qmk_hid v0.1.13` built from source, both at `~/.cargo/bin/`
- [x] Idempotent re-run: `command -v` guards short-circuit, no reinstall
- [x] `qmk_hid --help` launches cleanly
- [x] `./scripts/test-fish-loads.sh` — ✅
- [x] `./scripts/test-helpers.sh` — 10 pre-existing failures (theme mismatch + glow symlink in worktree), 0 new regressions from this PR

## Session stats

| | |
|---|---|
| Start | 2026-05-14 05:30 UTC |
| End | 2026-05-14 06:13 UTC |
| Elapsed | 43m 12s |
| Working | 40m 20s (93%) |
| Cost (public rates) | $3.43 |
| Effective rate | $5.10/hr |

| Model | Messages | Input | Output | Cache Read | Cost |
|---|---|---|---|---|---|
| Sonnet 4.6 | 102 | 125 | 29.8k | 5.8M | $3.43 |

> 💡 Public-rate estimate — plan billing (Max/Pro) may differ. Cache reads dominate at ~10% of base input price.