### PR TITLE
🧵 Install beads (bd) + wire global Claude Code hook

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -19,6 +19,9 @@ brew "zoxide"  # frecency-ranked dir jumping; sesh picker source
 # Worktree manager
 brew "worktrunk"
 
+# Issue tracker
+brew "beads"  # `bd` — distributed graph issue tracker for AI agents; pulls dolt + icu4c@78 transitively. README "Manual extras" covers the `bd setup claude` one-time hook step.
+
 # Runtime version manager (Node + Ruby) + Python package runner
 brew "mise"
 brew "uv"  # owns the Python lifecycle: interpreters (`uv python install --default`), projects (`uv add`/`run`/`sync`), CLIs (`uv tool`), pip-shim (`uv pip`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -492,6 +492,32 @@ Personal multi-theme, multi-font setup for Ghostty + tmux + vim + fish. `theme-s
   If gh-dash ever starts writing cache/state inside
   `~/.config/gh-dash/`, the mixed-dir pattern already accommodates it
   (`link_tracked_entries` only touches tracked files).
+- **`bd` is the beads issue tracker** (raw command, no alias). Distributed
+  graph issue tracker for AI agents, Dolt-backed. Installed via `Brewfile`
+  (`brew "beads"`); the global Claude Code `SessionStart` + `PreCompact`
+  hooks in `~/.claude/settings.json` are a one-time manual step run after
+  first `brew bundle` via `bd setup claude --global` (see README
+  "Manual extras"). Deliberately not automated from `bootstrap.sh` — that
+  file does not write to `~/.claude/`. `bd prime` injects 1–2k tokens of
+  workflow context at session start (and again on context compaction) and
+  no-ops in projects without a `.beads/` directory, so the global hooks
+  are safe in every session. **Quirks of `bd setup claude --global` in
+  this repo:** (1) when CLAUDE.md is present in cwd, `bd setup` also
+  appends a "BEADS INTEGRATION v:1" section to it on every run —
+  reverted here because it preempts policy decisions still deferred (see
+  below) and contradicts existing conventions (TodoWrite/TaskCreate use,
+  MEMORY.md, PR-based workflow); (2) `bd setup claude --global --check`
+  therefore exits 1 with a "CLAUDE.md exists but no beads section found"
+  warning, even though the hooks side is correctly installed — ignore the
+  warning until the policy decision lands. **Don't run `bd init` here
+  yet** (or anywhere) — three policy decisions are deferred to follow-up
+  issues opened against #244: #246 (memory-layer niche — bd vs
+  episodic-memory MCP, per-project MEMORY.md auto-memory, and
+  `.superpowers/` specs+plans), #247 (AGENTS.md vs CLAUDE.md handling on
+  first `bd init` — bd writes AGENTS.md by default, and `bd setup`
+  clobbers CLAUDE.md on every run, see quirks above), #248 (`.beads/`
+  gitignore stance — bd's design intent is committed, for Dolt team sync;
+  we have not committed yet). Pin those before any `bd init`.
 - **`diff` aliased to `difft`** (guarded). For ad-hoc, non-git
   comparisons. Git diffs unaffected (still `delta`); `vimdiff`
   unaffected (separate alias). Escape: `command diff`, `\diff`,

--- a/README.md
+++ b/README.md
@@ -71,6 +71,25 @@ git config --global delta.line-numbers true
 git config --global include.path "~/.config/themes/delta-current.gitconfig"
 ```
 
+**4. beads — wire global Claude Code hook.** `brew bundle` installs `bd`,
+but the global `SessionStart` + `PreCompact` hooks into
+`~/.claude/settings.json` are a one-time manual step (deliberately not
+automated from `bootstrap.sh` — that file does not write to
+`~/.claude/`):
+
+```sh
+# One-time: install the global SessionStart + PreCompact hooks that run `bd prime`
+bd setup claude --global
+
+# Verify (hooks side; CLAUDE.md warning is expected — see project CLAUDE.md note)
+bd setup claude --global --check
+```
+
+`bd prime` no-ops in projects without a `.beads/` directory, so these hooks
+are safe in every session. `bd init` is **not** part of fresh-machine
+setup — running it is a per-project decision, currently gated on the
+follow-up issues opened against #244.
+
 ## What's where
 
 | Tool         | Source path                          | Target              |


### PR DESCRIPTION
## 🎯 Summary

- 🍺 `Brewfile`: declare `brew "beads"` under a new `# Issue tracker` section
- 📘 `README.md`: new "Manual extras" entry for the one-time `bd setup claude --global` step
- 📓 `CLAUDE.md`: new conventions bullet recording the install, the two `bd setup` quirks in this repo, and the three deferred policy decisions
- 🧵 Follow-ups opened: #246 (memory-layer niche), #247 (AGENTS.md vs CLAUDE.md policy), #248 (`.beads/` gitignore stance)

