### PR TITLE
⌨️ tmux: move copy-mode scrollback from Insert to prefixed PageUp

### DIFF
--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -125,10 +125,10 @@ bind -r ">" swap-window -t +1
 # ─── Reload ─────────────────────────────────
 bind r source-file ~/.config/tmux/tmux.conf \; display "config reloaded"
 
-# ─── Copy mode: vi keys + Insert drops into scrollback ───
+# ─── Copy mode: vi keys + PageUp drops into scrollback ───
 set -g mode-keys vi
 unbind -n PageUp
-bind Insert copy-mode -u
+bind PageUp copy-mode -u
 bind -T copy-mode-vi v send -X begin-selection
 bind -T copy-mode-vi y send -X copy-selection-and-cancel
 


### PR DESCRIPTION
## Summary

- Replaces `bind Insert copy-mode -u` with `bind PageUp copy-mode -u` (prefix-table)
- Keeps `unbind -n PageUp` so bare PageUp doesn't accidentally trigger scrollback
- Reverts the Insert remap from #226 in favour of the more natural PageUp key

## Test plan

- [ ] `<prefix> PageUp` enters copy-mode and scrolls up
- [ ] Bare `PageUp` does nothing (root-table binding removed)
- [ ] `Insert` no longer enters copy-mode
- [ ] vi copy-mode `v`/`y` selection and yank still work