### PR TITLE
🙈 gitignore_global: stop ignoring .claude/commands/

### DIFF
--- a/.gitignore_global
+++ b/.gitignore_global
@@ -2,7 +2,6 @@
 .claude/settings.local.json
 .claude/todos.json
 .claude/worktrees/
-.claude/commands/
 .claude/logs/
 .claude/.credentials.json
 .claude/scheduled_tasks.lock


### PR DESCRIPTION
## Summary

- 🗑️ Remove `.claude/commands/` from `.gitignore_global` so custom Claude Code slash commands are tracked and shared across machines