### PR TITLE
🙈 gitignore_global: ignore .projections.json

### DIFF
--- a/.gitignore_global
+++ b/.gitignore_global
@@ -23,6 +23,7 @@ reports/
 
 # Neovim per-project config
 .nvim.lua
+.projections.json
 
 # Ruby LSP cache
 .ruby-lsp/


### PR DESCRIPTION
## Summary

- Adds `.projections.json` to the global gitignore so projectionist/vim-projectionist per-project config files are never accidentally committed.