### PR TITLE
🪟 tmux: keep focus on moved window when reordering with prefix </>

### DIFF
--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -97,11 +97,11 @@ bind -r . next-window
 
 # ─── Window reordering ──────────────────────
 # Shove the current window left/right by one index. Repeatable so a single
-# prefix press lets you keep nudging until placed. Default `swap-window`
-# (without `-d`) follows the moved window, so the next tap keeps acting on
-# the same window.
-bind -r "<" swap-window -t -1
-bind -r ">" swap-window -t +1
+# prefix press lets you keep nudging until placed. `-d` keeps focus on the
+# moved window (its index changes with the swap); without `-d`, focus would
+# jump to the displaced neighbour instead.
+bind -r "<" swap-window -d -t -1
+bind -r ">" swap-window -d -t +1
 
 # ─── Reload ─────────────────────────────────
 bind r source-file ~/.config/tmux/tmux.conf \; display "config reloaded"

--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -69,15 +69,18 @@ bind k select-pane -U
 bind l select-pane -R
 
 # ─── Session cycling ────────────────────────
-# Unshifted alternatives to the default <prefix> L / ( / ).
+# Single canonical pair on the home row / thumb:
 #   <prefix> Space  → last (most-recently-used) session
 #   <prefix> Tab    → next session   (repeatable — hold prefix once,
 #                                     tap Tab to keep cycling)
 #   <prefix> S-Tab  → previous session (repeatable; BTab = back-tab)
-# Overrides:
-#   - default <prefix> Space (next-layout) — pane layouts unused here
-#     (prefix h/j/k/l + | / - cover splits).
-#   - Tab / BTab are unbound by default.
+# Defaults `L` / `(` / `)` are unbound so cycling lives on this pair only
+# and those keys stay free for other uses. Also overrides default
+# <prefix> Space (next-layout) — pane layouts unused here (prefix h/j/k/l
+# + | / - cover splits).
+unbind L
+unbind (
+unbind )
 bind    Space switch-client -l
 bind -r Tab   switch-client -n
 bind -r BTab  switch-client -p
@@ -191,6 +194,14 @@ set -g @fingers-pattern-0 'worktree-[a-z0-9._/-]+'
 set -g @fingers-pattern-1 '#\d+'
 
 run '~/.config/tmux/plugins/tpm/tpm'
+
+# ─── Plugin overrides (must come AFTER `run` above) ──
+# `tmux-sensible` adds `<prefix> C-p` / `<prefix> C-n` for window cycling.
+# We already have `,` / `.` as the single canonical cycle pair (see
+# "Window cycling" above); drop the C-p/C-n shadows so cycling lives on
+# one keystroke pair only and `C-p`/`C-n` stay free for other uses.
+unbind C-p
+unbind C-n
 
 # ─── Theme palette (sourced via ~/.config/themes/current.tmux symlink) ──
 # Defines @color_* user options used throughout status-line definitions and

--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -86,12 +86,15 @@ bind -r BTab  switch-client -p
 # Unshifted neighbours on the US layout for rapid window-hop.
 #   <prefix> ,  → previous window (repeatable)
 #   <prefix> .  → next window     (repeatable)
-# Default `n`/`p` still work. Overrides the default `,` rename-window —
-# the unshifted cycling pair (`,`/`.`) is the keystroke we want; manual
-# rename remains reachable via `<prefix> :rename-window <name>` from the
-# command prompt.
+# Defaults `n`/`p` are unbound — the unshifted, repeatable `,`/`.` pair is
+# the only cycling keystroke we want, and freeing `n`/`p` keeps them
+# available for future bindings. Overrides the default `,` rename-window;
+# manual rename remains reachable via `<prefix> :rename-window <name>`
+# from the command prompt.
 unbind ,
 unbind .
