### PR TITLE
🌐 fish: split locale categories for Polish dates and numbers

### DIFF
--- a/.config/fish/conf.d/00-env.fish
+++ b/.config/fish/conf.d/00-env.fish
@@ -3,8 +3,12 @@
 eval (/opt/homebrew/bin/brew shellenv)
 
 set -gx EDITOR vim
-set -gx LANG en_US.UTF-8
-set -gx LC_ALL en_US.UTF-8
+set -gx LANG en_US.UTF-8 # fallback for any LC_* you don't set
+set -gx LC_MESSAGES en_US.UTF-8 # English UI / error text
+set -gx LC_CTYPE en_US.UTF-8 # character classification
+set -gx LC_COLLATE en_US.UTF-8 # sort order (avoids ą interleaving)
+set -gx LC_TIME pl_PL.UTF-8 # Polish dates, week starts Monday
+set -gx LC_NUMERIC pl_PL.UTF-8 # 1 234,56 instead of 1,234.56
 
 # Kill the default "Welcome to fish, the friendly interactive shell" banner.
 # `-g` (not `-U`) so this conf.d file stays the source of truth — flipping


### PR DESCRIPTION
## Summary

- 🌐 Drop `LC_ALL` so per-category locale vars actually take effect (it was overriding everything to `en_US`)
- 🇬🇧 Keep `LC_MESSAGES` / `LC_CTYPE` / `LC_COLLATE` on `en_US.UTF-8` — English UI text, predictable char classification, ASCII-first sort (no `ą` interleaving)
- 🇵🇱 Switch `LC_TIME` and `LC_NUMERIC` to `pl_PL.UTF-8` — Polish dates with Monday-start weeks, `1 234,56` number formatting
- 🪧 `LANG` stays `en_US.UTF-8` as the fallback for any category left unset

## 🧪 Test plan

- [ ] `locale` in a fresh shell shows the per-category split (not all `en_US`)
- [ ] `date +%c` renders in Polish; week starts Monday in `cal`
- [ ] `printf "%'d\n" 1234567` outputs `1 234 567`
- [ ] `printf 'b\nA\na\nB\n' | sort` returns ASCII order (`A B a b`), confirming `LC_COLLATE` is English
- [ ] Error messages from common CLIs still render in English