### PR TITLE
👆 tmux-fingers: one-keystroke copy of visible matches

### DIFF
--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -166,6 +166,25 @@ set -g @sessionx-zoxide-mode 'off'
 set -g @sessionx-filter-current 'true'
 set -g @sessionx-preview-enabled 'true'
 
+# tmux-fingers: vimium-style hints for one-keystroke copy of visible
+# matches (paths, URLs, SHAs, k8s names, #N refs, worktree- branches).
+# First-run: after `prefix + I`, the wizard appears — pick "Build from
+# source" (crystal required; already in Brewfile via morantron tap).
+#   <prefix> F  → copy-mode: hint → letter → clipboard
+#   <prefix> J  → jump-mode: hint → letter → cursor at match in copy-mode
+# Hint styles use ANSI palette refs so they auto-adapt across themes.
+# Note: fingers' default <prefix> J shadows the dashboard pager binding
+# (.config/tmux/tmux.conf:141) once TPM loads. Accepted — dashboard is
+# scheduled for retirement separately.
+set -g @plugin 'Morantron/tmux-fingers'
+set -g @fingers-hint-style               "fg=colour9,bold"   # red, bold
+set -g @fingers-highlight-style          "fg=colour13"       # magenta
+set -g @fingers-backdrop-style           "fg=colour10"       # muted base01
+set -g @fingers-selected-hint-style      "fg=colour14,bold"  # cyan, bold
+set -g @fingers-selected-highlight-style "fg=colour14"       # cyan
+set -g @fingers-pattern-0 'worktree-[a-z0-9._/-]+'
+set -g @fingers-pattern-1 '#\d+'
+
 run '~/.config/tmux/plugins/tpm/tpm'
 
 # ─── Theme palette (sourced via ~/.config/themes/current.tmux symlink) ──

--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -169,7 +169,9 @@ set -g @sessionx-preview-enabled 'true'
 # tmux-fingers: vimium-style hints for one-keystroke copy of visible
 # matches (paths, URLs, SHAs, k8s names, #N refs, worktree- branches).
 # First-run: after `prefix + I`, the wizard appears — pick "Build from
-# source" (crystal required; already in Brewfile via morantron tap).
+# source" (crystal required — `brew install crystal` if absent;
+# tmux-fingers is intentionally not in Brewfile, the formula also
+# compiles from source).
 #   <prefix> F  → copy-mode: hint → letter → clipboard
 #   <prefix> J  → jump-mode: hint → letter → cursor at match in copy-mode
 # Hint styles use ANSI palette refs so they auto-adapt across themes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,10 +116,30 @@ Personal multi-theme, multi-font setup for Ghostty + tmux + vim + fish. `theme-s
 - **tmux prefix is `C-a`** (`C-Space` conflicts with macOS input-source
   switching). Pane nav: `<prefix> h/j/k/l` (Alt is reserved for Polish
   diacritics — never `bind -n M-*`). Splits: `|` and `-`.
+- **tmux-fingers gives one-keystroke copy of visible matches.**
+  TPM plugin `Morantron/tmux-fingers`. Bindings: `<prefix> F` enters
+  copy-mode (hint letter → match copied to clipboard via `pbcopy`),
+  `<prefix> J` enters jump-mode (hint letter → cursor at match inside
+  copy-mode). Default per-modifier actions in hint mode: `Ctrl+letter`
+  = open (URL → browser, path → Finder), `Shift+letter` = paste into
+  pane, `Tab` = multi-select. **No `bind -n M-*` recipes** from the
+  README — Alt stays reserved for Polish diacritics.
+  Hint colors use ANSI palette refs (`colour9`/`colour10`/`colour13`/
+  `colour14`) so they auto-adapt across all seven themes via Ghostty's
+  16-color palette — no per-theme variant files, same trick as
+  `FZF_DEFAULT_OPTS`. Custom patterns added on top of the built-ins:
+  `worktree-[a-z0-9._/-]+` (worktree branch names) and `#\d+` (PR/issue
+  refs). Built-ins kept on: `ip`, `uuid`, `sha`, `digit`, `url`, `path`,
+  `hex`, `kubernetes`, `git-status`, `git-status-branch`, `diff`. Fingers'
+  `<prefix> J` shadows the dashboard pager binding once TPM loads;
+  accepted, dashboard is scheduled for retirement separately.
+  **Fresh-machine setup:** after `prefix + I`, the first-run wizard
+  appears — pick "Build from source" (crystal must be on `$PATH`; install
+  via `brew tap morantron/tmux-fingers && brew install crystal` if needed).
 - **TPM is the tmux plugin manager.** Loaded: `tmux-sensible`,
   `tmux-resurrect`, `tmux-continuum` (`@continuum-restore 'on'`),
