### PR TITLE
🧪 test-tmux-pr-status: isolate with-PR tests from live tmux server

### DIFF
--- a/scripts/test-tmux-pr-status.sh
+++ b/scripts/test-tmux-pr-status.sh
@@ -52,8 +52,12 @@ assert_not_contains() {
 }
 
 # Build a sandbox: TEST_HOME for $HOME, plus a bin/ holding our gh shim.
+# Also stubs `tmux` so the orchestrator cannot reach the live tmux server —
+# forcing Solarized hex fallbacks for colour assertions rather than reading
+# the active theme's @color_accent_orange.
 setup_sandbox() {
   local fixture="$1" gh_response="$2"
+  _SAVED_PATH="$PATH"; _SAVED_HOME="$HOME"
   TEST_HOME=$(mktemp -d)
   mkdir -p "$TEST_HOME/bin"
   GH_CALLS="$TEST_HOME/gh-calls"
@@ -75,6 +79,19 @@ esac
 EOF
   chmod +x "$TEST_HOME/bin/gh"
 
+  # Stub `tmux` so show-option returns empty stdout (exit 0) → the
+  # `: "${var:=<solarized-hex>}"` fallbacks in tmux-status-right and
+  # tmux-git-status kick in. Without this, calls to the live tmux server would
+  # return the active theme's @color_accent_orange (e.g. Tokyo Night's #ff9e64)
+  # instead of the Solarized #cb4b16 the assertions expect, making the tests
+  # theme-dependent.
+  cat > "$TEST_HOME/bin/tmux" <<'EOF'
+#!/opt/homebrew/bin/bash
+# Shim: show-option returns empty (triggers Solarized fallbacks); all else no-ops.
+exit 0
+EOF
+  chmod +x "$TEST_HOME/bin/tmux"
+
   # XDG_CACHE_HOME under TEST_HOME so cache files are isolated.
   export XDG_CACHE_HOME="$TEST_HOME/cache"
   export HOME="$TEST_HOME"
@@ -82,10 +99,10 @@ EOF
 }
 
 teardown_sandbox() {
+  PATH="$_SAVED_PATH"; HOME="$_SAVED_HOME"
+  export PATH HOME
   rm -rf "$TEST_HOME"
-  PATH="${PATH#$TEST_HOME/bin:}"
-  export PATH
-  unset TEST_HOME GH_CALLS XDG_CACHE_HOME
+  unset TEST_HOME GH_CALLS XDG_CACHE_HOME _SAVED_PATH _SAVED_HOME
 }
 
 # Wait for a backgrounded refresh to finish writing its cache file.


### PR DESCRIPTION
Closes #235.

## 🐛 The bug

`scripts/test-tmux-pr-status.sh`'s `no-PR path` and `with-PR path` cases assert against Solarized orange `#cb4b16`, but the orchestrator (`bin/tmux-status-right`) reads `@color_accent_orange` from the live tmux server — which resolves to whatever theme is currently active. Under e.g. Tokyo Night (`#ff9e64`), the assertions fail:

```
FAIL  with-PR path: orange in output
        got:  '#[fg=#ff9e64,bg=#24283b]...'
        needle: '#cb4b16'
```

Pre-existing — predates #234, flagged in that PR's review.

## 🛠️ Fix

Add a `tmux` stub binary to `$TEST_HOME/bin/` inside `setup_sandbox`. The existing `PATH=$TEST_HOME/bin:$PATH` prepend already makes the stub take precedence. When the orchestrator calls `tmux show-option -gv @color_accent_orange`, it hits the stub (empty stdout, exit 0) — and the `: \"\${var:=<solarized-hex>}\"` fallbacks in `tmux-status-right` and `tmux-git-status` kick in. Tests now use the hardcoded Solarized hex regardless of the active theme.

Stylistically consistent with the existing `gh` mock in the same `setup_sandbox` — same PATH-shim approach.

## 🧪 Test plan

- [x] `bash scripts/test-tmux-pr-status.sh` under Solarized: 17 passed, 0 failed
- [x] `bash scripts/test-tmux-pr-status.sh` under Tokyo Night: 17 passed, 0 failed
- [x] No change to `bin/tmux-status-right` — orchestrator behavior is correct, only the test fixture needed isolation

## 📎 Notes

- The original issue suggested reusing a `setup_agent_sandbox` pattern that supposedly existed in this file. It does not (`grep` confirms only `setup_sandbox` is defined). The PATH-shim approach used here is a cleaner fit with the file's existing style anyway.