### PR TITLE
🔮 Brewfile: declare crystal for tmux-fingers source build

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -4,6 +4,7 @@
 # Core
 brew "git"
 brew "tmux"
+brew "crystal"  # compiles tmux-fingers from source on first `prefix + I` (TPM wizard always builds; no prebuilt binary)
 brew "jq"   # JSON parsing in shell helpers
 brew "gh"   # GitHub CLI — drives tmux-pr-detect + <prefix> P (gh pr view --web)
 brew "bash"   # bash 5; pinned-shebang scripts target /opt/homebrew/bin/bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,11 +142,11 @@ Personal multi-theme, multi-font setup for Ghostty + tmux + vim + fish. `theme-s
   refs). Built-ins kept on: `ip`, `uuid`, `sha`, `digit`, `url`, `path`,
   `hex`, `kubernetes`, `git-status`, `git-status-branch`, `diff`.
   **Fresh-machine setup:** after `prefix + I`, the first-run wizard
-  appears — pick "Build from source" (crystal must be on `$PATH`; install
-  via `brew install crystal` if absent). Why no `brew "tmux-fingers"` in
-  Brewfile: the morantron tap also compiles Crystal from source, so the
-  wizard fires either way — declaring it gains nothing over documenting
-  the one-liner here.
+  appears — pick "Build from source". `crystal` is declared in
+  `Brewfile` so it's already on `$PATH` after `brew bundle`. Why no
+  `brew "tmux-fingers"` in Brewfile: the morantron tap also compiles
+  from source, so the wizard fires either way — declaring it gains
+  nothing.
 - **TPM is the tmux plugin manager.** Loaded: `tmux-sensible`,
   `tmux-resurrect`, `tmux-continuum` (`@continuum-restore 'on'`),
   `tmux-sessionx`, `tmux-fingers`. Status bar is hand-rolled, behavior


### PR DESCRIPTION
## 📝 Summary

- ➕ Adds `brew "crystal"` to `Brewfile` so fresh-machine `brew bundle` provides the compiler tmux-fingers needs when its TPM wizard builds from source.
- 📚 Updates the tmux-fingers fresh-machine note in `CLAUDE.md` to reflect that crystal is no longer a manual one-liner.

## 🤔 Why

The morantron tap always compiles tmux-fingers from source on first `prefix + I`, so crystal must be on `$PATH` before the wizard runs. Previously the setup expected a hand-run `brew install crystal`; declaring it in `Brewfile` folds that step into `brew bundle`.

## ✅ Test plan

- [ ] `brew bundle check --file=$PROJECTS_HOME/dotfiles/Brewfile --verbose` reports crystal satisfied
- [ ] Fresh-machine path: after `brew bundle`, `which crystal` resolves to a Homebrew prefix
- [ ] tmux-fingers TPM wizard's "Build from source" succeeds without any extra manual install