-  `tmux-sessionx`. Status bar is hand-rolled, behavior plugins aren't —
-  don't remove TPM.
+  `tmux-sessionx`, `tmux-fingers`. Status bar is hand-rolled, behavior
+  plugins aren't — don't remove TPM.
 - **OSC 8 hyperlinks pass through tmux.** Two `terminal-features`
   entries (`xterm-ghostty:hyperlinks`, `xterm-256color:hyperlinks`).
   Without them, tmux strips OSC 8 and Claude Code's file-ref links don't

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,7 +135,10 @@ Personal multi-theme, multi-font setup for Ghostty + tmux + vim + fish. `theme-s
   accepted, dashboard is scheduled for retirement separately.
   **Fresh-machine setup:** after `prefix + I`, the first-run wizard
   appears — pick "Build from source" (crystal must be on `$PATH`; install
-  via `brew tap morantron/tmux-fingers && brew install crystal` if needed).
+  via `brew install crystal` if absent). Why no `brew "tmux-fingers"` in
+  Brewfile: the morantron tap also compiles Crystal from source, so the
+  wizard fires either way — declaring it gains nothing over documenting
+  the one-liner here.
 - **TPM is the tmux plugin manager.** Loaded: `tmux-sensible`,
   `tmux-resurrect`, `tmux-continuum` (`@continuum-restore 'on'`),
   `tmux-sessionx`, `tmux-fingers`. Status bar is hand-rolled, behavior

--- a/docs/tmux-cheatsheet.html
+++ b/docs/tmux-cheatsheet.html
@@ -59,7 +59,7 @@
       <tr><td class="key">Mouse</td><td class="desc">on (URLs: <span class="k">⇧⌘ click</span>)</td></tr>
       <tr><td class="key">History</td><td class="desc">50,000 lines</td></tr>
       <tr><td class="key">Bells</td><td class="desc">silenced (<code>bell-action/visual-bell/monitor-bell off</code>)</td></tr>
-      <tr><td class="key">TPM plugins</td><td class="desc">tpm, tmux-sensible, tmux-resurrect, tmux-continuum, tmux-sessionx</td></tr>
+      <tr><td class="key">TPM plugins</td><td class="desc">tpm, tmux-sensible, tmux-resurrect, tmux-continuum, tmux-sessionx, tmux-fingers</td></tr>
     </table>
   </div>
 
@@ -287,6 +287,28 @@
       <tr><td class="key"><span class="k">v</span> / <span class="k">V</span></td><td class="desc">char / line selection (vi-mode)</td></tr>
     </table>
     <p class="note">Mouse drag also selects. macOS clipboard is wired through tmux's default OSC 52 path; if your terminal supports it (Ghostty does) <span class="k">Enter</span> reaches the system clipboard.</p>
+  </div>
+
+  <div class="card">
+    <h3>Fingers — one-keystroke copy <span class="pill">prefix F / J</span></h3>
+    <p>
+      <code>Morantron/tmux-fingers</code> overlays vimium-style letter
+      hints on every visible match in the active pane. Press the hint
+      letter; the match lands on the macOS clipboard via <code>pbcopy</code>.
+      Built-in patterns cover paths, URLs, SHAs, IPs, UUIDs, k8s names,
+      <code>git status</code> / <code>diff</code> hunks; custom patterns
+      add <code>worktree-…</code> branch names and <code>#N</code>
+      PR/issue refs.
+    </p>
+    <table>
+      <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">F</span></td><td class="desc">copy-mode: hint → letter → clipboard</td></tr>
+      <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">J</span></td><td class="desc">jump-mode: hint → letter → cursor at match (inside copy-mode)</td></tr>
+      <tr><td class="key"><span class="k">a</span>…<span class="k">z</span></td><td class="desc">pick a hint (single letter copies / jumps)</td></tr>
+      <tr><td class="key"><span class="k">Tab</span></td><td class="desc">multi-select — pick several matches before confirming</td></tr>
+      <tr><td class="key"><span class="k">⇧</span> <span class="k">letter</span></td><td class="desc">paste match into the current pane instead of clipboard</td></tr>
+      <tr><td class="key"><span class="k">Ctrl</span> <span class="k">letter</span></td><td class="desc">open match (URL → browser, path → Finder via macOS default)</td></tr>
+    </table>
+    <p class="note">Hint colors use ANSI palette refs (<code>colour9</code>/<code>colour13</code>/<code>colour14</code>) so they auto-adapt across themes — no <code>theme-set</code> handoff needed. First-run: after <code>prefix + I</code>, the wizard appears — pick "Build from source" (crystal required).</p>
   </div>
 </div>
 


### PR DESCRIPTION
## 🎯 Summary

Install [`Morantron/tmux-fingers`](https://github.com/Morantron/tmux-fingers) so visible matches (paths, URLs, SHAs, k8s names, `#N` refs, `worktree-*` branch names) get vimium-style letter hints; one keystroke copies the chosen match.

- **Install path** — TPM plugin only. No pre-built macOS arm64 binary exists in any release; the Homebrew tap compiles Crystal from source. First-run: after `prefix + I`, the wizard appears — pick "Build from source" (crystal required).
- **Bindings** — fingers' defaults: `<prefix> F` copy-mode, `<prefix> J` jump-mode.
- **Styling** — ANSI palette refs (`colour9`/`colour10`/`colour13`/`colour14`) auto-adapt across all seven themes. No per-theme variant files.
- **Custom patterns** — `worktree-[a-z0-9._/-]+` and `#\d+` on top of the built-ins (`path`, `url`, `sha`, `digit`, `ip`, `uuid`, `kubernetes`, `git-status`, `git-status-branch`, `diff`, `hex`).

## 🔀 Note on jump-mode

Fingers' default `<prefix> J` binding shadows the dashboard pager (`.config/tmux/tmux.conf`). Accepted — dashboard is scheduled for retirement separately.

## 🧪 Test plan

- [ ] `tmux source-file ~/.config/tmux/tmux.conf` — no syntax errors
- [ ] `prefix + I` installs the plugin; wizard appears — pick "Build from source"
- [ ] `prefix + F` shows hints over visible matches; picking a letter places the match on `pbpaste` output
- [ ] `prefix + J` shows hints; picking a letter drops cursor at the match in copy-mode
- [ ] `theme-set mocha` — hint colors stay legible (role-stable, hex shifts)
- [ ] Cheatsheet renders the new Fingers card and updated at-a-glance plugin list

Closes #238.