### PR TITLE
⌨️ tmux/ghostty: remap copy-mode scroll from PageUp to Insert

### DIFF
--- a/.config/ghostty/config.ghostty
+++ b/.config/ghostty/config.ghostty
@@ -77,6 +77,12 @@ split-inherit-working-directory = false
 # (The Polish-Pro layout broke the default `cmd+shift+,` for this user.)
 keybind = cmd+ctrl+shift+r=reload_config
 
+# ─── Keybindings (scrolling) ──────────────────
+# Scrolls Ghostty's buffer and passes the key through to apps (e.g. Claude Code).
+# Note: doesn't work inside tmux — tmux snaps the view back immediately.
+keybind = unconsumed:page_up=scroll_page_up
+keybind = unconsumed:page_down=scroll_page_down
+
 # ─── Keybindings (splits) ─────────────────────
 keybind = cmd+d=new_split:right
 keybind = cmd+shift+d=new_split:down

--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -125,9 +125,10 @@ bind -r ">" swap-window -t +1
 # ─── Reload ─────────────────────────────────
 bind r source-file ~/.config/tmux/tmux.conf \; display "config reloaded"
 
-# ─── Copy mode: vi keys + PageUp drops into scrollback ───
+# ─── Copy mode: vi keys + Insert drops into scrollback ───
 set -g mode-keys vi
-bind PageUp copy-mode -u
+unbind -n PageUp
+bind Insert copy-mode -u
 bind -T copy-mode-vi v send -X begin-selection
 bind -T copy-mode-vi y send -X copy-selection-and-cancel
 


### PR DESCRIPTION
## Summary

- 🖥️ **tmux**: unbind the default root-table `PageUp → copy-mode` binding; wire `Insert` instead so `PageUp` passes through to running apps
- 👻 **ghostty**: add `unconsumed:page_up/page_down → scroll_page_up/down` so bare terminal (no tmux) and Claude Code both scroll with PageUp/PageDown

## Notes

- The Ghostty `unconsumed:` bindings don't help inside tmux — tmux snaps the view back immediately after Ghostty scrolls up (known limitation, tracked in [ghostty#6765](https://github.com/ghostty-org/ghostty/issues/6765))
- Inside tmux, use mouse wheel or `<prefix> Insert` to enter copy-mode scroll