### PR TITLE
⌨️ tmux: enable vi mode-keys for copy mode

### DIFF
--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -125,7 +125,8 @@ bind -r ">" swap-window -t +1
 # ─── Reload ─────────────────────────────────
 bind r source-file ~/.config/tmux/tmux.conf \; display "config reloaded"
 
-# ─── Copy mode: PageUp drops into scrollback ───
+# ─── Copy mode: vi keys + PageUp drops into scrollback ───
+set -g mode-keys vi
 bind PageUp copy-mode -u
 
 # ─── PR pin: open in browser ────────────────


### PR DESCRIPTION
## Summary

- Sets `mode-keys vi` so copy mode uses vi keybindings (`v` to select, `y` to yank, `hjkl` to navigate).