### PR TITLE
⌨️ tmux: bind v/y for vi copy-mode selection and yank

### DIFF
--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -128,6 +128,8 @@ bind r source-file ~/.config/tmux/tmux.conf \; display "config reloaded"
 # ─── Copy mode: vi keys + PageUp drops into scrollback ───
 set -g mode-keys vi
 bind PageUp copy-mode -u
+bind -T copy-mode-vi v send -X begin-selection
+bind -T copy-mode-vi y send -X copy-selection-and-cancel
 
 # ─── PR pin: open in browser ────────────────
 # `<prefix> P` opens the current branch's PR in the default browser via


### PR DESCRIPTION
## Summary

- Binds `v` to `begin-selection` in `copy-mode-vi` (tmux defaults to `Space`)
- Binds `y` to `copy-selection-and-cancel` (tmux defaults to `Enter`)