+unbind n
+unbind p
 bind -r , previous-window
 bind -r . next-window
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,16 @@ Personal multi-theme, multi-font setup for Ghostty + tmux + vim + fish. `theme-s
 - **tmux prefix is `C-a`** (`C-Space` conflicts with macOS input-source
   switching). Pane nav: `<prefix> h/j/k/l` (Alt is reserved for Polish
   diacritics — never `bind -n M-*`). Splits: `|` and `-`.
+  **Cycling pairs are single-canonical** — exactly one keystroke combo
+  per motion, no duplicates: window cycling on `,` / `.` only (defaults
+  `n`/`p` and `tmux-sensible`'s `C-p`/`C-n` are unbound — the `C-p`/`C-n`
+  unbinds must sit *after* `run '~/.config/tmux/plugins/tpm/tpm'` since
+  the plugin re-applies them otherwise); session cycling on `Tab` /
+  `S-Tab` / `Space` only (defaults `(`/`)`/`L` unbound). Window reorder
+  on `<` / `>`: `swap-window -d -t ±1` — `-d` keeps focus on the moved
+  window (its index changes with the swap; without `-d` focus would
+  jump to the displaced neighbour instead). All four are `-r` so a
+  single prefix press lets you keep nudging until placed.
 - **tmux-fingers gives one-keystroke copy of visible matches.**
   TPM plugin `Morantron/tmux-fingers`. Bindings: `<prefix> F` enters
   copy-mode (hint letter → match copied to clipboard via `pbcopy`),

--- a/README.md
+++ b/README.md
@@ -140,6 +140,9 @@ Smoke test: `scripts/test-theme-switch.sh`.
 - session switcher (tmux-sessionx): `<prefix> t`  (clock-mode moved to `<prefix> T`)
 - pane nav: `<prefix> h/j/k/l` (Alt is reserved for Polish diacritics)
 - splits: `<prefix> |` (right) / `<prefix> -` (down)
+- window cycling: `<prefix> ,` (prev) / `<prefix> .` (next) — repeatable. Defaults `n`/`p` and `tmux-sensible`'s `C-p`/`C-n` are unbound; this is the only cycle pair.
+- session cycling: `<prefix> Tab` (next) / `<prefix> S-Tab` (prev) / `<prefix> Space` (last) — repeatable. Defaults `(`/`)`/`L` unbound.
+- window reorder: `<prefix> <` (left) / `<prefix> >` (right) — repeatable, focus follows the moved window.
 - reload tmux: `<prefix> r`
 - TPM plugin install: `<prefix> I` (capital I)
 - worktree+session command (any shell): `s [<project>] [<name>]` — inside tmux 1 arg = worktree name in current project; outside tmux 1 arg = project name (attach), 0 args = fzf picker. Branch name verbatim — the `worktree-` prefix is reserved for the `EnterWorktree` workflow.

--- a/docs/tmux-cheatsheet.html
+++ b/docs/tmux-cheatsheet.html
@@ -104,8 +104,8 @@
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">d</span></td><td class="desc">detach</td></tr>
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">s</span></td><td class="desc">session picker (tree)</td></tr>
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">$</span></td><td class="desc">rename current session</td></tr>
-      <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">(</span> / <span class="k">)</span></td><td class="desc">prev / next session</td></tr>
-      <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">L</span></td><td class="desc">switch to last session</td></tr>
+      <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">Tab</span> / <span class="k">S-Tab</span></td><td class="desc">next / prev session <span class="muted">(repeatable; defaults <code>(</code>/<code>)</code> unbound)</span></td></tr>
+      <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">Space</span></td><td class="desc">switch to last session <span class="muted">(default <code>L</code> unbound)</span></td></tr>
     </table>
     <p class="note">Closing the last pane of a session (<code>exit</code>, <code>Ctrl-D</code>) switches to the most-recently-used other session via <code>detach-on-destroy off</code>. Detaches only when no other session exists.</p>
   </div>
@@ -198,7 +198,7 @@
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">c</span></td><td class="desc">create window — opens at session root (<code>@session_root</code>, set by <code>s</code>) when present, else inherits pane cwd</td></tr>
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">&amp;</span></td><td class="desc">kill window (confirm)</td></tr>
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">w</span></td><td class="desc">window picker (tree)</td></tr>
-      <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">&lt;</span> / <span class="k">&gt;</span></td><td class="desc">swap window left / right <span class="muted">(repeatable; follows the window)</span></td></tr>
+      <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">&lt;</span> / <span class="k">&gt;</span></td><td class="desc">swap window left / right <span class="muted">(repeatable; <code>-d</code> keeps focus on the moved window — its index changes, not yours)</span></td></tr>
       <tr><td class="key"><code>:rename-window &lt;name&gt;</code></td><td class="desc">force a name <span class="muted">(no keybind — <code>automatic-rename</code> would clobber it anyway)</span></td></tr>
     </table>
   </div>
@@ -206,13 +206,12 @@
   <div class="card">
     <h3>Switch</h3>
     <table>
-      <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">.</span> / <span class="k">,</span></td><td class="desc">next / prev window <span class="muted">(repeatable)</span></td></tr>
-      <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">n</span> / <span class="k">p</span></td><td class="desc">next / prev window <span class="muted">(tmux default; same as <code>.</code>/<code>,</code>)</span></td></tr>
+      <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">.</span> / <span class="k">,</span></td><td class="desc">next / prev window <span class="muted">(repeatable; defaults <code>n</code>/<code>p</code> and <code>tmux-sensible</code>'s <code>C-n</code>/<code>C-p</code> unbound)</span></td></tr>
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">1</span>…<span class="k">9</span></td><td class="desc">window 1–9 by number</td></tr>
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">l</span></td><td class="desc">last window <span class="muted">(but <code>l</code> is also pane-right here — see "Quirks")</span></td></tr>
       <tr><td class="key"><span class="k prefix">C-a</span> <span class="k">f</span></td><td class="desc">find by name (search)</td></tr>
     </table>
-    <p class="note"><strong>Quirk:</strong> we rebind <span class="k prefix">C-a</span><span class="k">l</span> to <em>pane-right</em> (vim style). To go to the previous window, use <span class="k prefix">C-a</span><span class="k">n</span>/<span class="k">p</span> or the picker.</p>
+    <p class="note"><strong>Quirk:</strong> we rebind <span class="k prefix">C-a</span><span class="k">l</span> to <em>pane-right</em> (vim style). To hop between windows, use <span class="k prefix">C-a</span><span class="k">,</span>/<span class="k">.</span> or the picker.</p>
   </div>
 </div>
 
@@ -423,7 +422,7 @@
 </table>
 
 <footer>
-  Built from <code>~/.config/tmux/tmux.conf</code> on 2026-05-16. Refresh after meaningful config changes.
+  Built from <code>~/.config/tmux/tmux.conf</code> on 2026-05-17. Refresh after meaningful config changes.
   <br>
   When in doubt: <span class="k prefix">C-a</span> <span class="k">?</span> for the live keymap list.
 </footer>


### PR DESCRIPTION
## 📝 Summary

- `<prefix> <` / `<prefix> >` now keep focus on the window you just moved instead of jumping to the displaced neighbour.
- Added `-d` to both `swap-window` bindings; `swap-window` is window-centric, so `-d` is what makes focus stay with the moved window as its index changes.
- Rewrote the surrounding comment — the previous version described the index-centric mental model, which had the semantics backwards.

## 🧪 Test plan

- [x] `tmux source-file ~/.config/tmux/tmux.conf` reloads cleanly.
- [x] From a mid-list window, `<prefix> <` moves it one slot left and focus follows.
- [x] From a mid-list window, `<prefix> >` moves it one slot right and focus follows.
- [x] Repeated taps under a single prefix (`-r`) keep acting on the same window.