### PR TITLE
⌨️ qmk_hid: fish completion + man page

### DIFF
--- a/.config/fish/completions/qmk_hid.fish
+++ b/.config/fish/completions/qmk_hid.fish
@@ -1,0 +1,48 @@
+# qmk_hid — RAW HID / VIA CLI for QMK keyboards
+# Upstream: https://github.com/FrameworkComputer/qmk_hid (v0.1.13)
+
+set -l subcommands factory via qmk help
+set -l no_subcmd "not __fish_seen_subcommand_from $subcommands"
+
+# --- global options
+complete -c qmk_hid -n "$no_subcmd" -s l -l list    -d "List connected HID devices"
+complete -c qmk_hid -n "$no_subcmd" -s V -l version -d "Print version"
+complete -c qmk_hid -s v -l verbose -d "Verbose output"
+complete -c qmk_hid -s h -l help    -d "Print help"
+complete -c qmk_hid       -l vid    -d "Vendor ID (hex)"  -x
+complete -c qmk_hid       -l pid    -d "Product ID (hex)" -x
+
+# --- subcommands
+complete -c qmk_hid -n "$no_subcmd" -f -a factory -d "Factory utilities (Framework 16)"
+complete -c qmk_hid -n "$no_subcmd" -f -a via     -d "VIA runtime control (RGB / backlight / EEPROM)"
+complete -c qmk_hid -n "$no_subcmd" -f -a qmk     -d "QMK protocol passthrough"
+complete -c qmk_hid -n "$no_subcmd" -f -a help    -d "Print help for a subcommand"
+
+# `help <subcmd>`
+complete -c qmk_hid -n "__fish_seen_subcommand_from help" -f -a "factory via qmk"
+
+# --- via
+complete -c qmk_hid -n "__fish_seen_subcommand_from via" -l info               -d "VIA protocol/config dump (debug only)"
+complete -c qmk_hid -n "__fish_seen_subcommand_from via" -l device-indication  -d "Flash backlight 3× (identify device)"
+complete -c qmk_hid -n "__fish_seen_subcommand_from via" -l rgb-brightness     -d "Set/get RGB brightness % (0–100)" -x
+complete -c qmk_hid -n "__fish_seen_subcommand_from via" -l rgb-effect         -d "Set/get RGB effect index"          -x
+complete -c qmk_hid -n "__fish_seen_subcommand_from via" -l rgb-effect-speed   -d "Set/get RGB effect speed (0–255)"  -x
+complete -c qmk_hid -n "__fish_seen_subcommand_from via" -l rgb-hue            -d "Set/get RGB hue (0–255)"           -x
+complete -c qmk_hid -n "__fish_seen_subcommand_from via" -l rgb-saturation     -d "Set/get RGB saturation (0–255)"    -x
+complete -c qmk_hid -n "__fish_seen_subcommand_from via" -l rgb-color          -d "Set RGB color (named)" \
+    -x -a "red yellow green cyan blue purple white"
+complete -c qmk_hid -n "__fish_seen_subcommand_from via" -l backlight          -d "Set/get backlight %" -x
+complete -c qmk_hid -n "__fish_seen_subcommand_from via" -l backlight-breathing -d "Set/get backlight breathing" \
+    -x -a "true false"
+complete -c qmk_hid -n "__fish_seen_subcommand_from via" -l save               -d "Persist current settings to EEPROM"
+complete -c qmk_hid -n "__fish_seen_subcommand_from via" -l eeprom-reset       -d "Reset EEPROM (firmware-dependent)"
+complete -c qmk_hid -n "__fish_seen_subcommand_from via" -l bootloader         -d "Jump to bootloader (firmware-dependent)"
+
+# --- qmk
+complete -c qmk_hid -n "__fish_seen_subcommand_from qmk" -s c -l console -d "Listen to QMK debug console"
+
+# --- factory
+complete -c qmk_hid -n "__fish_seen_subcommand_from factory" -l led          -d "Light up a single LED" -x
+complete -c qmk_hid -n "__fish_seen_subcommand_from factory" -s s            -d "(Boolean flag; see qmk_hid help factory)"
+complete -c qmk_hid -n "__fish_seen_subcommand_from factory" -l bios-mode    -d "Toggle BIOS mode"     -x -a "true false"
+complete -c qmk_hid -n "__fish_seen_subcommand_from factory" -l factory-mode -d "Toggle factory mode" -x -a "true false"

