### PR TITLE
🔍 atuin: Ctrl-R + Up history picker with scope cycling (#245)

### DIFF
--- a/.config/atuin/config.toml
+++ b/.config/atuin/config.toml
@@ -11,10 +11,8 @@ update_check = false
 # Picker geometry — inline popup over the prompt, not full-screen.
 inline_height = 20
 
-# Default scope on Ctrl-R open + cycle order inside the picker.
+# Default scope on Ctrl-R open.
 filter_mode = "global"
-[search]
-filters = ["global", "host", "session", "directory"]
 
 # Up arrow picker scope. atuin Up opens a session-scoped mini-picker.
 filter_mode_shell_up_key_binding = "session"
@@ -22,7 +20,13 @@ filter_mode_shell_up_key_binding = "session"
 # Enter = paste to commandline (fzf parity); Tab = run immediately.
 enter_accept = false
 
+# Cycle order inside the picker (Ctrl-R cycles through these).
+[search]
+filters = ["global", "host", "session", "directory"]
+
 # Per-row visible columns. Exit code first so ✓/✗ leads each row.
+# (atuin schema: picker columns live under [ui], not [search].)
+[ui]
 columns = ["exit", "duration", "command"]
 
 # Default theme uses terminal ANSI palette refs — auto-themes across all

--- a/.config/atuin/config.toml
+++ b/.config/atuin/config.toml
@@ -1,0 +1,33 @@
+# Local-only history store. No sync, no telemetry, no remote.
+# Picker config locks in the answers from issue #245:
+#   - default scope = global (atuin default); Ctrl-R cycles within picker
+#   - Up arrow opens session-scoped picker (NOT disabled)
+#   - Enter pastes to commandline; Tab runs immediately (fzf-parity)
+#   - inline popup (~20 rows), keeps tmux statusbar visible
+#   - default ANSI-palette theme; auto-adapts via Ghostty's 16-color palette
+auto_sync = false
+update_check = false
+
+# Picker geometry — inline popup over the prompt, not full-screen.
+inline_height = 20
+
+# Default scope on Ctrl-R open + cycle order inside the picker.
+filter_mode = "global"
+[search]
+filters = ["global", "host", "session", "directory"]
+
+# Up arrow picker scope. atuin Up opens a session-scoped mini-picker.
+filter_mode_shell_up_key_binding = "session"
+
+# Enter = paste to commandline (fzf parity); Tab = run immediately.
+enter_accept = false
+
+# Per-row visible columns. Exit code first so ✓/✗ leads each row.
+columns = ["exit", "duration", "command"]
+
+# Default theme uses terminal ANSI palette refs — auto-themes across all
+# 7 dotfile themes (Solarized / Mocha / Frappé / Dracula / Gruvbox /
+# Tokyo Night Storm / Latte) via Ghostty's 16-color palette. Same trick
+# as FZF_DEFAULT_OPTS in .config/fish/conf.d/10-colors.fish.
+[theme]
+name = "default"

--- a/.config/fish/conf.d/45-atuin.fish
+++ b/.config/fish/conf.d/45-atuin.fish
@@ -1,0 +1,9 @@
+# atuin — Ctrl-R history picker with exit-status markers and scope cycling.
+# Loads after 40-plugins.fish (which runs `fzf --fish | source` and grabs
+# Ctrl-R for fzf's history widget). atuin's init rebinds Ctrl-R to its
+# own picker; fzf's Ctrl-T / Ctrl-V / Ctrl-S / Ctrl-Alt-F widgets are
+# unaffected. Up arrow is also bound to atuin's session-scoped picker.
+# Config in .config/atuin/config.toml; history at ~/.local/share/atuin/.
+if command -q atuin
+    atuin init fish | source
+end

--- a/Brewfile
+++ b/Brewfile
@@ -15,6 +15,7 @@ brew "fzf"
 tap  "joshmedeski/sesh"
 brew "joshmedeski/sesh/sesh"
 brew "zoxide"  # frecency-ranked dir jumping; sesh picker source
+brew "atuin"   # Ctrl-R history picker with exit-status markers + scope cycling; wired by .config/fish/conf.d/45-atuin.fish
 
 # Worktree manager
 brew "worktrunk"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,10 +35,33 @@ Personal multi-theme, multi-font setup for Ghostty + tmux + vim + fish. `theme-s
   `25-prompt` (starship), `30-aliases`,
   `35-abbreviations` (git-flow mnemonic abbrs — `gst`, `gco`, `gp`, …),
   `40-plugins` (fzf, zoxide, wt, Polish-diacritic Alt-C unbind),
+  `45-atuin` (atuin Ctrl-R + Up; rebinds after fzf),
   `99-secrets` (untracked). The two untracked files are copied from
   `.template` companions by `bootstrap.sh`. `functions/less.fish`
   is a bat-backed `less` wrapper; `completions/wt.fish` adds wt
   tab-completion. Smoke test: `scripts/test-fish-loads.sh`.
+- **`atuin` owns Ctrl-R and Up arrow** (`~/.config/atuin/config.toml`,
+  wired by `.config/fish/conf.d/45-atuin.fish` via
+  `atuin init fish | source`, loaded after fzf so atuin's rebinds win).
+  Sqlite history at `~/.local/share/atuin/history.db` (machine-global,
+  outside the repo — worktrunk's copy-ignored never touches it). fish's
+  own `~/.local/share/fish/fish_history` keeps recording in parallel
+  (cheap revert: delete `45-atuin.fish`). Picker UX locked in:
+  `filter_mode = "global"` with Ctrl-R cycling
+  `global → host → session → directory` inside the picker; Up opens a
+  session-scoped mini-picker
+  (`filter_mode_shell_up_key_binding = "session"`); `enter_accept = false`
+  so Enter pastes to the commandline and Tab runs immediately (fzf
+  parity); `inline_height = 20` keeps the tmux statusbar visible above
+  the popup; `columns = ["exit", "duration", "command"]` puts the
+  ✓/✗ marker first. Theming: `[theme] name = "default"` uses ANSI
+  palette refs (same trick as `FZF_DEFAULT_OPTS`), auto-adapts across
+  all 7 themes via Ghostty's 16-color palette — no per-theme files,
+  no `theme-set` coupling. Failed commands are **shown with ✗**, not
+  hidden — visual filter, not behavioural. fzf's other widgets
+  (Ctrl-T file, Ctrl-V variable, Ctrl-S process) are unaffected.
+  First-time only: `atuin import fish` to backfill `fish_history` into
+  the sqlite store.
 - **`Brewfile` is installed by bootstrap.** `bootstrap.sh` runs
   `brew bundle --file=$DOTFILES/Brewfile` unconditionally at the top,
   before any symlinks. Aborts on failure (`set -euo pipefail`).
@@ -414,7 +437,8 @@ Personal multi-theme, multi-font setup for Ghostty + tmux + vim + fish. `theme-s
   `delta-current.gitconfig` include), `glow` / `md` (via `glamour.json`
   symlink), `vivid` / `LS_COLORS` (via `$VIVID_THEME`, read by
   `.config/fish/conf.d/10-colors.fish`), fzf (palette-symbolic refs in
-  `FZF_DEFAULT_OPTS`, auto-adapts via Ghostty's 16-color palette).
+  `FZF_DEFAULT_OPTS`, auto-adapts via Ghostty's 16-color palette),
+  atuin (`[theme] name = "default"`, same ANSI-palette trick).
   Stay Solarized-only: `procs` (`ps`), `tailspin` (`tspin`), `xh`. Pins:
   `bat --theme="Solarized (dark)"` is the fallback when `$BAT_THEME` is
   unset; `procs` reads `.config/procs/procs.toml`, `md` passes

--- a/README.md
+++ b/README.md
@@ -90,6 +90,17 @@ are safe in every session. `bd init` is **not** part of fresh-machine
 setup — running it is a per-project decision, currently gated on the
 follow-up issues opened against #244.
 
+**5. `atuin import fish`** — one-time backfill of existing fish history
+into the atuin sqlite store. Run after `brew bundle` (which installs
+atuin) and after `bootstrap.sh` (which symlinks `~/.config/atuin/`):
+
+```sh
+atuin import fish
+```
+
+Safe to re-run (idempotent for already-imported rows). After this,
+Ctrl-R and Up open atuin's picker (config at `.config/atuin/config.toml`).
+
 ## What's where
 
 | Tool         | Source path                          | Target              |

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -159,6 +159,8 @@ link ".config/procs"   "$HOME/.config/procs"
 # --- xh (modern HTTP client; Solarized via default_options)
 link ".config/xh"      "$HOME/.config/xh"
 
+link ".config/atuin"   "$HOME/.config/atuin"
+
 # --- gh-dash (TUI for PRs/issues/notifications; switchable theme)
 # ~/.config/gh-dash/ is a real dir. Shared schema lives in config-base.yml;
 # per-theme palettes live in theme-colors-<name>.yml. Both are tracked and

--- a/docs/terminal-cheatsheet.html
+++ b/docs/terminal-cheatsheet.html
@@ -548,13 +548,51 @@
 </div>
 
 <!-- ═══════════════════════════════════════════════════════════════════════ -->
+<h2 id="atuin">atuin <span class="tool-tag">shell history</span></h2>
+
+<div class="grid">
+  <div class="card">
+    <h3>Shell key bindings</h3>
+    <table>
+      <tr><td class="key"><span class="k">Ctrl-R</span></td><td class="desc">atuin history picker — full screen-aware popup with scope cycling</td></tr>
+      <tr><td class="key"><span class="k">Up</span></td><td class="desc">session-scoped mini-picker (was: fish previous-command)</td></tr>
+    </table>
+    <p class="note">Cycle scope inside the picker with <span class="k">Ctrl-R</span>: <code>global → host → session → directory</code>. Default scope is <code>global</code>.</p>
+  </div>
+
+  <div class="card">
+    <h3>Inside the picker</h3>
+    <table>
+      <tr><td class="key"><span class="k">Enter</span></td><td class="desc">paste selected command to commandline (does not run)</td></tr>
+      <tr><td class="key"><span class="k">Tab</span></td><td class="desc">run selected command immediately</td></tr>
+      <tr><td class="key"><span class="k">Ctrl-R</span></td><td class="desc">cycle scope (global → host → session → directory)</td></tr>
+      <tr><td class="key"><span class="k">Ctrl-S</span></td><td class="desc">toggle exact / fuzzy match</td></tr>
+      <tr><td class="key"><span class="k">Ctrl-N</span> / <span class="k">Ctrl-P</span></td><td class="desc">next / prev match (arrows work too)</td></tr>
+      <tr><td class="key"><span class="k">Esc</span></td><td class="desc">cancel</td></tr>
+      <tr><td class="key"><code>cwd:.</code></td><td class="desc">filter syntax — restrict to current directory</td></tr>
+    </table>
+  </div>
+
+  <div class="card">
+    <h3>Notes</h3>
+    <table>
+      <tr><td class="key">✓ / ✗</td><td class="desc">leading column = exit-status marker on each row</td></tr>
+      <tr><td class="key"><code>~/.local/share/atuin/history.db</code></td><td class="desc">sqlite store; machine-global, outside the repo</td></tr>
+      <tr><td class="key"><code>fish_history</code></td><td class="desc">still recorded in parallel; revert by deleting <code>45-atuin.fish</code></td></tr>
+      <tr><td class="key"><code>atuin import fish</code></td><td class="desc">one-time backfill from existing fish history</td></tr>
+    </table>
+    <p class="note">Config in <code>.config/atuin/config.toml</code>. Theme is <code>default</code> — auto-adapts to whatever Ghostty's 16-color palette is via ANSI refs, same trick as <code>FZF_DEFAULT_OPTS</code>.</p>
+  </div>
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════════════════ -->
 <h2 id="fzf">fzf <span class="tool-tag">fuzzy finder</span></h2>
 
 <div class="grid">
   <div class="card">
     <h3>Shell key bindings</h3>
     <table>
-      <tr><td class="key"><span class="k">Ctrl-R</span></td><td class="desc">fuzzy history search</td></tr>
+      <tr><td class="key"><span class="k">Ctrl-R</span></td><td class="desc warn">REPLACED by <a href="#atuin">atuin</a> — fzf no longer owns Ctrl-R</td></tr>
       <tr><td class="key"><span class="k">Ctrl-T</span></td><td class="desc">file picker → inserts paths at the cursor</td></tr>
       <tr><td class="key"><span class="k">Alt-C</span></td><td class="desc warn">UNBOUND — Alt is reserved for Polish diacritics</td></tr>
     </table>
@@ -611,7 +649,7 @@
 <span class="cmd">git log -p</span> | <span class="cmd">head</span>                 <span class="c"># should look styled</span></pre>
 
 <footer>
-  Built from <code>~/.config/fish/</code>, <code>Brewfile</code>, and project CLAUDE.md on 2026-05-11.
+  Built from <code>~/.config/fish/</code>, <code>Brewfile</code>, and project CLAUDE.md on 2026-05-17.
   Refresh after meaningful color-tooling changes.
 </footer>
 


### PR DESCRIPTION
## 🎯 Summary

- Declares `atuin` in `Brewfile` and adds `~/.config/atuin/` whole-dir symlink in `bootstrap.sh`
- Adds `.config/atuin/config.toml` with: `filter_mode = "global"`, `inline_height = 20`, `enter_accept = false` (Enter pastes, Tab runs), `columns = ["exit", "duration", "command"]`, ANSI-palette default theme
- Adds `.config/fish/conf.d/45-atuin.fish` — loads after `40-plugins.fish` so atuin's `atuin init fish | source` rebinds Ctrl-R and Up after fzf grabs them
- Updates CLAUDE.md (conf.d listing, new atuin bullet, Terminal-tools ANSI-adapt list), README.md (Manual extras `atuin import fish` step), and `docs/terminal-cheatsheet.html` (new atuin section, fzf Ctrl-R row marked REPLACED, footer date)

## ✅ Test Plan

- [x] `scripts/test-fish-loads.sh` exits 0 (new `45-atuin.fish` module; `command -q atuin` guard makes it safe before `brew bundle`)
- [x] `bash -n bootstrap.sh` exits 0 (no syntax error)
- [ ] On a machine with atuin installed: `brew bundle` → `bootstrap.sh` → `atuin import fish` — then Ctrl-R opens atuin's inline popup (~20 rows), Ctrl-R inside cycles scope, Enter pastes, Tab runs
- [ ] `theme-set mocha` / `theme-set latte` — atuin picker re-themes via ANSI palette automatically (no extra config)

## 📝 Notes

- 🪤 fish's `~/.local/share/fish/fish_history` keeps recording in parallel — cheap revert: delete `45-atuin.fish`
- 🎨 Theming uses `[theme] name = "default"` (ANSI palette refs), same auto-adapt trick as `FZF_DEFAULT_OPTS` — no per-theme files, no `theme-set` coupling needed
- 🔒 `auto_sync = false`, `update_check = false` — local-only, no remote, no telemetry

Closes #245