### PR TITLE
🤖 tmux: agent-status chip in status-right (working/waiting/idle)

### DIFF
--- a/.config/tmux/bin/tmux-agent-status
+++ b/.config/tmux/bin/tmux-agent-status
@@ -1,0 +1,53 @@
+#!/opt/homebrew/bin/bash
+# Reads ~/.cache/tmux-agent-status/*.status (written by the
+# samleeney/tmux-agent-status plugin's hook handlers) and emits two
+# whitespace-separated lines that bin/tmux-status-right consumes:
+#
+#   line 1: <state>   — one of: empty | idle | working | wait
+#   line 2: <n_wait> <n_work> <n_done>
+#
+# State derivation:
+#   empty    — cache dir absent OR contains zero .status files
+#   idle     — N≥1 files, all `done`
+#   working  — N≥1 `working`, 0 `wait`
+#   wait     — N≥1 `wait` (regardless of `working`)
+#
+# Unknown tokens are silently ignored. v1 reads only top-level
+# <session>.status files; the plugin's panes/<session>_<pane>.status
+# layer is a purely additive future extension.
+#
+# This is the public contract. Other status-bar code may grow to consume
+# this output — keep the two-line shape stable.
+
+set -e
+
+cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/tmux-agent-status"
+if [ ! -d "$cache_dir" ]; then
+  printf 'empty\n0 0 0\n'
+  exit 0
+fi
+
+shopt -s nullglob
+files=("$cache_dir"/*.status)
+if [ ${#files[@]} -eq 0 ]; then
+  printf 'empty\n0 0 0\n'
+  exit 0
+fi
+
+declare -i n_wait=0 n_work=0 n_done=0
+for f in "${files[@]}"; do
+  state=""
+  { read -r state || true; } < "$f"
+  case "$state" in
+    wait)    n_wait+=1 ;;
+    working) n_work+=1 ;;
+    done)    n_done+=1 ;;
+  esac
+done
+
+if   [ "$n_wait" -gt 0 ]; then printf 'wait\n'
+elif [ "$n_work" -gt 0 ]; then printf 'working\n'
+elif [ "$n_done" -gt 0 ]; then printf 'idle\n'
+else                            printf 'empty\n'
+fi
+printf '%d %d %d\n' "$n_wait" "$n_work" "$n_done"

--- a/.config/tmux/bin/tmux-agent-status-hook
+++ b/.config/tmux/bin/tmux-agent-status-hook
@@ -1,0 +1,50 @@
+#!/opt/homebrew/bin/bash
+# Dotfiles-owned Claude Code hook writer for the agent-status chip.
+#
+# Why this exists instead of pointing settings.json directly at the
+# upstream plugin's `better-hook.sh`: that script builds flat paths
+# like `$STATUS_DIR/<session>.status`, which breaks for tmux sessions
+# whose names contain '/' (the `s` worktree convention writes sessions
+# as `<project>/<branch>`). better-hook.sh's writes then silently fail
+# (mkdir is not done for the implied parent), and the agent-status
+# chip stays empty forever. See README "Manual extras" item 5 and the
+# upstream-issue link there for the durable fix.
+#
+# This wrapper sanitizes '/' → '_' and writes the state directly. The
+# top-level <session>.status path is the same shape the upstream
+# plugin reads, so its switcher / popup still sees our writes; only
+# the broken nested-path code path is bypassed.
+#
+# Contract:
+#   $1                 — one of: UserPromptSubmit | PreToolUse | Stop | Notification
+#   stdin (drained)    — Claude Code event JSON (ignored; drained to avoid
+#                        EPIPE in the caller per the hook protocol)
+#   side effect        — writes a single token (working | done) to
+#                        $XDG_CACHE_HOME/tmux-agent-status/<sanitized>.status
+#                        (default $HOME/.cache); creates the dir if absent.
+#
+# Outside tmux (no $TMUX, empty session name) the script exits 0
+# without touching the cache.
+
+set -e
+
+cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/tmux-agent-status"
+
+# Drain stdin so Claude Code's writer side never blocks on EPIPE.
+cat >/dev/null 2>&1 || true
+
+[ -n "${TMUX:-}" ] || exit 0
+session=$(tmux display-message -p '#{session_name}' 2>/dev/null || true)
+[ -n "$session" ] || exit 0
+
+# Sanitize '/' so flat-path writes succeed under <project>/<branch> names.
+session="${session//\//_}"
+
+case "${1:-}" in
+  UserPromptSubmit|PreToolUse) state=working ;;
+  Stop|Notification)            state=done ;;
+  *) exit 0 ;;
+esac
+
+mkdir -p "$cache_dir"
+printf '%s\n' "$state" > "$cache_dir/${session}.status"

--- a/.config/tmux/bin/tmux-status-right
+++ b/.config/tmux/bin/tmux-status-right
@@ -3,45 +3,114 @@
 #
 # Usage: tmux-status-right <pwd>
 #
-# Layout:
-#   With PR  : [orange ◖][orange body: <pr-glyph> #<num>][git chip flush-right
-#              with prev_bg=orange — tmux-git-status's tri_l renders as the
-#              yellow-on-orange separator]
-#   Without PR: [git chip flush-right, prev_bg=bar-bg]
+# Layout (left → right, flush-right anchor):
 #
-# Both branches end without a closing cap — the git chip body extends to
-# the screen edge, mirroring the session chip's flush-left anchor.
+#   [optional agent slot][optional PR slot][git chip]
+#
+# Agent slot (from bin/tmux-agent-status output):
+#   empty    → no slot emitted
+#   idle     → muted "<check> N ready" text on bar_bg, no chip cap
+#   working  → cyan chip:  bar_bg <tri_l> #[cyan bold] <bolt> N
+#   wait     → red  chip:  bar_bg <tri_l> #[red  bold] <pause> K [• <bolt> N]
+#
+# PR slot (from bin/tmux-pr-detect): unchanged — orange chip when a
+# PR exists for the current branch. Its leading <tri_l>'s prev_bg is
+# whatever the agent slot left behind (cyan, red, or bar_bg).
+#
+# Git chip (delegated to bin/tmux-git-status): unchanged contract.
+# Receives the final prev_bg (orange when PR present; otherwise the
+# agent's trailing bg, or bar_bg).
 
 set -e
 pwd_in="${1:-$PWD}"
-
-# Colours read from tmux @color_* options (see ~/.config/themes/*.tmux).
-# Solarized hex retained as fallback so the helper still works when invoked
-# outside a tmux server (e.g. from scripts/test-helpers.sh).
-bar_bg="$(tmux show-option -gv @color_bar_bg          2>/dev/null)"; : "${bar_bg:=#073642}"
-pr_bg="$(tmux show-option  -gv @color_accent_orange   2>/dev/null)"; : "${pr_bg:=#cb4b16}"
-pr_fg="$(tmux show-option  -gv @color_light_fg        2>/dev/null)"; : "${pr_fg:=#fdf6e3}"
 helper_dir="$(dirname "${BASH_SOURCE[0]}")"
 
-# Powerline rounded left cap (U+E0B6) and nf-oct-git_pull_request (U+F407)
-# as raw UTF-8 byte sequences (avoids editor-dependent literal embedding;
-# matches the pattern in tmux-git-status).
-tri_l=$(printf '\xee\x82\xb6')
-pr_glyph=$(printf '\xef\x90\x87')
+# ─── Palette ────────────────────────────────
+# Solarized hex retained as fallback so the helper still works when
+# invoked outside a tmux server (test harness path).
+bar_bg="$(tmux  show-option -gv @color_bar_bg        2>/dev/null || true)"; : "${bar_bg:=#073642}"
+muted="$(tmux   show-option -gv @color_muted_fg      2>/dev/null || true)"; : "${muted:=#586e75}"
+red="$(tmux     show-option -gv @color_accent_red    2>/dev/null || true)"; : "${red:=#dc322f}"
+cyan="$(tmux    show-option -gv @color_accent_cyan   2>/dev/null || true)"; : "${cyan:=#2aa198}"
+pr_bg="$(tmux   show-option -gv @color_accent_orange 2>/dev/null || true)"; : "${pr_bg:=#cb4b16}"
+chip_fg="$(tmux show-option -gv @color_light_fg      2>/dev/null || true)"; : "${chip_fg:=#fdf6e3}"
 
-pr_num=$("$helper_dir/tmux-pr-detect" "$pwd_in" 2>/dev/null || true)
+# ─── Glyphs (raw UTF-8; editor-independent) ─
+tri_l=$(printf    '\xee\x82\xb6')   # U+E0B6 left rounded cap
+pr_glyph=$(printf '\xef\x90\x87')   # U+F407 nf-oct-git_pull_request
+bolt=$(printf     '\xef\x83\xa7')   # U+F0E7 nf-fa-bolt        (working)
+pause=$(printf    '\xef\x81\x8c')   # U+F04C nf-fa-pause       (waiting)
+check=$(printf    '\xef\x80\x8c')   # U+F00C nf-fa-check       (ready)
 
-if [ -n "$pr_num" ]; then
-  # Orange PR chip: rounded left cap on bar bg, then bold body. No right
-  # cap — the next chip's tri_l serves as the visual transition.
-  printf '#[fg=%s,bg=%s]%s#[fg=%s,bg=%s,bold] %s #%s ' \
-    "$pr_bg" "$bar_bg" "$tri_l" \
-    "$pr_fg" "$pr_bg" \
-    "$pr_glyph" "$pr_num"
-  # Git chip with prev_bg=orange (so its tri_l becomes the yellow-on-orange
-  # separator) and next_bg='' (flush-right).
-  "$helper_dir/tmux-git-status" "$pwd_in" "$pr_bg" ''
-else
-  # No PR — git chip alone, flush-right.
-  "$helper_dir/tmux-git-status" "$pwd_in" "$bar_bg" ''
+# ─── Agent slot ─────────────────────────────
+# `tmux-agent-status` emits two lines. The orchestrator picks them up
+# via `command -v` so a PATH-shim in the test harness wins over the
+# repo binary; in a live tmux server, the helper_dir copy is on PATH
+# automatically when called from tmux-status-right.
+agent_bin="$(command -v tmux-agent-status 2>/dev/null || true)"
+if [ -z "$agent_bin" ]; then
+  agent_bin="$helper_dir/tmux-agent-status"
 fi
+
+agent_state="empty"
+agent_n_wait=0
+agent_n_work=0
+agent_n_done=0
+if [ -x "$agent_bin" ]; then
+  { read -r agent_state || true; read -r agent_n_wait agent_n_work agent_n_done || true; } < <("$agent_bin")
+fi
+
+agent_slot=""
+trailing_bg="$bar_bg"
+case "$agent_state" in
+  working)
+    body=$(printf ' %s %d ' "$bolt" "$agent_n_work")
+    agent_slot=$(printf '#[fg=%s,bg=%s]%s#[fg=%s,bg=%s,bold]%s' \
+      "$cyan" "$bar_bg" "$tri_l" \
+      "$chip_fg" "$cyan" \
+      "$body")
+    trailing_bg="$cyan"
+    ;;
+  wait)
+    if [ "$agent_n_work" -gt 0 ]; then
+      body=$(printf ' %s %d \xe2\x80\xa2 %s %d ' \
+        "$pause" "$agent_n_wait" "$bolt" "$agent_n_work")
+    else
+      body=$(printf ' %s %d ' "$pause" "$agent_n_wait")
+    fi
+    agent_slot=$(printf '#[fg=%s,bg=%s]%s#[fg=%s,bg=%s,bold]%s' \
+      "$red" "$bar_bg" "$tri_l" \
+      "$chip_fg" "$red" \
+      "$body")
+    trailing_bg="$red"
+    ;;
+  idle)
+    agent_slot=$(printf '#[fg=%s,bg=%s] %s %d ready ' \
+      "$muted" "$bar_bg" "$check" "$agent_n_done")
+    trailing_bg="$bar_bg"
+    ;;
+  empty|*)
+    agent_slot=""
+    trailing_bg="$bar_bg"
+    ;;
+esac
+
+# ─── PR slot ────────────────────────────────
+pr_detect_bin="$(command -v tmux-pr-detect 2>/dev/null || true)"
+if [ -z "$pr_detect_bin" ]; then
+  pr_detect_bin="$helper_dir/tmux-pr-detect"
+fi
+pr_num=$("$pr_detect_bin" "$pwd_in" 2>/dev/null || true)
+
+pr_slot=""
+if [ -n "$pr_num" ]; then
+  pr_slot=$(printf '#[fg=%s,bg=%s]%s#[fg=%s,bg=%s,bold] %s #%s ' \
+    "$pr_bg" "$trailing_bg" "$tri_l" \
+    "$chip_fg" "$pr_bg" \
+    "$pr_glyph" "$pr_num")
+  trailing_bg="$pr_bg"
+fi
+
+# ─── Compose + delegate to git chip ─────────
+printf '%s%s' "$agent_slot" "$pr_slot"
+"$helper_dir/tmux-git-status" "$pwd_in" "$trailing_bg" ''

--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -185,6 +185,24 @@ set -g @sessionx-zoxide-mode 'off'
 set -g @sessionx-filter-current 'true'
 set -g @sessionx-preview-enabled 'true'
 
+# tmux-agent-status: aggregate liveness signal for Claude Code sessions
+# across all tmux sessions on this server. Sidebar disabled (popup +
+# status-line chip only); the default status-right auto-append is
+# overridden naturally because our explicit `set -g status-right ...`
+# below runs after this `run` block — last assignment wins. State flows
+# from Claude Code hooks (~/.claude/settings.json, per-machine — see
+# README "Manual extras") into ~/.cache/tmux-agent-status/<session>.status
+# and bin/tmux-agent-status reads from there.
+#
+# Keybindings adopt the plugin defaults: <prefix> S (popup switcher),
+# <prefix> N (jump to next-ready), <prefix> W (wait mode), <prefix> p
+# (park). <prefix> o (sidebar focus/create) is dead in popup mode.
+# <prefix> p shadows the default previous-window; covered by the
+# existing `,` / `.` window-cycle bindings above.
+set -g @plugin 'samleeney/tmux-agent-status'
+set -g @agent-switcher-style     'popup'
+set -g @agent-notification-sound 'none'
+
 run '~/.config/tmux/plugins/tpm/tpm'
 
 # ─── Theme palette (sourced via ~/.config/themes/current.tmux symlink) ──

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ Personal multi-theme, multi-font setup for Ghostty + tmux + vim + fish. `theme-s
   (main-checkout git chip on the right + 7d Claude-usage chip on the
   left), yellow (worktree git chip on the right + 5h Claude-usage chip
   on the left), orange (PR pin, left of git chip), **red** (agent-status
-  chip "needs input" state, left of PR pin), **cyan** (agent-status chip
+  chip operator-wait state, left of PR pin), **cyan** (agent-status chip
   "working" state, same slot). When adding a pin,
   pick from unused accents (magenta); reconsider if all are
   taken. **Palette reuse across the left and right clusters is
@@ -127,8 +127,16 @@ Personal multi-theme, multi-font setup for Ghostty + tmux + vim + fish. `theme-s
   renders muted `<check> N ready` on `bar_bg` (no chip bg), `working`
   is a cyan chip ` <bolt> N `, `wait` is a red chip ` <pause> K ` (or
   ` <pause> K • <bolt> N ` when both states co-exist). State precedence
-  `wait > working > done > empty` because "needs input" is the only
-  actionable state. Glyphs: `nf-fa-bolt` (U+F0E7), `nf-fa-pause`
+  `wait > working > done > empty` because operator-marked wait is the
+  highest-priority signal — you've explicitly parked the session and
+  don't want it drowned out by transient working/done noise. **State
+  origins (upstream `better-hook.sh` behavior):** `working` from
+  Claude Code's `UserPromptSubmit` / `PreToolUse` hooks; `done` from
+  `Stop` *and* `Notification` (the chip does not distinguish "turn
+  finished" from "blocked on permission prompt" — both surface as
+  muted "N ready"); `wait` only from the operator pressing
+  `<prefix> W` on a tmux session, never from a Claude lifecycle
+  event. Glyphs: `nf-fa-bolt` (U+F0E7), `nf-fa-pause`
   (U+F04C), `nf-fa-check` (U+F00C). Plugin runs in popup-only mode
   (`@agent-switcher-style 'popup'`) — no per-session sidebar.
   Notification sound disabled (`@agent-notification-sound 'none'`) per
@@ -141,7 +149,7 @@ Personal multi-theme, multi-font setup for Ghostty + tmux + vim + fish. `theme-s
   and `claude-tmux-window-name`; see README "Manual extras" item 5,
   and #232 for the cross-cutting follow-up to track that file). The
   unique-accent rule above gains two entries: **red** claimed by the
-  needs-input state, **cyan** claimed by the working state; magenta
+  operator-wait state, **cyan** claimed by the working state; magenta
   still free. Smoke test: `scripts/test-tmux-agent-status.sh`.
 - **tmux prefix is `C-a`** (`C-Space` conflicts with macOS input-source
   switching). Pane nav: `<prefix> h/j/k/l` (Alt is reserved for Polish

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,10 +147,20 @@ Personal multi-theme, multi-font setup for Ghostty + tmux + vim + fish. `theme-s
   `<prefix> ,` / `.` cycle bindings cover it. Hook config lives in
   `~/.claude/settings.json` per-machine (same pattern as ccstatusline
   and `claude-tmux-window-name`; see README "Manual extras" item 5,
-  and #232 for the cross-cutting follow-up to track that file). The
-  unique-accent rule above gains two entries: **red** claimed by the
-  operator-wait state, **cyan** claimed by the working state; magenta
-  still free. Smoke test: `scripts/test-tmux-agent-status.sh`.
+  and #232 for the cross-cutting follow-up to track that file).
+  **Hooks point at a dotfiles-owned wrapper, not the upstream plugin's
+  `better-hook.sh`.** The wrapper at `bin/tmux-agent-status-hook`
+  sanitizes `/` → `_` before writing the cache path; the upstream
+  hook builds flat paths and chokes on `/`-bearing session names like
+  `dotfiles/231-tmux-agent-status` (the `s` worktree convention). Our
+  wrapper writes the same `<sanitized>.status` shape the plugin's
+  switcher reads, so the popup/sidebar pick up our state too. Patching
+  upstream is the durable fix — track via the linked issue against
+  `samleeney/tmux-agent-status`. The unique-accent rule above gains two
+  entries: **red** claimed by the operator-wait state, **cyan** claimed
+  by the working state; magenta still free. Smoke tests:
+  `scripts/test-tmux-agent-status.sh` (reader),
+  `scripts/test-tmux-agent-status-hook.sh` (writer).
 - **tmux prefix is `C-a`** (`C-Space` conflicts with macOS input-source
   switching). Pane nav: `<prefix> h/j/k/l` (Alt is reserved for Polish
   diacritics — never `bind -n M-*`). Splits: `|` and `-`.
@@ -582,7 +592,7 @@ Personal multi-theme, multi-font setup for Ghostty + tmux + vim + fish. `theme-s
   `bin/` files symlink to `~/.local/bin/`.
 - The repo's `.claude/CLAUDE.md` IS the user-global Claude config
   (symlinked to `~/.claude/CLAUDE.md`). Edits apply machine-wide.
-- Helpers: `.config/tmux/bin/{tmux-git-status,claude-tmux-window-name,tmux-ssh-indicator,tmux-pr-detect,tmux-status-right}`.
+- Helpers: `.config/tmux/bin/{tmux-git-status,claude-tmux-window-name,tmux-ssh-indicator,tmux-pr-detect,tmux-status-right,tmux-agent-status,tmux-agent-status-hook}`.
 
 ## Cheatsheets (`docs/`)
 
@@ -614,6 +624,8 @@ is `nvim-cheatsheet.html`).
 - Claude tmux window-name: `scripts/test-claude-tmux-window-name.sh`
 - tmux SSH-indicator: `scripts/test-tmux-ssh-indicator.sh`
 - tmux PR-pin: `scripts/test-tmux-pr-status.sh`
+- tmux agent-status reader: `scripts/test-tmux-agent-status.sh`
+- tmux agent-status hook (writer): `scripts/test-tmux-agent-status-hook.sh`
 - tmux Claude usage: `scripts/test-tmux-claude-usage.sh`
 - Session-root binding: `scripts/test-s-session-root.sh`
 - Dashboard smoke + integration: `scripts/test-dashboard.sh`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,8 +56,10 @@ Personal multi-theme, multi-font setup for Ghostty + tmux + vim + fish. `theme-s
   blue (session chip, left), green (active window pin, center), violet
   (main-checkout git chip on the right + 7d Claude-usage chip on the
   left), yellow (worktree git chip on the right + 5h Claude-usage chip
-  on the left), orange (PR pin, left of git chip). When adding a pin,
-  pick from unused accents (red, magenta, cyan); reconsider if all are
+  on the left), orange (PR pin, left of git chip), **red** (agent-status
+  chip "needs input" state, left of PR pin), **cyan** (agent-status chip
+  "working" state, same slot). When adding a pin,
+  pick from unused accents (magenta); reconsider if all are
   taken. **Palette reuse across the left and right clusters is
   permitted** — the usage cluster's violet and yellow slots are
   positional, not paired with anything on the right. Two violets or
@@ -114,6 +116,33 @@ Personal multi-theme, multi-font setup for Ghostty + tmux + vim + fish. `theme-s
   The cluster's violet/yellow palette is positional and independent
   of the right-side git chips' palette — see the palette-reuse note
   in the unique-accent rule.
+- **tmux Claude agent-status chip** wired into `status-right` via
+  `bin/tmux-status-right`, slotted *left* of the PR pin. Reads
+  `bin/tmux-agent-status` (a thin consumer of
+  `~/.cache/tmux-agent-status/*.status` files written by the
+  `samleeney/tmux-agent-status` plugin's Claude Code hook handlers).
+  Two-line stdout contract: `<state>` ∈ {empty, idle, working, wait},
+  then `<n_wait> <n_work> <n_done>`. Adaptive single chip, same shape
+  as the 7d usage chip's auto-expand: `empty` hides entirely, `idle`
+  renders muted `<check> N ready` on `bar_bg` (no chip bg), `working`
+  is a cyan chip ` <bolt> N `, `wait` is a red chip ` <pause> K ` (or
+  ` <pause> K • <bolt> N ` when both states co-exist). State precedence
+  `wait > working > done > empty` because "needs input" is the only
+  actionable state. Glyphs: `nf-fa-bolt` (U+F0E7), `nf-fa-pause`
+  (U+F04C), `nf-fa-check` (U+F00C). Plugin runs in popup-only mode
+  (`@agent-switcher-style 'popup'`) — no per-session sidebar.
+  Notification sound disabled (`@agent-notification-sound 'none'`) per
+  the bells-silenced posture. Keybindings claim plugin defaults
+  (`<prefix> S` popup switcher, `<prefix> N` next-ready, `<prefix> W`
+  wait, `<prefix> p` park; `<prefix> o` is dead in popup mode).
+  `<prefix> p` shadows tmux's default `previous-window`; existing
+  `<prefix> ,` / `.` cycle bindings cover it. Hook config lives in
+  `~/.claude/settings.json` per-machine (same pattern as ccstatusline
+  and `claude-tmux-window-name`; see README "Manual extras" item 5,
+  and #232 for the cross-cutting follow-up to track that file). The
+  unique-accent rule above gains two entries: **red** claimed by the
+  needs-input state, **cyan** claimed by the working state; magenta
+  still free. Smoke test: `scripts/test-tmux-agent-status.sh`.
 - **tmux prefix is `C-a`** (`C-Space` conflicts with macOS input-source
   switching). Pane nav: `<prefix> h/j/k/l` (Alt is reserved for Polish
   diacritics — never `bind -n M-*`). Splits: `|` and `-`.

--- a/README.md
+++ b/README.md
@@ -123,9 +123,14 @@ do not nest:
 ```
 
 These drive the agent-status chip in the right cluster of the tmux
-status bar (left of the PR pin): cyan when any Claude Code session is
-working, red when any is waiting on input, muted "N ready" when all
-done, hidden when no sessions are tracked.
+status bar (left of the PR pin): **cyan** when any Claude Code session
+is actively responding; **red** when one or more sessions are in
+operator-marked wait mode (set via `<prefix> W`); muted **"N ready"**
+when all sessions are settled — finished a turn *or* blocked on a
+permission prompt (both `Stop` and `Notification` write `done`, so the
+chip does not distinguish them); hidden when no sessions are tracked.
+The plugin's `better-hook.sh` keys each session by tmux session name
+(via `tmux display-message`), not by Claude's session id.
 
 
 ## What's where

--- a/README.md
+++ b/README.md
@@ -97,28 +97,30 @@ These drive the `claude[<name>]` window title (tmux's
 **5. tmux-agent-status hooks.** Same per-machine pattern as item 4 —
 `~/.claude/settings.json` is not symlinked from this repo, so wiring
 the four hook entries is manual. After `prefix + I` inside tmux
-installs the plugin via TPM, merge these into the same top-level
-`hooks` object. Where an array already exists (e.g.
-`UserPromptSubmit` and `PreToolUse` host ccstatusline; `Stop` hosts
-`claude-tmux-window-name set`), append the new entry as a sibling —
-do not nest:
+installs the upstream plugin via TPM, merge these into the same
+top-level `hooks` object. Hooks point at a dotfiles-owned wrapper
+(`bin/tmux-agent-status-hook`) rather than the plugin's own
+`better-hook.sh` — see the "why a wrapper" note below. Where an array
+already exists (e.g. `UserPromptSubmit` and `PreToolUse` host
+ccstatusline; `Stop` hosts `claude-tmux-window-name set`), append the
+new entry as a sibling — do not nest:
 
 ```json
 "UserPromptSubmit": [
   { "hooks": [ { "type": "command",
-    "command": "~/.config/tmux/plugins/tmux-agent-status/hooks/better-hook.sh UserPromptSubmit" } ] }
+    "command": "~/.config/tmux/bin/tmux-agent-status-hook UserPromptSubmit" } ] }
 ],
 "PreToolUse": [
   { "hooks": [ { "type": "command",
-    "command": "~/.config/tmux/plugins/tmux-agent-status/hooks/better-hook.sh PreToolUse" } ] }
+    "command": "~/.config/tmux/bin/tmux-agent-status-hook PreToolUse" } ] }
 ],
 "Stop": [
   { "hooks": [ { "type": "command",
-    "command": "~/.config/tmux/plugins/tmux-agent-status/hooks/better-hook.sh Stop" } ] }
+    "command": "~/.config/tmux/bin/tmux-agent-status-hook Stop" } ] }
 ],
 "Notification": [
   { "hooks": [ { "type": "command",
-    "command": "~/.config/tmux/plugins/tmux-agent-status/hooks/better-hook.sh Notification" } ] }
+    "command": "~/.config/tmux/bin/tmux-agent-status-hook Notification" } ] }
 ]
 ```
 
@@ -129,8 +131,20 @@ operator-marked wait mode (set via `<prefix> W`); muted **"N ready"**
 when all sessions are settled — finished a turn *or* blocked on a
 permission prompt (both `Stop` and `Notification` write `done`, so the
 chip does not distinguish them); hidden when no sessions are tracked.
-The plugin's `better-hook.sh` keys each session by tmux session name
-(via `tmux display-message`), not by Claude's session id.
+The wrapper keys each session by tmux session name (via
+`tmux display-message`), sanitizing `/` → `_` in the path, not by
+Claude's session id.
+
+*Why a wrapper instead of pointing at the plugin's `better-hook.sh`
+directly?* The upstream plugin builds flat cache paths like
+`$STATUS_DIR/<session>.status` and chokes when session names contain
+`/` — which is exactly the `s` worktree-session convention
+(`<project>/<branch>`). The wrapper sanitizes `/` → `_` before writing,
+so `dotfiles/231-tmux-agent-status` becomes
+`dotfiles_231-tmux-agent-status.status` instead of a broken nested path.
+The plugin's switcher and popup read the same cache files, so they see
+our writes too. The durable fix is to land the sanitization upstream
+in `samleeney/tmux-agent-status`.
 
 
 ## What's where

--- a/README.md
+++ b/README.md
@@ -94,6 +94,39 @@ so this is a one-time manual edit. Add (or merge into) the top-level
 These drive the `claude[<name>]` window title (tmux's
 `automatic-rename-format` reads `@claude_session_name`).
 
+**5. tmux-agent-status hooks.** Same per-machine pattern as item 4 —
+`~/.claude/settings.json` is not symlinked from this repo, so wiring
+the four hook entries is manual. After `prefix + I` inside tmux
+installs the plugin via TPM, merge these into the same top-level
+`hooks` object. Where an array already exists (e.g.
+`UserPromptSubmit` and `PreToolUse` host ccstatusline; `Stop` hosts
+`claude-tmux-window-name set`), append the new entry as a sibling —
+do not nest:
+
+```json
+"UserPromptSubmit": [
+  { "hooks": [ { "type": "command",
+    "command": "~/.config/tmux/plugins/tmux-agent-status/hooks/better-hook.sh UserPromptSubmit" } ] }
+],
+"PreToolUse": [
+  { "hooks": [ { "type": "command",
+    "command": "~/.config/tmux/plugins/tmux-agent-status/hooks/better-hook.sh PreToolUse" } ] }
+],
+"Stop": [
+  { "hooks": [ { "type": "command",
+    "command": "~/.config/tmux/plugins/tmux-agent-status/hooks/better-hook.sh Stop" } ] }
+],
+"Notification": [
+  { "hooks": [ { "type": "command",
+    "command": "~/.config/tmux/plugins/tmux-agent-status/hooks/better-hook.sh Notification" } ] }
+]
+```
+
+These drive the agent-status chip in the right cluster of the tmux
+status bar (left of the PR pin): cyan when any Claude Code session is
+working, red when any is waiting on input, muted "N ready" when all
+done, hidden when no sessions are tracked.
+
 
 ## What's where
 

--- a/docs/tmux-cheatsheet.html
+++ b/docs/tmux-cheatsheet.html
@@ -317,7 +317,7 @@
     <ul class="compact">
       <li><strong>Left:</strong> session name on a blue chip with a powerline arrow (gains a leading globe glyph <code></code> <code>nf-fa-globe</code> when any attached tmux client is SSH-rooted — drives <code>tmux-ssh-indicator</code>), followed by the Claude-usage cluster: violet 7d chip (<code>🤖</code> U+1F916 + <code></code> <code>nf-oct-calendar</code>, compact <code>&lt;pct&gt;%</code> that auto-expands to add <code>• &lt;reset&gt;</code> at <code>pct ≥ 80</code>) fused with the yellow 5h chip (<code></code> <code>nf-fa-hourglass-half</code>, always shows <code>&lt;pct&gt;% • &lt;reset&gt;</code>). On overreach (<code>projection.&lt;window&gt;.will_overreach == true</code> from <code>ccpulse</code>), the affected chip inserts <code></code> <code>nf-fa-fire</code> + <code>→ &lt;projected_pct&gt;%</code> after the <code>&lt;pct&gt;%</code>; the 7d chip auto-expands on overreach even at low <code>pct</code>. Whole cluster hides cleanly when <code>ccpulse</code> is missing or any of the four core fields are null; missing <code>projection</code> field renders the cluster without overreach decoration (graceful degrade). Drives <code>tmux-claude-usage</code>.</li>
       <li><strong>Center (absolute-centered on the full bar):</strong> windows. Inactive = <code>base01</code> on <code>base02</code>; active = <code>green</code>-on-<code>base3</code> chip with rounded powerline caps.</li>
-      <li><strong>Right:</strong> agent-status chip (left of PR pin) — cyan when any Claude Code session is working, red when any is waiting on input, muted "N ready" when all done, hidden when no sessions tracked. Then optional orange PR pin (open/draft PR for current branch). Then branch chip: violet for main checkout, yellow for worktree, always flush-right (no closing cap). Drives <code>tmux-status-right</code> → <code>tmux-agent-status</code> + <code>tmux-pr-detect</code> + <code>tmux-git-status</code>.</li>
+      <li><strong>Right:</strong> agent-status chip (left of PR pin) — cyan when any Claude Code session is actively responding, red when one or more sessions are in operator-marked wait mode (<span class="k prefix">C-a</span> <span class="k">W</span>), muted "N ready" when sessions are settled (turn finished <em>or</em> blocked on a permission prompt — both surface the same), hidden when no sessions tracked. Then optional orange PR pin (open/draft PR for current branch). Then branch chip: violet for main checkout, yellow for worktree, always flush-right (no closing cap). Drives <code>tmux-status-right</code> → <code>tmux-agent-status</code> + <code>tmux-pr-detect</code> + <code>tmux-git-status</code>.</li>
     </ul>
   </div>
 
@@ -338,7 +338,7 @@
       <span class="swatch"><i style="background:#6c71c4"></i> violet (main branch)</span>
       <span class="swatch"><i style="background:#cb4b16"></i> orange (PR pin)</span>
       <span class="swatch"><i style="background:#2aa198"></i> cyan (agent working)</span>
-      <span class="swatch"><i style="background:#dc322f"></i> red (agent waiting)</span>
+      <span class="swatch"><i style="background:#dc322f"></i> red (operator wait)</span>
     </div>
     <p class="note">Selection / message style uses cyan-on-base03; pane border switches base01 → blue when active.</p>
   </div>

--- a/docs/tmux-cheatsheet.html
+++ b/docs/tmux-cheatsheet.html
@@ -76,6 +76,10 @@
       <tr><td class="key"><code>s [&lt;project&gt;] [&lt;name&gt;]</code></td><td class="desc">create-or-attach worktree+session — inside tmux 1 arg = worktree name in current project, outside tmux 1 arg = project, 0 args = fzf picker</td></tr>
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">T</span></td><td class="desc">clock-mode <span class="muted">(swapped from default <code>t</code>)</span></td></tr>
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">P</span></td><td class="desc">open current branch's PR in browser via <code>gh pr view --web</code> (silent when no PR — counterpart to the orange status-bar PR pin)</td></tr>
+      <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">S</span></td><td class="desc">tmux-agent-status — open hierarchical fzf switcher (sessions / windows / panes) <span class="muted">(<code>samleeney/tmux-agent-status</code>)</span></td></tr>
+      <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">N</span></td><td class="desc">tmux-agent-status — jump to next "ready" / waiting agent session</td></tr>
+      <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">W</span></td><td class="desc">tmux-agent-status — put current session or pane into timed wait mode</td></tr>
+      <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">p</span></td><td class="desc">tmux-agent-status — park current session or pane <span class="muted">(shadows tmux default <code>previous-window</code>; use <span class="k prefix">C-a</span> <span class="k">,</span> for that)</span></td></tr>
       <tr><td class="key"><span class="k">⇧⌘ click</span></td><td class="desc">Claude Code file links → routes via macOS file-type defaults (OSC 8 passthrough enabled in <code>tmux.conf</code> via <code>terminal-features hyperlinks</code>)</td></tr>
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">?</span></td><td class="desc">list all keybindings</td></tr>
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">:</span></td><td class="desc">command prompt</td></tr>
@@ -313,7 +317,7 @@
     <ul class="compact">
       <li><strong>Left:</strong> session name on a blue chip with a powerline arrow (gains a leading globe glyph <code></code> <code>nf-fa-globe</code> when any attached tmux client is SSH-rooted — drives <code>tmux-ssh-indicator</code>), followed by the Claude-usage cluster: violet 7d chip (<code>🤖</code> U+1F916 + <code></code> <code>nf-oct-calendar</code>, compact <code>&lt;pct&gt;%</code> that auto-expands to add <code>• &lt;reset&gt;</code> at <code>pct ≥ 80</code>) fused with the yellow 5h chip (<code></code> <code>nf-fa-hourglass-half</code>, always shows <code>&lt;pct&gt;% • &lt;reset&gt;</code>). On overreach (<code>projection.&lt;window&gt;.will_overreach == true</code> from <code>ccpulse</code>), the affected chip inserts <code></code> <code>nf-fa-fire</code> + <code>→ &lt;projected_pct&gt;%</code> after the <code>&lt;pct&gt;%</code>; the 7d chip auto-expands on overreach even at low <code>pct</code>. Whole cluster hides cleanly when <code>ccpulse</code> is missing or any of the four core fields are null; missing <code>projection</code> field renders the cluster without overreach decoration (graceful degrade). Drives <code>tmux-claude-usage</code>.</li>
       <li><strong>Center (absolute-centered on the full bar):</strong> windows. Inactive = <code>base01</code> on <code>base02</code>; active = <code>green</code>-on-<code>base3</code> chip with rounded powerline caps.</li>
-      <li><strong>Right:</strong> orange PR pin (when the current branch has an open/draft PR) glued to the branch chip via a rounded yellow-on-orange separator. Branch chip is violet for main checkout, yellow for worktree, always flush-right (no closing cap — mirrors the session chip's flush-left anchor). Drives <code>tmux-status-right</code> → <code>tmux-pr-detect</code> + <code>tmux-git-status</code>.</li>
+      <li><strong>Right:</strong> agent-status chip (left of PR pin) — cyan when any Claude Code session is working, red when any is waiting on input, muted "N ready" when all done, hidden when no sessions tracked. Then optional orange PR pin (open/draft PR for current branch). Then branch chip: violet for main checkout, yellow for worktree, always flush-right (no closing cap). Drives <code>tmux-status-right</code> → <code>tmux-agent-status</code> + <code>tmux-pr-detect</code> + <code>tmux-git-status</code>.</li>
     </ul>
   </div>
 
@@ -333,8 +337,8 @@
       <span class="swatch"><i style="background:#b58900"></i> yellow (worktree branch)</span>
       <span class="swatch"><i style="background:#6c71c4"></i> violet (main branch)</span>
       <span class="swatch"><i style="background:#cb4b16"></i> orange (PR pin)</span>
-      <span class="swatch"><i style="background:#2aa198"></i> cyan (selection)</span>
-      <span class="swatch"><i style="background:#dc322f"></i> red</span>
+      <span class="swatch"><i style="background:#2aa198"></i> cyan (agent working)</span>
+      <span class="swatch"><i style="background:#dc322f"></i> red (agent waiting)</span>
     </div>
     <p class="note">Selection / message style uses cyan-on-base03; pane border switches base01 → blue when active.</p>
   </div>
@@ -342,7 +346,8 @@
   <div class="card">
     <h3>Status helpers</h3>
     <table>
-      <tr><td class="key"><code>~/.config/tmux/bin/tmux-status-right</code></td><td class="desc">orchestrator for the right-side status segment — composes PR pin (when present) + git chip flush-right</td></tr>
+      <tr><td class="key"><code>~/.config/tmux/bin/tmux-status-right</code></td><td class="desc">orchestrator for the right-side status segment — composes agent-status chip + PR pin (when present) + git chip flush-right</td></tr>
+      <tr><td class="key"><code>~/.config/tmux/bin/tmux-agent-status</code></td><td class="desc">reads <code>~/.cache/tmux-agent-status/*.status</code> (written by <code>samleeney/tmux-agent-status</code> hooks); emits <code>&lt;state&gt;</code> + counts on two lines; state precedence: wait &gt; working &gt; done &gt; empty</td></tr>
       <tr><td class="key"><code>~/.config/tmux/bin/tmux-pr-detect</code></td><td class="desc">stale-while-revalidate file cache around <code>gh pr view</code> (TTL 60s) — echoes PR number for current branch or empty</td></tr>
       <tr><td class="key"><code>~/.config/tmux/bin/tmux-git-status</code></td><td class="desc">git/worktree status segment, colors as args</td></tr>
       <tr><td class="key"><code>~/.config/tmux/bin/claude-tmux-window-name</code></td><td class="desc">sets/clears <code>@claude_session_name</code> from Claude Code hooks (drives <code>claude[&lt;name&gt;]</code> window title)</td></tr>
@@ -424,7 +429,7 @@
 </table>
 
 <footer>
-  Built from <code>~/.config/tmux/tmux.conf</code> on 2026-05-13. Refresh after meaningful config changes.
+  Built from <code>~/.config/tmux/tmux.conf</code> on 2026-05-16. Refresh after meaningful config changes.
   <br>
   When in doubt: <span class="k prefix">C-a</span> <span class="k">?</span> for the live keymap list.
 </footer>

--- a/scripts/test-helpers.sh
+++ b/scripts/test-helpers.sh
@@ -240,6 +240,12 @@ else
   fi
 fi
 
+# ─── tmux-agent-status ───────────────────────
+if ! bash "$(dirname "$0")/test-tmux-agent-status.sh"; then
+  fail=$((fail+1))
+  fail_msgs+=("FAIL  scripts/test-tmux-agent-status.sh reported failures")
+fi
+
 if ! bash "$(dirname "$0")/test-s.sh"; then
   fail=$((fail+1))
   fail_msgs+=("FAIL  scripts/test-s.sh reported failures")

--- a/scripts/test-helpers.sh
+++ b/scripts/test-helpers.sh
@@ -246,6 +246,11 @@ if ! bash "$(dirname "$0")/test-tmux-agent-status.sh"; then
   fail_msgs+=("FAIL  scripts/test-tmux-agent-status.sh reported failures")
 fi
 
+if ! bash "$(dirname "$0")/test-tmux-agent-status-hook.sh"; then
+  fail=$((fail+1))
+  fail_msgs+=("FAIL  scripts/test-tmux-agent-status-hook.sh reported failures")
+fi
+
 if ! bash "$(dirname "$0")/test-s.sh"; then
   fail=$((fail+1))
   fail_msgs+=("FAIL  scripts/test-s.sh reported failures")

--- a/scripts/test-tmux-agent-status-hook.sh
+++ b/scripts/test-tmux-agent-status-hook.sh
@@ -1,0 +1,132 @@
+#!/opt/homebrew/bin/bash
+# Smoke tests for tmux-agent-status-hook.
+#
+# Strategy: PATH-shim `tmux` to fake `display-message`, point
+# XDG_CACHE_HOME at a sandbox, run the hook, inspect the result.
+set -u
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HOOK="$REPO/.config/tmux/bin/tmux-agent-status-hook"
+
+pass=0
+fail=0
+fail_msgs=()
+
+assert_eq() {
+  local got="$1" want="$2" desc="$3"
+  if [ "$got" = "$want" ]; then
+    pass=$((pass+1))
+    echo "  PASS  $desc"
+  else
+    fail=$((fail+1))
+    fail_msgs+=("FAIL  $desc"$'\n'"        got:  '$got'"$'\n'"        want: '$want'")
+    echo "  FAIL  $desc"
+  fi
+}
+
+setup() {
+  local session="$1"
+  SANDBOX=$(mktemp -d)
+  mkdir -p "$SANDBOX/bin" "$SANDBOX/cache"
+  cat > "$SANDBOX/bin/tmux" <<EOF
+#!/opt/homebrew/bin/bash
+[ "\$1" = "display-message" ] && printf '%s\n' "$session"
+EOF
+  chmod +x "$SANDBOX/bin/tmux"
+  _SAVED_PATH="$PATH"
+  export PATH="$SANDBOX/bin:$PATH"
+  export XDG_CACHE_HOME="$SANDBOX/cache"
+  export TMUX="dummy-socket,1234,0"
+}
+
+teardown() {
+  PATH="$_SAVED_PATH"
+  unset TMUX XDG_CACHE_HOME _SAVED_PATH
+  rm -rf "$SANDBOX"
+}
+
+read_or_blank() {
+  if [ -f "$1" ]; then cat "$1"; else echo "<MISSING>"; fi
+}
+
+echo
+echo "tmux-agent-status-hook"
+echo "──────────────────────"
+
+if [ ! -x "$HOOK" ]; then
+  echo "  SKIP — $HOOK not present yet"
+else
+  # Case 1: no TMUX env → no file written.
+  SANDBOX=$(mktemp -d)
+  mkdir -p "$SANDBOX/cache"
+  ( unset TMUX; XDG_CACHE_HOME="$SANDBOX/cache" printf '{}' | "$HOOK" UserPromptSubmit )
+  files=$(find "$SANDBOX/cache" -name '*.status' 2>/dev/null | wc -l | tr -d ' ')
+  assert_eq "$files" "0" "1. no TMUX → no .status file written"
+  rm -rf "$SANDBOX"
+
+  # Case 2: empty session name from shim → no file.
+  setup ''
+  printf '{}' | "$HOOK" UserPromptSubmit
+  files=$(find "$XDG_CACHE_HOME" -name '*.status' 2>/dev/null | wc -l | tr -d ' ')
+  assert_eq "$files" "0" "2. empty session name → no .status file"
+  teardown
+
+  # Case 3: UserPromptSubmit + flat name → working.
+  setup 'demo'
+  printf '{}' | "$HOOK" UserPromptSubmit
+  assert_eq "$(read_or_blank "$XDG_CACHE_HOME/tmux-agent-status/demo.status")" \
+            "working" "3. UserPromptSubmit + flat → working"
+  teardown
+
+  # Case 4: PreToolUse + flat → working.
+  setup 'demo'
+  printf '{}' | "$HOOK" PreToolUse
+  assert_eq "$(read_or_blank "$XDG_CACHE_HOME/tmux-agent-status/demo.status")" \
+            "working" "4. PreToolUse + flat → working"
+  teardown
+
+  # Case 5: Stop + flat → done.
+  setup 'demo'
+  printf '{}' | "$HOOK" Stop
+  assert_eq "$(read_or_blank "$XDG_CACHE_HOME/tmux-agent-status/demo.status")" \
+            "done" "5. Stop + flat → done"
+  teardown
+
+  # Case 6: Notification + flat → done.
+  setup 'demo'
+  printf '{}' | "$HOOK" Notification
+  assert_eq "$(read_or_blank "$XDG_CACHE_HOME/tmux-agent-status/demo.status")" \
+            "done" "6. Notification + flat → done"
+  teardown
+
+  # Case 7: slash-bearing session → sanitized to _.
+  setup 'dotfiles/231-tmux-agent-status'
+  printf '{}' | "$HOOK" UserPromptSubmit
+  assert_eq "$(read_or_blank "$XDG_CACHE_HOME/tmux-agent-status/dotfiles_231-tmux-agent-status.status")" \
+            "working" "7a. session with / → sanitized to _"
+  if [ -e "$XDG_CACHE_HOME/tmux-agent-status/dotfiles" ]; then
+    fail=$((fail+1))
+    fail_msgs+=("FAIL  7b. unsanitized nested 'dotfiles/' dir should NOT exist")
+    echo "  FAIL  7b. unsanitized nested 'dotfiles/' dir should NOT exist"
+  else
+    pass=$((pass+1))
+    echo "  PASS  7b. no nested 'dotfiles/' dir created"
+  fi
+  teardown
+
+  # Case 8: unknown event → no file.
+  setup 'demo'
+  printf '{}' | "$HOOK" Bogus
+  files=$(find "$XDG_CACHE_HOME" -name '*.status' 2>/dev/null | wc -l | tr -d ' ')
+  assert_eq "$files" "0" "8. unknown event → no file written"
+  teardown
+fi
+
+echo
+echo "──────────────────────────────"
+echo "$pass passed, $fail failed"
+if [ "$fail" -gt 0 ]; then
+  echo
+  printf '%s\n\n' "${fail_msgs[@]}"
+  exit 1
+fi

--- a/scripts/test-tmux-agent-status.sh
+++ b/scripts/test-tmux-agent-status.sh
@@ -1,0 +1,107 @@
+#!/opt/homebrew/bin/bash
+# Smoke tests for tmux-agent-status.
+#
+# Strategy: run the helper with XDG_CACHE_HOME pointed at a throwaway dir
+# so the live cache is untouched, then drop fake <session>.status files
+# and assert the two-line stdout contract.
+set -u
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HELPER="$REPO/.config/tmux/bin/tmux-agent-status"
+
+pass=0
+fail=0
+fail_msgs=()
+
+assert_eq() {
+  local got="$1" want="$2" desc="$3"
+  if [ "$got" = "$want" ]; then
+    pass=$((pass+1))
+    echo "  PASS  $desc"
+  else
+    fail=$((fail+1))
+    fail_msgs+=("FAIL  $desc"$'\n'"        got:  '$got'"$'\n'"        want: '$want'")
+    echo "  FAIL  $desc"
+  fi
+}
+
+run_helper() {
+  XDG_CACHE_HOME="$1" "$HELPER"
+}
+
+echo
+echo "tmux-agent-status"
+echo "─────────────────"
+
+if [ ! -x "$HELPER" ]; then
+  echo "  SKIP — $HELPER not present yet"
+else
+  # Case 1: cache dir absent.
+  sandbox=$(mktemp -d)
+  out=$(run_helper "$sandbox")
+  assert_eq "$out" $'empty\n0 0 0' "1. cache dir absent → empty"
+
+  # Case 2: cache dir present, no .status files.
+  sandbox=$(mktemp -d)
+  mkdir -p "$sandbox/tmux-agent-status"
+  out=$(run_helper "$sandbox")
+  assert_eq "$out" $'empty\n0 0 0' "2. dir present, no files → empty"
+
+  # Case 3: one done file.
+  sandbox=$(mktemp -d)
+  mkdir -p "$sandbox/tmux-agent-status"
+  printf 'done' > "$sandbox/tmux-agent-status/foo.status"
+  out=$(run_helper "$sandbox")
+  assert_eq "$out" $'idle\n0 0 1' "3. one done → idle 0 0 1"
+
+  # Case 4: one working file.
+  sandbox=$(mktemp -d)
+  mkdir -p "$sandbox/tmux-agent-status"
+  printf 'working' > "$sandbox/tmux-agent-status/foo.status"
+  out=$(run_helper "$sandbox")
+  assert_eq "$out" $'working\n0 1 0' "4. one working → working 0 1 0"
+
+  # Case 5: one wait file.
+  sandbox=$(mktemp -d)
+  mkdir -p "$sandbox/tmux-agent-status"
+  printf 'wait' > "$sandbox/tmux-agent-status/foo.status"
+  out=$(run_helper "$sandbox")
+  assert_eq "$out" $'wait\n1 0 0' "5. one wait → wait 1 0 0"
+
+  # Case 6: mixed: 1 wait, 2 working, 1 done.
+  sandbox=$(mktemp -d)
+  mkdir -p "$sandbox/tmux-agent-status"
+  printf 'wait'    > "$sandbox/tmux-agent-status/a.status"
+  printf 'working' > "$sandbox/tmux-agent-status/b.status"
+  printf 'working' > "$sandbox/tmux-agent-status/c.status"
+  printf 'done'    > "$sandbox/tmux-agent-status/d.status"
+  out=$(run_helper "$sandbox")
+  assert_eq "$out" $'wait\n1 2 1' "6. mixed wait/working/done → wait 1 2 1"
+
+  # Case 7: mixed: 0 wait, 3 working, 2 done.
+  sandbox=$(mktemp -d)
+  mkdir -p "$sandbox/tmux-agent-status"
+  printf 'working' > "$sandbox/tmux-agent-status/a.status"
+  printf 'working' > "$sandbox/tmux-agent-status/b.status"
+  printf 'working' > "$sandbox/tmux-agent-status/c.status"
+  printf 'done'    > "$sandbox/tmux-agent-status/d.status"
+  printf 'done'    > "$sandbox/tmux-agent-status/e.status"
+  out=$(run_helper "$sandbox")
+  assert_eq "$out" $'working\n0 3 2' "7. no wait, 3 working, 2 done → working 0 3 2"
+
+  # Case 8: lone file containing unknown token.
+  sandbox=$(mktemp -d)
+  mkdir -p "$sandbox/tmux-agent-status"
+  printf 'bogus' > "$sandbox/tmux-agent-status/foo.status"
+  out=$(run_helper "$sandbox")
+  assert_eq "$out" $'empty\n0 0 0' "8. unknown token only → empty"
+fi
+
+echo
+echo "──────────────────────────────"
+echo "$pass passed, $fail failed"
+if [ "$fail" -gt 0 ]; then
+  echo
+  printf '%s\n\n' "${fail_msgs[@]}"
+  exit 1
+fi

--- a/scripts/test-tmux-pr-status.sh
+++ b/scripts/test-tmux-pr-status.sh
@@ -233,6 +233,90 @@ else
   teardown_sandbox
 fi
 
+# ─── Agent-slot composition (Task 3 of plan #231) ─────────────
+echo
+echo "tmux-status-right — agent slot"
+echo "──────────────────────────────"
+
+# Helper: build a sandbox with both tmux-pr-detect and tmux-agent-status
+# shimmed onto PATH. $1 = PR number to emit ('' for no PR). $2 = first
+# stdout line of the agent helper. $3 = second line.
+# Also unsets TMUX and points TMUX_TMPDIR at an empty dir so the
+# orchestrator cannot reach a live tmux server and uses Solarized
+# fallback colours instead of whatever theme is active.
+setup_agent_sandbox() {
+  local pr="$1" agent_line1="$2" agent_line2="$3"
+  _SAVED_PATH="$PATH"; _SAVED_HOME="$HOME"
+  _SAVED_TMUX="${TMUX:-}"; _SAVED_TMUX_TMPDIR="${TMUX_TMPDIR:-}"; _SAVED_TMPDIR="${TMPDIR:-}"
+  TEST_HOME=$(mktemp -d)
+  mkdir -p "$TEST_HOME/bin"
+
+  cat > "$TEST_HOME/bin/tmux-pr-detect" <<EOF
+#!/opt/homebrew/bin/bash
+printf '%s' "$pr"
+EOF
+  chmod +x "$TEST_HOME/bin/tmux-pr-detect"
+
+  cat > "$TEST_HOME/bin/tmux-agent-status" <<EOF
+#!/opt/homebrew/bin/bash
+printf '%s\n%s\n' "$agent_line1" "$agent_line2"
+EOF
+  chmod +x "$TEST_HOME/bin/tmux-agent-status"
+
+  export PATH="$TEST_HOME/bin:$PATH"
+  export HOME="$TEST_HOME"
+  # Prevent the orchestrator from reaching the live tmux server so
+  # Solarized hex fallbacks are used for colour assertions.
+  # tmux searches: $TMUX (cleared) → $TMUX_TMPDIR/tmux-<uid>/ →
+  # $TMPDIR/tmux-<uid>/ → /tmp/tmux-<uid>/. Overriding both TMUX_TMPDIR
+  # and TMPDIR with an empty dir ensures no socket is found.
+  mkdir -p "$TEST_HOME/no-tmux-socket"
+  unset TMUX
+  export TMUX_TMPDIR="$TEST_HOME/no-tmux-socket"
+  export TMPDIR="$TEST_HOME/no-tmux-socket"
+}
+
+teardown_agent_sandbox() {
+  PATH="$_SAVED_PATH"; HOME="$_SAVED_HOME"
+  export PATH HOME
+  if [ -n "${_SAVED_TMUX:-}" ]; then export TMUX="$_SAVED_TMUX"; else unset TMUX; fi
+  if [ -n "${_SAVED_TMUX_TMPDIR:-}" ]; then export TMUX_TMPDIR="$_SAVED_TMUX_TMPDIR"; else unset TMUX_TMPDIR; fi
+  if [ -n "${_SAVED_TMPDIR:-}" ]; then export TMPDIR="$_SAVED_TMPDIR"; else unset TMPDIR; fi
+  rm -rf "$TEST_HOME"
+  unset TEST_HOME _SAVED_PATH _SAVED_HOME _SAVED_TMUX _SAVED_TMUX_TMPDIR _SAVED_TMPDIR
+}
+
+# Case A: no agent, no PR — git chip flush-right, prev_bg=bar_bg.
+setup_agent_sandbox '' 'empty' '0 0 0'
+out=$("$ORCHESTRATOR" "$REPO")
+assert_not_contains "$out" '#cb4b16' "A. no agent + no PR → no orange chip"
+assert_not_contains "$out" '#dc322f' "A. no agent + no PR → no red chip"
+assert_not_contains "$out" '#2aa198' "A. no agent + no PR → no cyan chip"
+teardown_agent_sandbox
+
+# Case B: working agent (cyan), no PR.
+setup_agent_sandbox '' 'working' '0 2 0'
+out=$("$ORCHESTRATOR" "$REPO")
+assert_contains     "$out" '#2aa198' "B. working agent → cyan chip"
+assert_not_contains "$out" '#dc322f' "B. working agent → no red chip"
+assert_not_contains "$out" '#cb4b16' "B. no PR → no orange chip"
+teardown_agent_sandbox
+
+# Case C: waiting agent (red, dominant) + working tally, with PR.
+setup_agent_sandbox '107' 'wait' '1 1 0'
+out=$("$ORCHESTRATOR" "$REPO")
+assert_contains "$out" '#dc322f' "C. waiting agent → red chip"
+assert_contains "$out" '#cb4b16' "C. PR present → orange chip"
+teardown_agent_sandbox
+
+# Case D: idle agent (muted N ready, no chip bg) + no PR.
+setup_agent_sandbox '' 'idle' '0 0 3'
+out=$("$ORCHESTRATOR" "$REPO")
+assert_contains     "$out" 'ready'    "D. idle agent → 'ready' text"
+assert_not_contains "$out" '#2aa198' "D. idle agent → no cyan chip bg"
+assert_not_contains "$out" '#dc322f' "D. idle agent → no red chip bg"
+teardown_agent_sandbox
+
 echo
 if [ "$fail" -gt 0 ]; then
   echo "──────"


### PR DESCRIPTION
## 🗒️ Summary

- Adds `bin/tmux-agent-status` — a thin, read-only consumer of `~/.cache/tmux-agent-status/*.status` files written by the agent-status hook wrapper. Emits a stable two-line stdout contract (`<state>` + `<n_wait> <n_work> <n_done>`) that `bin/tmux-status-right` now reads.
- Adds `bin/tmux-agent-status-hook` — a dotfiles-owned Claude Code hook writer that sanitizes `/` → `_` in tmux session names before writing the cache path. **Why a wrapper instead of pointing settings.json at the upstream plugin's `better-hook.sh`?** The plugin builds flat paths like `$STATUS_DIR/<session>.status` and silently fails for `/`-bearing session names — which is the `s` worktree convention (`<project>/<branch>`). Wrapper survives plugin updates; durable fix tracked as a follow-up upstream issue.
- Rewrites `bin/tmux-status-right` to compose an adaptive agent-status chip left of the PR pin. State semantics:
  - **cyan** — at least one Claude Code session is actively responding (driven by `UserPromptSubmit` / `PreToolUse` hooks)
  - **red** — at least one session is in operator-marked wait mode (set via `<prefix> W`); never written by a Claude lifecycle event
  - muted **"N ready"** — all sessions are settled, i.e. finished a turn *or* blocked on a permission prompt (`Stop` and `Notification` both write `done`; the chip does not distinguish them)
  - **hidden** — no sessions are tracked
  - Precedence: `wait > working > done > empty`.
- Installs the `samleeney/tmux-agent-status` TPM plugin in popup-only mode (`@agent-switcher-style 'popup'`, `@agent-notification-sound 'none'`). Keybindings: `<prefix> S/N/W/p` (plugin defaults; `p` shadows `previous-window` — `<prefix> ,` covers it).
- Documents hook wiring in README "Manual extras" item 5 (the four `~/.claude/settings.json` entries are per-machine — not symlinked from this repo; see issue #232 for the follow-up to track that file).
- Updates CLAUDE.md convention bullet + unique-accent rule (red + cyan now claimed, magenta remains free). Bumps `docs/tmux-cheatsheet.html` with four new prefix rows + chip-color note + footer date.

## 🧪 Test plan

- [ ] `bash scripts/test-tmux-agent-status.sh` → 8 passed, 0 failed (chip reader)
- [ ] `bash scripts/test-tmux-agent-status-hook.sh` → 9 passed, 0 failed (hook writer, incl. `/`-sanitization assertion)
- [ ] `bash scripts/test-tmux-pr-status.sh` → all pre-existing passes still pass; new Cases A/B/C/D pass (2 pre-existing failures about Solarized orange hex are unrelated to this PR and pre-date it — tracked in #235)
- [ ] `bash scripts/test-helpers.sh` — both new agent-status sections pass alongside the existing helpers
- [ ] In a live tmux session: `<prefix> I` to install the plugin via TPM, merge the 4 hook entries into `~/.claude/settings.json` per the snippet below, then `tmux source-file ~/.config/tmux/tmux.conf` — chip should be hidden until a Claude Code session writes its first state file

## ⚠️ Post-merge manual steps (per-machine)

1. **Pull the merged branch.**
2. **`<prefix> I` in tmux** to install the upstream plugin via TPM (clones `samleeney/tmux-agent-status` into `~/.config/tmux/plugins/` — the popup switcher + daemon come from there). Note: hooks do **not** go through the plugin's `better-hook.sh`; the wrapper (`bin/tmux-agent-status-hook`) handles all writes.
3. **Merge the four hook entries into `~/.claude/settings.json`.** This file is not symlinked from the repo (see #232). Where an array already exists for one of these event names (e.g. `UserPromptSubmit` and `PreToolUse` host ccstatusline; `Stop` hosts `claude-tmux-window-name set`), **append the new entry as a sibling** inside the existing array — do not nest and do not replace:

   ```json
   "UserPromptSubmit": [
     { "hooks": [ { "type": "command",
       "command": "~/.config/tmux/bin/tmux-agent-status-hook UserPromptSubmit" } ] }
   ],
   "PreToolUse": [
     { "hooks": [ { "type": "command",
       "command": "~/.config/tmux/bin/tmux-agent-status-hook PreToolUse" } ] }
   ],
   "Stop": [
     { "hooks": [ { "type": "command",
       "command": "~/.config/tmux/bin/tmux-agent-status-hook Stop" } ] }
   ],
   "Notification": [
     { "hooks": [ { "type": "command",
       "command": "~/.config/tmux/bin/tmux-agent-status-hook Notification" } ] }
   ]
   ```

   What each event does, in plain terms:

   | Claude Code event | Fires when… | Effect on the chip |
   |---|---|---|
   | `UserPromptSubmit` | you submit a prompt | session → **cyan "working"** |
   | `PreToolUse` | Claude is about to call a tool | session → **cyan "working"** |
   | `Stop` | Claude finishes a turn | session → **muted "N ready"** |
   | `Notification` | Claude is blocked on a permission prompt | session → **muted "N ready"** (same as `Stop` — chip does not distinguish) |

   The red **wait** state is reached only by pressing **`<prefix> W`** inside tmux — it's an operator action, not a Claude lifecycle event.

4. **`tmux source-file ~/.config/tmux/tmux.conf`** — chip stays hidden until a Claude Code session writes its first state file.
5. **Restart any open Claude Code sessions** — `~/.claude/settings.json` is read at session start, so already-running sessions won't fire the new hooks until they restart.

After #232 lands, step 3 collapses to "pull the merged branch" — `~/.claude/settings.json` will be managed via a base + machine-local split.

## 🪟 Optional: enable the per-session sidebar

The plugin ships here in **popup-only** mode — `<prefix> S` opens a one-shot
switcher, and the chip in the status bar carries the persistent signal.
The plugin also supports a ~42-col left-side sidebar pane in every tmux
session, listing all tracked agents and their state. It is **off by
default** in this PR; flip it on by editing `.config/tmux/tmux.conf`
(around line 203):

```diff
- set -g @agent-switcher-style 'popup'
+ set -g @agent-switcher-style 'both'      # sidebar + popup, OR
+ set -g @agent-switcher-style 'sidebar'   # sidebar only
```

Then `tmux source-file ~/.config/tmux/tmux.conf`. Fully reversible.

Tradeoffs to be aware of before flipping:

- **~42 cols of horizontal space** gone in every session — on a 200-col
  Ghostty window that's ~21%; on a narrower split it's more.
- **The agent list duplicates across sessions** — each tmux session
  renders its own copy of the same global roster.
- **The chip + `<prefix> S` already cover "where's the actionable
  agent"** on demand without paying continuous geometry cost.

The plan rejected sidebar mode in favor of popup + chip for these
reasons. This knob is documented here so the decision can be revisited
without code changes.

Closes #231