--- a/.config/fish/conf.d/00-env.fish
+++ b/.config/fish/conf.d/00-env.fish
@@ -25,6 +25,12 @@ end
 
 fish_add_path -gPm $HOME/.local/bin $HOME/.cargo/bin
 
+# Prepend the user-scope man tree so `man <cmd>` picks up dotfiles-shipped
+# pages (~/.local/share/man/man1/*.1). Trailing colon = "prepend to the
+# default list" per man(1)'s MANPATH grammar; without it macOS replaces the
+# default search path entirely.
+set -gx MANPATH $HOME/.local/share/man:
+
 # Force Claude Code truecolor inside tmux. Single env line; the only tmux
 # integration that survives B-scope.
 if test -n "$TMUX"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -556,7 +556,10 @@ Personal multi-theme, multi-font setup for Ghostty + tmux + vim + fish. `theme-s
   and `lnav/configs/installed` (mixed-dir) +
   `lnav/formats/installed` (whole-dir)),
   `.vimrc`, `.vim/colors`, `.gitignore_global`, `.claude/CLAUDE.md`.
-  `bin/` files symlink to `~/.local/bin/`.
+  `bin/` files symlink to `~/.local/bin/`. `man/*.1` files symlink to
+  `~/.local/share/man/man1/` (user-scope groff/troff pages; `MANPATH` is
+  pre-pended in `.config/fish/conf.d/00-env.fish` so `man <cmd>` picks
+  them up — `qmk_hid.1` is the first).
 - The repo's `.claude/CLAUDE.md` IS the user-global Claude config
   (symlinked to `~/.claude/CLAUDE.md`). Edits apply machine-wide.
 - Helpers: `.config/tmux/bin/{tmux-git-status,claude-tmux-window-name,tmux-ssh-indicator,tmux-pr-detect,tmux-status-right}`.

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -393,6 +393,16 @@ for src in "$DOTFILES"/bin/*; do
   link "bin/$(basename "$src")" "$HOME/.local/bin/$(basename "$src")"
 done
 
+# --- man pages (section 1, user-scope)
+# Mirror the bin/ pattern: each tracked man page is symlinked into the
+# user-scope man tree. macOS's `man` walks $HOME/.local/share/man via
+# /etc/manpaths.d entries on most installs; `manpath` reports the live list.
+mkdir -p "$HOME/.local/share/man/man1"
+for src in "$DOTFILES"/man/*.1; do
+  [ -e "$src" ] || continue
+  link "man/$(basename "$src")" "$HOME/.local/share/man/man1/$(basename "$src")"
+done
+
 # --- TPM (clone if missing; warn but don't abort if offline)
 TPM_DIR="$HOME/.config/tmux/plugins/tpm"
 if [ ! -d "$TPM_DIR/.git" ]; then

--- a/man/qmk_hid.1
+++ b/man/qmk_hid.1
@@ -1,0 +1,173 @@
+.TH QMK_HID 1 "2026-05-14" "qmk_hid 0.1.13" "User Commands"
+.SH NAME
+qmk_hid \- RAW HID and VIA command-line for QMK devices
+.SH SYNOPSIS
+.B qmk_hid
+[\fIOPTIONS\fR] [\fICOMMAND\fR]
+.SH DESCRIPTION
+.B qmk_hid
+is a small Rust CLI that speaks raw HID to QMK and VIA-compatible keyboards.
+It is the runtime counterpart to the QMK
+.BR qmk (1)
+build/flash CLI:
+.B qmk_hid
+talks to keyboards already running QMK firmware and tweaks live state (RGB
+underglow, backlight, EEPROM, bootloader entry).
+.PP
+Although shipped by Framework Computer for the Framework 16 keyboard, it
+works against any HID device that exposes the VIA/QMK protocol.
+.SH GLOBAL OPTIONS
+.TP
+.B \-l, \-\-list
+List connected HID devices, printing vendor ID, product ID, manufacturer,
+product name, firmware version, and serial number.
+.TP
+.B \-v, \-\-verbose
+Verbose protocol logging.
+.TP
+.BI \-\-vid " VID"
+Vendor ID in hex digits. Required when more than one HID device is attached.
+.TP
+.BI \-\-pid " PID"
+Product ID in hex digits. Required when more than one HID device is attached.
+.TP
+.B \-h, \-\-help
+Print help.
+.TP
+.B \-V, \-\-version
+Print version.
+.SH SUBCOMMANDS
+.SS via
+The main runtime surface. Every option follows a get-or-set convention: omit
+the argument to read the current state, supply one to set.
+.TP
+.B \-\-info
+VIA protocol and configuration dump. Self-described upstream as "most likely
+NOT what you're looking for"; debugging only.
+.TP
+.B \-\-device\-indication
+Flash the keyboard backlight three times to physically identify which device
+a vid/pid maps to.
+.TP
+.BI \-\-rgb\-brightness " [PCT]"
+Set or read RGB brightness as a percentage (0\(en100).
+.TP
+.BI \-\-rgb\-effect " [N]"
+Set or read the RGB effect index.
+.B qmk_hid
+does NOT enumerate effect names; the index-to-name mapping is firmware-
+specific. Consult the keyboard's QMK source or its VIA JSON definition for
+the mapping.
+.TP
+.BI \-\-rgb\-effect\-speed " [0-255]"
+Set or read RGB effect speed.
+.TP
+.BI \-\-rgb\-hue " [0-255]"
+Set or read RGB hue.
+.TP
+.BI \-\-rgb\-saturation " [0-255]"
+Set or read RGB saturation.
+.TP
+.BI \-\-rgb\-color " NAME"
+Set RGB color from a named preset. Values:
+.BR red ,
+.BR yellow ,
+.BR green ,
+.BR cyan ,
+.BR blue ,
+.BR purple ,
+.B white .
+.TP
+.BI \-\-backlight " [PCT]"
+Set or read single-color backlight brightness percentage.
+.TP
+.BI \-\-backlight\-breathing " BOOL"
+Set or read backlight breathing
+.RB ( true " or " false ).
+.TP
+.B \-\-save
+Persist current RGB and backlight settings to EEPROM.
+.B Required
+for changes to survive a power cycle. May be passed alone or together with
+a set operation.
+.TP
+.B \-\-eeprom\-reset
+Reset the EEPROM contents. Not supported by all firmware.
+.TP
+.B \-\-bootloader
+Jump the keyboard into the bootloader. Not supported by all firmware.
+.SS qmk
+.TP
+.B \-c, \-\-console
+Listen to the QMK debug console. Upstream recommends
+.B qmk console
+from
+.BR qmk_cli (1)
+instead.
+.SS factory
+Framework 16 production-line utilities. Not relevant for most third-party
+keyboards.
+.TP
+.BI \-\-led " LED"
+Light up a single LED by index.
+.TP
+.B \-s
+Boolean toggle; see
+.B qmk_hid help factory
+for current semantics.
+.TP
+.BI \-\-bios\-mode " BOOL"
+Toggle BIOS mode (\fBtrue\fR or \fBfalse\fR).
+.TP
+.BI \-\-factory\-mode " BOOL"
+Toggle factory mode (\fBtrue\fR or \fBfalse\fR).
+.SH EXAMPLES
+.PP
+List attached HID devices:
+.PP
+.RS
+.EX
+qmk_hid \-l
+.EE
+.RE
+.PP
+Set a keyboard (vid 19f5, pid 3246) to 30% cyan and persist it:
+.PP
+.RS
+.EX
+qmk_hid \-\-vid 19f5 \-\-pid 3246 via \\
+    \-\-rgb\-color cyan \-\-rgb\-brightness 30 \-\-save
+.EE
+.RE
+.PP
+Cycle effect indices to discover which animation each one renders
+(qmk_hid does not enumerate them):
+.PP
+.RS
+.EX
+for i in (seq 0 30)
+    echo "effect $i:"
+    qmk_hid \-\-vid 19f5 \-\-pid 3246 via \-\-rgb\-effect $i
+    sleep 2
+end
+.EE
+.RE
+.SH NOTES
+.IP \(bu 2
+.B \-\-save
+is not implicit. Without it, set operations revert on the next power cycle.
+.IP \(bu 2
+On macOS the first invocation may require granting Input Monitoring
+permission to the parent terminal in System Settings.
+.IP \(bu 2
+.B qmk_hid
+cannot enumerate available RGB effects. The effect index is a single byte
+known only to the firmware; consult the board's QMK source or its VIA JSON
+definition for name mappings.
+.SH SEE ALSO
+.BR qmk (1)
+.SH AUTHORS
+Framework Computer Inc.
+Upstream: https://github.com/FrameworkComputer/qmk_hid
+.SH BUGS
+Report at https://github.com/FrameworkComputer/qmk_hid/issues


### PR DESCRIPTION
## 🎯 Summary

Follow-up polish for PR #220 (qmk_hid opt-in). Two artifacts — discovery + reference — for the `qmk_hid` extra installed via `~/.dotfiles-extras`.

- ⌨️ **Fish completion** at `.config/fish/completions/qmk_hid.fish`. Subcommand-aware (`factory` / `via` / `qmk` / `help`), value enums for `--rgb-color` (red/yellow/green/cyan/blue/purple/white), `--backlight-breathing` / `--bios-mode` / `--factory-mode` (true/false). Picked up automatically by the existing `link_tracked_entries .config/fish/completions` call — no new `link` line in `bootstrap.sh`.
- 📖 **Man page** at `man/qmk_hid.1` (groff section 1). Covers global options, every `via` flag, both deferred sub-surfaces (`qmk`, `factory`), examples, and the gotchas: `--save` is not implicit, `qmk_hid` cannot enumerate available RGB effects, macOS may need Input Monitoring permission on first invocation.

## 📐 New convention — `man/` directory

This PR introduces `man/` as a tracked top-level dir, mirroring the `bin/` pattern:

- 🔗 `bootstrap.sh` loops `\"$DOTFILES\"/man/*.1` and symlinks each into `~/.local/share/man/man1/` (creating the dir if needed). Insertion-point sits right after the `bin/` loop.
- 🐟 `.config/fish/conf.d/00-env.fish` prepends `~/.local/share/man` to `$MANPATH` with a trailing colon (the magic suffix that means \"prepend to default list\" per `man(1)`). Without this, macOS's default `/etc/manpaths` list doesn't walk user-scope pages.
- 📐 `CLAUDE.md`'s \"Where things live\" entry now mentions `man/*.1 → ~/.local/share/man/man1/` so the convention is discoverable by future tools.

This is fish-only by design (per the project shell-preference rule); zsh users on this machine would need a parallel MANPATH line which is intentionally out of scope.

## ✅ Test plan

- 🧪 \`bash -n bootstrap.sh\` — clean (no syntax errors after the man-block insertion)
- 🐟 \`./scripts/test-fish-loads.sh\` — fish config still loads clean with the MANPATH addition
- 🔎 \`fish -c manpath\` — `/Users/martinciu/.local/share/man` appears in the resolved list (verified locally)
- 📚 `man -P cat ./man/qmk_hid.1` — renders sections NAME, SYNOPSIS, DESCRIPTION, GLOBAL OPTIONS, SUBCOMMANDS (via/qmk/factory), EXAMPLES, NOTES, SEE ALSO, AUTHORS, BUGS cleanly
- 🔁 Fish completion sourcing — `fish -c \"source .config/fish/completions/qmk_hid.fish && complete -c qmk_hid\"` registers 28 rules, no errors

End-state once merged: `qmk_hid <Tab>` lists subcommands with descriptions, `qmk_hid via --<Tab>` lists VIA flags with units (\"Set/get RGB brightness % (0–100)\"), and `man qmk_hid` shows the full reference page.

## 🔗 Related

Builds on the qmk_hid opt-in landed in #220. The original PR's review note explicitly deferred \"wrapping qmk_hid commands in fish completions / functions\" — this PR cashes that in.