`bd init` is **not** run anywhere as part of this PR. The three deferred decisions gate that.

## 🧭 Plan deviations worth flagging

The plan assumed `bd setup claude` writes a hook into `~/.claude/settings.json`. In bd 1.0.4, the default does a **project-local** install (writes `.claude/settings.json` + appends a "BEADS INTEGRATION" section to project CLAUDE.md). The `--global` flag is required for the behaviour the plan describes. Two additional surprises:

1. `bd setup claude --global` writes the hook globally but **still** appends the BEADS INTEGRATION section to the project CLAUDE.md (when CLAUDE.md exists in cwd) — reverted twice during execution; documented in the CLAUDE.md bullet and re-flagged in follow-up #247.
2. `bd setup claude --global --check` exits 1 with a `⚠ CLAUDE.md exists but no beads section found` warning even when the hook side is correctly installed — same root cause; ignore the warning until #247 lands.

The hook also registers **two** entries (`SessionStart` + `PreCompact`), not one as the plan anticipated — both run `bd prime`. Reflected in the README copy and CLAUDE.md bullet.

## ✅ Verification

### bd on PATH

```text
$ which bd && bd --version
/opt/homebrew/bin/bd
bd version 1.0.4 (Homebrew)
```

### `~/.claude/settings.json` hook reconciliation

**Before** (existing hooks pre-install):

```json
{
  "PreToolUse": [{"matcher": "Skill", "hooks": [{"type": "command", "command": "npx -y ccstatusline@latest --hook"}]}],
  "UserPromptSubmit": [{"hooks": [{"type": "command", "command": "npx -y ccstatusline@latest --hook"}]}],
  "Stop": [{"matcher": "", "hooks": [{"type": "command", "command": "ccpulse status --quiet"}]}]
}
```

**After** (post `bd setup claude --global`):

```json
{
  "PreCompact": [{"hooks": [{"command": "bd prime", "type": "command"}], "matcher": ""}],
  "PreToolUse": [{"hooks": [{"command": "npx -y ccstatusline@latest --hook", "type": "command"}], "matcher": "Skill"}],
  "SessionStart": [{"hooks": [{"command": "bd prime", "type": "command"}], "matcher": ""}],
  "Stop": [{"hooks": [{"command": "ccpulse status --quiet", "type": "command"}], "matcher": ""}],
  "UserPromptSubmit": [{"hooks": [{"command": "npx -y ccstatusline@latest --hook", "type": "command"}]}]
}
```

All pre-existing hooks preserved verbatim; only additions are `SessionStart` and `PreCompact` (both `bd prime`).

### Idempotency check

```text
$ bd setup claude --global   # second run
Installing Claude hooks globally...
✓ Hook already registered: SessionStart
✓ Hook already registered: PreCompact
…
```

Re-running does not duplicate hook entries — `jq '.hooks.SessionStart, .hooks.PreCompact'` still shows a single entry per key after the second run.

### `--check`

```text
$ bd setup claude --global --check
✓ Global hooks installed: /Users/martinciu/.claude/settings.json
⚠ CLAUDE.md exists but no beads section found
  Run: bd setup claude (to add beads section)
```

Hook side reported installed; the CLAUDE.md warning is the expected quirk (see "Plan deviations" above). Exit 1.

### Fresh-session smoke test

Not exercised inside this PR — the hooks were registered mid-session, so they fire on the *next* Claude Code session start. The hook payload is `bd prime`, which no-ops in projects without `.beads/`, so no perceptible delay is expected for the dotfiles repo specifically. **Reviewer can verify by opening a fresh Claude session** in this repo (or any repo without `.beads/`) and confirming startup remains clean.

## ⚠️ Risks / open questions

- 🕒 `bd prime` token cost (1–2k) and latency at SessionStart + PreCompact — to revisit if it becomes noticeable; could flip global → `--project` later (per #246).
- 🔄 bd version churn (currently 1.0.4 via Homebrew) — `brew upgrade` flows future versions in transparently; the `--check` flag catches schema drift on re-runs (with the documented CLAUDE.md caveat).
- 🚧 Three policy decisions deferred — tracked in #246, #247, #248.
- 🧹 `bd setup claude --global` keeps appending a BEADS INTEGRATION section to CLAUDE.md on every run. We do not currently run `bd setup` from `bootstrap.sh`, so this only matters when running it manually — but worth knowing for #247.

## 🧪 Test plan

- [x] `brew bundle check --file=Brewfile` confirms beads is installed
- [x] `bd setup claude --global --check` reports global hooks present (with documented CLAUDE.md warning)
- [x] `jq` diff confirms `SessionStart` + `PreCompact` added without clobbering existing `PreToolUse` / `UserPromptSubmit` / `Stop` hooks
- [x] `bd setup claude --global` run twice — no duplicate hook entries
- [ ] Fresh Claude session in dotfiles (no `.beads/`) starts cleanly — reviewer to verify on next session

Closes #244