### PR TITLE
🅰️ option-key split: left = Alt for TUIs, right = Polish (+ downstream cleanup)

### DIFF
--- a/.config/atuin/config.toml
+++ b/.config/atuin/config.toml
@@ -44,14 +44,16 @@ exit_mode = "return-query"
 [search]
 filters = ["session", "workspace", "global"]
 
-# Per-row visible columns. atuin's column renderer supports a fixed-
-# width column after the expanding one, so `exit` pins to the right
-# edge of each row (right-aligned within its 3-char column) — handy
-# scan target for the actual integer (`-1`, `0`, `127`, …). atuin
-# renders the raw exit value coloured green/red, not a glyph.
+# Per-row visible columns. `exit` sits before `command` because
+# atuin's `command()` renderer ignores its allocated width and draws
+# to the row edge — putting `exit` after it would push the exit
+# integer out of sight (or render it next to the command, not pinned
+# right). Order is `datetime` → `exit` → `command`: timestamp left,
+# exit code in a fixed-position scan column (raw integer `-1` / `0`
+# / `127` coloured green or red, not a glyph), command expands last.
 # Schema note: picker columns live under [ui], not [search].
 [ui]
-columns = ["datetime", "command", "exit"]
+columns = ["datetime", "exit", "command"]
 
 # Default theme uses terminal ANSI palette refs — auto-themes across all
 # 7 dotfile themes (Solarized / Mocha / Frappé / Dracula / Gruvbox /

--- a/.config/atuin/config.toml
+++ b/.config/atuin/config.toml
@@ -1,7 +1,9 @@
 # Local-only history store. No sync, no telemetry, no remote.
-# Picker config locks in the answers from issue #245:
+# Picker config:
+#   - Ctrl-R opens atuin's picker (scope cycles inside it)
+#   - Up arrow stays on fish's native history-search (disabled in
+#     `.config/fish/conf.d/45-atuin.fish` via `--disable-up-arrow`)
 #   - default scope = global (atuin default); Ctrl-R cycles within picker
-#   - Up arrow opens session-scoped picker (NOT disabled)
 #   - Enter pastes to commandline; Tab runs immediately (fzf-parity)
 #   - inline popup (~20 rows), keeps tmux statusbar visible
 #   - default ANSI-palette theme; auto-adapts via Ghostty's 16-color palette
@@ -13,9 +15,6 @@ inline_height = 20
 
 # Default scope on Ctrl-R open.
 filter_mode = "global"
-
-# Up arrow picker scope. atuin Up opens a session-scoped mini-picker.
-filter_mode_shell_up_key_binding = "session"
 
 # Enter = paste to commandline (fzf parity); Tab = run immediately.
 enter_accept = false

--- a/.config/atuin/config.toml
+++ b/.config/atuin/config.toml
@@ -20,9 +20,10 @@ filter_mode_shell_up_key_binding = "session"
 # Enter = paste to commandline (fzf parity); Tab = run immediately.
 enter_accept = false
 
+
 # Cycle order inside the picker (Ctrl-R cycles through these).
 [search]
-filters = ["global", "host", "session", "directory"]
+filters = ["global", "session", "directory"]
 
 # Per-row visible columns. Exit code first so ✓/✗ leads each row.
 # (atuin schema: picker columns live under [ui], not [search].)

--- a/.config/atuin/config.toml
+++ b/.config/atuin/config.toml
@@ -11,13 +11,25 @@ auto_sync = false
 update_check = false
 
 # Picker geometry — inline popup over the prompt, not full-screen.
+# Default chrome (help row, tab bar, preview pane) all off: with
+# inline_height = 20 every row matters; the visible result list is
+# easier to scan than a preview of the highlighted command, and the
+# help/tab rows are static once you know the cycle.
 inline_height = 20
+show_help = false
+show_tabs = false
+show_preview = false
 
 # Default scope on Ctrl-R open.
 filter_mode = "global"
 
 # Enter = paste to commandline (fzf parity); Tab = run immediately.
 enter_accept = false
+
+# Esc returns the typed query to the prompt instead of clearing it,
+# so a stray Esc + edit + Ctrl-R doesn't lose the in-progress search.
+# Ctrl+C / Ctrl+D still discard the query.
+exit_mode = "return-query"
 
 
 # Cycle order inside the picker (Ctrl-R cycles through these).

--- a/.config/atuin/config.toml
+++ b/.config/atuin/config.toml
@@ -10,6 +10,10 @@
 auto_sync = false
 update_check = false
 
+# Enable the `workspace` filter scope so the picker can be narrowed to
+# the current git repo. Skipped silently when cwd is outside any repo.
+workspaces = true
+
 # Picker geometry — inline popup over the prompt, not full-screen.
 # Default chrome (help row, tab bar, preview pane) all off: with
 # inline_height = 20 every row matters; the visible result list is
@@ -20,8 +24,9 @@ show_help = false
 show_tabs = false
 show_preview = false
 
-# Default scope on Ctrl-R open.
-filter_mode = "global"
+# Default scope on Ctrl-R open. Session-first so the most recent
+# commands from this shell surface immediately; Ctrl-R widens.
+filter_mode = "session"
 
 # Enter = paste to commandline (fzf parity); Tab = run immediately.
 enter_accept = false
@@ -33,8 +38,11 @@ exit_mode = "return-query"
 
 
 # Cycle order inside the picker (Ctrl-R cycles through these).
+# session → workspace → global, narrow-to-wide; `directory` is
+# dropped (workspace is the repo-aware superset that's more useful
+# than cwd-only filtering).
 [search]
-filters = ["global", "session", "directory"]
+filters = ["session", "workspace", "global"]
 
 # Per-row visible columns. Exit code first so ✓/✗ leads each row.
 # (atuin schema: picker columns live under [ui], not [search].)

--- a/.config/atuin/config.toml
+++ b/.config/atuin/config.toml
@@ -44,10 +44,14 @@ exit_mode = "return-query"
 [search]
 filters = ["session", "workspace", "global"]
 
-# Per-row visible columns. Exit code first so ✓/✗ leads each row.
-# (atuin schema: picker columns live under [ui], not [search].)
+# Per-row visible columns. atuin's column renderer supports a fixed-
+# width column after the expanding one, so `exit` pins to the right
+# edge of each row (right-aligned within its 3-char column) — handy
+# scan target for the actual integer (`-1`, `0`, `127`, …). atuin
+# renders the raw exit value coloured green/red, not a glyph.
+# Schema note: picker columns live under [ui], not [search].
 [ui]
-columns = ["exit", "duration", "command"]
+columns = ["datetime", "command", "exit"]
 
 # Default theme uses terminal ANSI palette refs — auto-themes across all
 # 7 dotfile themes (Solarized / Mocha / Frappé / Dracula / Gruvbox /

--- a/.config/fish/conf.d/40-plugins.fish
+++ b/.config/fish/conf.d/40-plugins.fish
@@ -9,9 +9,6 @@ end
 # Overriding to 1,3.. drops the unix timestamp column.
 set -gx FZF_CTRL_R_OPTS "--with-nth=1,3.."
 
-# Alt-C is reserved for Polish diacritics; remove fzf's cd-widget binding.
-bind -e \ec 2>/dev/null
-
 # zoxide — frecency-ranked cd.
 if command -q zoxide
     set -gx _ZO_EXCLUDE_DIRS "$HOME:$HOME/Downloads/*:$HOME/.config/*:$HOME/Library/*"

--- a/.config/fish/conf.d/45-atuin.fish
+++ b/.config/fish/conf.d/45-atuin.fish
@@ -2,8 +2,10 @@
 # Loads after 40-plugins.fish (which runs `fzf --fish | source` and grabs
 # Ctrl-R for fzf's history widget). atuin's init rebinds Ctrl-R to its
 # own picker; fzf's Ctrl-T / Ctrl-V / Ctrl-S / Ctrl-Alt-F widgets are
-# unaffected. Up arrow is also bound to atuin's session-scoped picker.
+# unaffected. `--disable-up-arrow` leaves the Up key on fish's native
+# history search (previous command), which feels more natural than
+# atuin's session-scoped mini-picker for fast re-runs.
 # Config in .config/atuin/config.toml; history at ~/.local/share/atuin/.
 if command -q atuin
-    atuin init fish | source
+    atuin init fish --disable-up-arrow | source
 end

--- a/.config/ghostty/config.ghostty
+++ b/.config/ghostty/config.ghostty
@@ -84,6 +84,18 @@ split-inherit-working-directory = false
 # operates at the byte-emission layer and is the supported way to do this.
 macos-option-as-alt = left
 
+# ─── Unbind alt+arrow translation ─────────────
+# Ghostty defaults map alt+arrow_left → `esc:b` and alt+arrow_right →
+# `esc:f` (readline word-jump shortcut). That intercept means tmux
+# inside Ghostty never sees the proper Alt+Left/Right CSI sequence
+# (`ESC [1;3D` / `ESC [1;3C`), so `<prefix> M-Left` / `<prefix> M-Right`
+# (pane resize) don't fire — only `<prefix> M-Up` / `M-Down` work.
+# Unbind so the raw CSI form reaches tmux. Trade-off: at a plain shell
+# prompt, Alt+arrow no longer triggers readline word-jump — use
+# Alt+f / Alt+b instead (always worked, now reliably via left Option).
+keybind = alt+arrow_left=unbind
+keybind = alt+arrow_right=unbind
+
 # ─── Keybindings (config reload) ──────────────
 # Three-modifier combo to avoid clashes with launchers / menu shortcuts.
 # (The Polish-Pro layout broke the default `cmd+shift+,` for this user.)

--- a/.config/ghostty/config.ghostty
+++ b/.config/ghostty/config.ghostty
@@ -72,6 +72,18 @@ tab-inherit-working-directory = false
 window-inherit-working-directory = false
 split-inherit-working-directory = false
 
+# ─── Left Option = Alt (right Option = Polish) ─
+# Ghostty distinguishes left and right Option natively. `left` means:
+# left-Option emits ESC+key for TUIs (atuin row-N shortcuts, fish/readline
+# word-jump, etc.) while right-Option keeps producing Polish diacritics
+# via the OS layout (ą, ć, ę, ł, ń, ó, ś, ź, ż). Why this and not
+# right_cmd: Ghostty 1.3 keybinds do not accept sided modifiers
+# (`right_cmd+x` is `error.InvalidFormat`), and `key-remap = right_cmd=alt`
+# only changes keybind matching, not byte emission, so the modifier was
+# silently dropped and apps only saw the bare key. macos-option-as-alt
+# operates at the byte-emission layer and is the supported way to do this.
+macos-option-as-alt = left
+
 # ─── Keybindings (config reload) ──────────────
 # Three-modifier combo to avoid clashes with launchers / menu shortcuts.
 # (The Polish-Pro layout broke the default `cmd+shift+,` for this user.)

--- a/.config/nvim/lua/config/keymaps.lua
+++ b/.config/nvim/lua/config/keymaps.lua
@@ -1,13 +1,6 @@
 -- Loaded automatically on the VeryLazy event.
 -- LazyVim defaults: https://github.com/LazyVim/LazyVim/blob/main/lua/lazyvim/config/keymaps.lua
 
--- Polish keyboard reserves Alt for diacritics (ą/ć/ę/ł/ń/ó/ś/ź/ż).
--- LazyVim defaults bind <A-j>/<A-k> to move-line; remove them.
--- pcall guards against load-order edge cases where the map isn't set yet.
-local del = vim.keymap.del
-pcall(del, { "n", "i", "v" }, "<A-j>")
-pcall(del, { "n", "i", "v" }, "<A-k>")
-
 -- Opt-in LSP per session. Usage: `:LspOn vtsls`.
 -- Sugar for vim.lsp.enable() — registers the server's FileType autocmd
 -- so every matching buffer in this session auto-attaches (existing

--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -62,7 +62,10 @@ unbind %
 bind c new-window -c "#{?#{!=:#{@session_root},},#{@session_root},#{pane_current_path}}"
 
 # ─── Vim-style pane nav (with prefix) ───────
-# Alt is reserved for Polish diacritics (ą ć ę ł ń ó ś ź ż), so we use prefix.
+# Prefix path is the established muscle memory. `bind -n M-h/j/k/l` is
+# safe with Ghostty's `macos-option-as-alt = left` (only left-Option
+# fires M-*; right-Option still types Polish ą/ć/ę/ł/ń/ó/ś/ź/ż), but
+# no root Alt-nav is wired here by choice.
 bind h select-pane -L
 bind j select-pane -D
 bind k select-pane -U

--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -21,6 +21,12 @@ set -g base-index 1
 setw -g pane-base-index 1
 set -g renumber-windows on
 set -g escape-time 10
+# Read CSI-u / xterm modifyOtherKeys from Ghostty and pass through to inner
+# apps. Without this, modifier+arrow combos (e.g. `<prefix> M-Up` for pane
+# resize) arrive as `ESC [1;3A`-style sequences that tmux can't parse as
+# `M-Up`, so the binding never fires. Alt+letter / Alt+digit work either
+# way because they use the legacy `ESC <byte>` meta prefix.
+set -g extended-keys on
 set -g focus-events on
 set -g history-limit 50000
 # Longer repeat window (default 500ms) so `-r` bindings — Tab/S-Tab for

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,8 +50,12 @@ Personal multi-theme, multi-font setup for Ghostty + tmux + vim + fish. `theme-s
   (machine-global, outside the repo — worktrunk's copy-ignored never
   touches it). fish's own `~/.local/share/fish/fish_history` keeps
   recording in parallel (cheap revert: delete `45-atuin.fish`).
-  Picker UX locked in: `filter_mode = "global"` with Ctrl-R cycling
-  `global → session → directory` inside the picker; `enter_accept = false`
+  Picker UX locked in: `filter_mode = "session"` (narrow first; the
+  most recent commands from this shell surface immediately) with
+  Ctrl-R cycling `session → workspace → global` inside the picker.
+  `workspaces = true` enables the `workspace` scope (current git
+  repo); skipped silently when cwd is outside any repo.
+  `enter_accept = false`
   so Enter pastes to the commandline and Tab runs immediately (fzf
   parity); `inline_height = 20` keeps the tmux statusbar visible above
   the popup, with picker chrome stripped (`show_help`, `show_tabs`,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,6 +198,30 @@ Personal multi-theme, multi-font setup for Ghostty + tmux + vim + fish. `theme-s
   Without them, tmux strips OSC 8 and Claude Code's file-ref links don't
   render. `file://` click routing: macOS file-type defaults — no `duti`,
   no Ghostty `link` rule.
+- **Option key is split: left = Alt, right = Polish.**
+  `macos-option-as-alt = left` in `.config/ghostty/config.ghostty`
+  routes left-Option to ESC-prefixed byte sequences (the "Alt+key"
+  encoding atuin / fish-readline / vim-nvim / tmux all read); right-
+  Option keeps producing Polish diacritics (ą ć ę ł ń ó ś ź ż) via the
+  OS layout. The two physical keys split cleanly. Why not `right_cmd`:
+  Ghostty 1.3 keybinds reject sided modifiers (`error.InvalidFormat`),
+  and `key-remap = right_cmd=alt` rewrites keybind matching but not
+  byte emission, so the modifier was silently dropped and apps only
+  saw the bare key. Two companion settings make the split useful:
+  `set -g extended-keys on` in `tmux.conf` so modifier+arrow CSI
+  sequences (`ESC [1;3A`) reach inner apps (without it, `<prefix>
+  M-Left/Right` pane resize is silent); `keybind = alt+arrow_left/
+  right=unbind` in Ghostty so its default readline word-jump
+  translation (`alt+arrow_left → esc:b`) doesn't shadow tmux's
+  pane-resize bindings. Trade-off: left-Option no longer types Polish
+  *inside Ghostty*, and Alt+arrow at the shell prompt no longer
+  triggers readline word-jump — use Alt+b / Alt+f instead (always
+  worked, now reliably via left Option). Consumers in this repo:
+  atuin row-N picker shortcuts (`Alt+1`..`9`,`0`), fish/readline
+  word-jump (Alt+f / Alt+b / Alt+d), fzf Alt-C cd-widget, LazyVim
+  `<A-j>` / `<A-k>` line-move, tmux `<prefix> M-Up/Down/Left/Right`
+  pane resize + `<prefix> M-1`..`7` layout select. Smoke test:
+  `scripts/test-ghostty-config.sh`.
 - **Sesh config is split: shared + machine-local.** Repo tracks
   `.config/sesh/sesh.toml` (a `Home 🏠` session for `~` plus
   `import = ["~/.config/sesh/sesh.local.toml"]`). Machine-local sessions
@@ -648,6 +672,7 @@ is `nvim-cheatsheet.html`).
 - tmux Claude usage: `scripts/test-tmux-claude-usage.sh`
 - Session-root binding: `scripts/test-s-session-root.sh`
 - Fish config smoke: `scripts/test-fish-loads.sh`
+- Ghostty config smoke: `scripts/test-ghostty-config.sh`
 - Reapply symlinks (idempotent): `$PROJECTS_HOME/dotfiles/bootstrap.sh`
 - Brew deps (installed by bootstrap): `brew bundle check --file=$PROJECTS_HOME/dotfiles/Brewfile --verbose`
 - nvim plugin smoke: `scripts/test-nvim.sh`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,17 +40,18 @@ Personal multi-theme, multi-font setup for Ghostty + tmux + vim + fish. `theme-s
   `.template` companions by `bootstrap.sh`. `functions/less.fish`
   is a bat-backed `less` wrapper; `completions/wt.fish` adds wt
   tab-completion. Smoke test: `scripts/test-fish-loads.sh`.
-- **`atuin` owns Ctrl-R and Up arrow** (`~/.config/atuin/config.toml`,
+- **`atuin` owns Ctrl-R only** (`~/.config/atuin/config.toml`,
   wired by `.config/fish/conf.d/45-atuin.fish` via
-  `atuin init fish | source`, loaded after fzf so atuin's rebinds win).
-  Sqlite history at `~/.local/share/atuin/history.db` (machine-global,
-  outside the repo — worktrunk's copy-ignored never touches it). fish's
-  own `~/.local/share/fish/fish_history` keeps recording in parallel
-  (cheap revert: delete `45-atuin.fish`). Picker UX locked in:
-  `filter_mode = "global"` with Ctrl-R cycling
-  `global → host → session → directory` inside the picker; Up opens a
-  session-scoped mini-picker
-  (`filter_mode_shell_up_key_binding = "session"`); `enter_accept = false`
+  `atuin init fish --disable-up-arrow | source`, loaded after fzf so
+  atuin's Ctrl-R rebind wins). `--disable-up-arrow` leaves the Up key
+  on fish's native history-search (previous command) — atuin's
+  session-scoped mini-picker on Up felt redundant against fish's
+  built-in. Sqlite history at `~/.local/share/atuin/history.db`
+  (machine-global, outside the repo — worktrunk's copy-ignored never
+  touches it). fish's own `~/.local/share/fish/fish_history` keeps
+  recording in parallel (cheap revert: delete `45-atuin.fish`).
+  Picker UX locked in: `filter_mode = "global"` with Ctrl-R cycling
+  `global → session → directory` inside the picker; `enter_accept = false`
   so Enter pastes to the commandline and Tab runs immediately (fzf
   parity); `inline_height = 20` keeps the tmux statusbar visible above
   the popup; `columns = ["exit", "duration", "command"]` puts the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,9 +60,12 @@ Personal multi-theme, multi-font setup for Ghostty + tmux + vim + fish. `theme-s
   parity); `inline_height = 20` keeps the tmux statusbar visible above
   the popup, with picker chrome stripped (`show_help`, `show_tabs`,
   `show_preview` all `false`) so every row goes to the result list;
-  `columns = ["exit", "duration", "command"]` puts the ✓/✗ marker
-  first; `exit_mode = "return-query"` keeps the typed query at the
-  prompt on Esc (Ctrl+C / Ctrl+D still discard). Theming:
+  `columns = ["datetime", "command", "exit"]` puts the timestamp on
+  the left and pins the raw exit-code integer to the right edge
+  (atuin's column renderer supports a fixed-width column after the
+  expanding one; exit is colour-coded green/red, not a glyph);
+  `exit_mode = "return-query"` keeps the typed query at the prompt
+  on Esc (Ctrl+C / Ctrl+D still discard). Theming:
   `[theme] name = "default"` uses ANSI
   palette refs (same trick as `FZF_DEFAULT_OPTS`), auto-adapts across
   all 7 themes via Ghostty's 16-color palette — no per-theme files,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,8 +54,12 @@ Personal multi-theme, multi-font setup for Ghostty + tmux + vim + fish. `theme-s
   `global → session → directory` inside the picker; `enter_accept = false`
   so Enter pastes to the commandline and Tab runs immediately (fzf
   parity); `inline_height = 20` keeps the tmux statusbar visible above
-  the popup; `columns = ["exit", "duration", "command"]` puts the
-  ✓/✗ marker first. Theming: `[theme] name = "default"` uses ANSI
+  the popup, with picker chrome stripped (`show_help`, `show_tabs`,
+  `show_preview` all `false`) so every row goes to the result list;
+  `columns = ["exit", "duration", "command"]` puts the ✓/✗ marker
+  first; `exit_mode = "return-query"` keeps the typed query at the
+  prompt on Esc (Ctrl+C / Ctrl+D still discard). Theming:
+  `[theme] name = "default"` uses ANSI
   palette refs (same trick as `FZF_DEFAULT_OPTS`), auto-adapts across
   all 7 themes via Ghostty's 16-color palette — no per-theme files,
   no `theme-set` coupling. Failed commands are **shown with ✗**, not

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,8 +219,14 @@ Personal multi-theme, multi-font setup for Ghostty + tmux + vim + fish. `theme-s
   dir (mixed-dir pattern): `init.lua`, `mason-lock.json`, `lua/` are
   symlinked from the repo; `lazy/`, `mason/`, `site/`, `lazyvim.json`,
   `lazy-lock.json` are real and stay outside the repo.
-- **LazyVim Alt-keymaps removed** in `lua/config/keymaps.lua`
-  (`<A-j>/<A-k>`) — Alt is reserved for Polish diacritics. Don't re-add.
+- **LazyVim Alt-keymaps kept as default.** `<A-j>/<A-k>` (move-line)
+  ship in LazyVim and stay. Safe here because Ghostty splits the
+  Option key: `macos-option-as-alt = left` makes **left Option** emit
+  ESC+key (the byte sequence nvim reads as `<A-x>`), while **right
+  Option** still produces Polish diacritics via the OS layout. So
+  left-Option-j/k drives line-move; right-Option types ą/ć/ę/ł/ń/ó/ś/ź/ż.
+  Don't reinstate the `pcall(del, …, "<A-j>")` block in
+  `lua/config/keymaps.lua` — it was the pre-split workaround.
 - **LSPs off by default in nvim.** `lua/plugins/lsp-disable-all.lua`
   sets `enabled = false, mason = false` on every LazyVim-core/extra
   server (`lua_ls`, `jsonls`, `marksman`, `vtsls`, `ts_ls`,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,10 +60,12 @@ Personal multi-theme, multi-font setup for Ghostty + tmux + vim + fish. `theme-s
   parity); `inline_height = 20` keeps the tmux statusbar visible above
   the popup, with picker chrome stripped (`show_help`, `show_tabs`,
   `show_preview` all `false`) so every row goes to the result list;
-  `columns = ["datetime", "command", "exit"]` puts the timestamp on
-  the left and pins the raw exit-code integer to the right edge
-  (atuin's column renderer supports a fixed-width column after the
-  expanding one; exit is colour-coded green/red, not a glyph);
+  `columns = ["datetime", "exit", "command"]` puts the timestamp on
+  the left and the raw exit-code integer in a fixed-position column
+  just before the command (atuin's `command()` renderer ignores its
+  allocated width and draws to the row edge — a trailing column
+  after `command` would get clipped or rendered mid-row, so `exit`
+  sits before; the value is colour-coded green/red, not a glyph);
   `exit_mode = "return-query"` keeps the typed query at the prompt
   on Esc (Ctrl+C / Ctrl+D still discard). Theming:
   `[theme] name = "default"` uses ANSI

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ Personal multi-theme, multi-font setup for Ghostty + tmux + vim + fish. `theme-s
   `00-env`, `10-colors`, `15-local` (per-machine, untracked), `20-mise`,
   `25-prompt` (starship), `30-aliases`,
   `35-abbreviations` (git-flow mnemonic abbrs — `gst`, `gco`, `gp`, …),
-  `40-plugins` (fzf, zoxide, wt, Polish-diacritic Alt-C unbind),
+  `40-plugins` (fzf, zoxide, wt),
   `45-atuin` (atuin Ctrl-R + Up; rebinds after fzf),
   `99-secrets` (untracked). The two untracked files are copied from
   `.template` companions by `bootstrap.sh`. `functions/less.fish`
@@ -137,8 +137,11 @@ Personal multi-theme, multi-font setup for Ghostty + tmux + vim + fish. `theme-s
   of the right-side git chips' palette — see the palette-reuse note
   in the unique-accent rule.
 - **tmux prefix is `C-a`** (`C-Space` conflicts with macOS input-source
-  switching). Pane nav: `<prefix> h/j/k/l` (Alt is reserved for Polish
-  diacritics — never `bind -n M-*`). Splits: `|` and `-`.
+  switching). Pane nav: `<prefix> h/j/k/l` — by choice, not necessity.
+  `bind -n M-*` is safe with Ghostty's `macos-option-as-alt = left`
+  (only left-Option fires M-*; right-Option still types Polish
+  diacritics), but no root Alt bindings are wired here. Splits: `|`
+  and `-`.
   **Cycling pairs are single-canonical** — exactly one keystroke combo
   per motion, no duplicates: window cycling on `,` / `.` only (defaults
   `n`/`p` and `tmux-sensible`'s `C-p`/`C-n` are unbound — the `C-p`/`C-n`
@@ -156,7 +159,9 @@ Personal multi-theme, multi-font setup for Ghostty + tmux + vim + fish. `theme-s
   copy-mode). Default per-modifier actions in hint mode: `Ctrl+letter`
   = open (URL → browser, path → Finder), `Shift+letter` = paste into
   pane, `Tab` = multi-select. **No `bind -n M-*` recipes** from the
-  README — Alt stays reserved for Polish diacritics.
+  README adopted — `<prefix> F` / `<prefix> J` are the canonical
+  bindings; root M-* would be safe with the Option split but the
+  prefix path is the established muscle memory.
   Hint colors use ANSI palette refs (`colour9`/`colour10`/`colour13`/
   `colour14`) so they auto-adapt across all seven themes via Ghostty's
   16-color palette — no per-theme variant files, same trick as

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Smoke test: `scripts/test-theme-switch.sh`.
 
 - tmux prefix: `C-a`
 - session switcher (tmux-sessionx): `<prefix> t`  (clock-mode moved to `<prefix> T`)
-- pane nav: `<prefix> h/j/k/l` (Alt is reserved for Polish diacritics)
+- pane nav: `<prefix> h/j/k/l` (prefix by choice; left-Option in Ghostty acts as Alt, right-Option still types Polish)
 - splits: `<prefix> |` (right) / `<prefix> -` (down)
 - window cycling: `<prefix> ,` (prev) / `<prefix> .` (next) — repeatable. Defaults `n`/`p` and `tmux-sensible`'s `C-p`/`C-n` are unbound; this is the only cycle pair.
 - session cycling: `<prefix> Tab` (next) / `<prefix> S-Tab` (prev) / `<prefix> Space` (last) — repeatable. Defaults `(`/`)`/`L` unbound.

--- a/README.md
+++ b/README.md
@@ -99,7 +99,8 @@ atuin import fish
 ```
 
 Safe to re-run (idempotent for already-imported rows). After this,
-Ctrl-R and Up open atuin's picker (config at `.config/atuin/config.toml`).
+Ctrl-R opens atuin's picker (config at `.config/atuin/config.toml`).
+Up stays on fish's native history-search.
 
 ## What's where
 

--- a/docs/nvim-cheatsheet.html
+++ b/docs/nvim-cheatsheet.html
@@ -23,7 +23,7 @@
     <h1>Neovim <span class="accent">— Getting Started &amp; Cheatsheet</span></h1>
     <div class="sub">
       LazyVim &middot; Solarized &middot; leader = <code>&lt;Space&gt;</code> &middot; localleader = <code>\</code>
-      &middot; Polish keyboard: <span class="warn">no Alt-bindings</span>
+      &middot; <span class="accent">left Option = Alt</span>, right Option = Polish
     </div>
   </div>
   <a class="hero-cta" href="images/example_vim.png">view full screenshot</a>
@@ -90,7 +90,7 @@
   <div class="card">
     <h3>House rules (per CLAUDE.md)</h3>
     <ul class="compact">
-      <li><strong>No Alt mappings.</strong> Alt is reserved for Polish diacritics. <code>&lt;A-j&gt;</code>/<code>&lt;A-k&gt;</code> are explicitly removed.</li>
+      <li><strong>Alt mappings via left Option.</strong> Ghostty's <code>macos-option-as-alt = left</code> routes left-Option to Alt; right-Option still produces Polish diacritics via the OS layout. LazyVim's <code>&lt;A-j&gt;</code> / <code>&lt;A-k&gt;</code> (move-line) are kept.</li>
       <li><strong>Solarized + JetBrainsMono Nerd Font</strong> only.</li>
       <li><strong>Lockfiles committed:</strong> <code>lazy-lock.json</code>, <code>mason-lock.json</code>.</li>
       <li>Mason: <code>:MasonLock</code> snapshots, <code>:MasonLockUpdate</code> upgrades + snapshots.</li>
@@ -359,7 +359,7 @@
       <tr><td class="key"><span class="k">Ctrl-e</span></td><td class="desc">cancel / hide menu</td></tr>
       <tr><td class="key"><span class="k">Ctrl-d</span> / <span class="k">Ctrl-f</span></td><td class="desc">scroll docs up / down</td></tr>
     </table>
-    <p class="note">No <code>&lt;A-...&gt;</code> bindings — Polish diacritics policy.</p>
+    <p class="note"><code>&lt;A-...&gt;</code> bindings reach nvim via left Option (right Option types Polish).</p>
   </div>
 
 </div>
@@ -582,12 +582,11 @@
 
 <h3>Removed defaults</h3>
 <ul class="compact">
-  <li><code>&lt;A-j&gt;</code>, <code>&lt;A-k&gt;</code> (move-line) — Alt is reserved for Polish diacritics.</li>
   <li><code>gzip</code>, <code>tarPlugin</code>, <code>tohtml</code>, <code>tutor</code>, <code>zipPlugin</code> are disabled in <code>lazy.lua</code>.</li>
 </ul>
 
 <footer>
-  Built from <code>~/.config/nvim/</code> on 2026-05-05. Refresh after meaningful config changes.
+  Built from <code>~/.config/nvim/</code> on 2026-05-17. Refresh after meaningful config changes.
   <br>
   Cheat-skill: when in doubt, press <span class="k leader">␣</span> and read which-key.
 </footer>

--- a/docs/terminal-cheatsheet.html
+++ b/docs/terminal-cheatsheet.html
@@ -576,7 +576,7 @@
   <div class="card">
     <h3>Notes</h3>
     <table>
-      <tr><td class="key">✓ / ✗</td><td class="desc">leading column = exit-status marker on each row</td></tr>
+      <tr><td class="key">exit code</td><td class="desc">trailing column on each row — raw integer (<code>-1</code> = "completion never recorded"; <code>0</code> = success; anything else = the actual exit code), coloured green/red</td></tr>
       <tr><td class="key"><code>~/.local/share/atuin/history.db</code></td><td class="desc">sqlite store; machine-global, outside the repo</td></tr>
       <tr><td class="key"><code>fish_history</code></td><td class="desc">still recorded in parallel; revert by deleting <code>45-atuin.fish</code></td></tr>
       <tr><td class="key"><code>atuin import fish</code></td><td class="desc">one-time backfill from existing fish history</td></tr>

--- a/docs/terminal-cheatsheet.html
+++ b/docs/terminal-cheatsheet.html
@@ -555,9 +555,9 @@
     <h3>Shell key bindings</h3>
     <table>
       <tr><td class="key"><span class="k">Ctrl-R</span></td><td class="desc">atuin history picker — full screen-aware popup with scope cycling</td></tr>
-      <tr><td class="key"><span class="k">Up</span></td><td class="desc">session-scoped mini-picker (was: fish previous-command)</td></tr>
+      <tr><td class="key"><span class="k">Up</span></td><td class="desc">fish native history-search (atuin's up-arrow binding disabled via <code>--disable-up-arrow</code>)</td></tr>
     </table>
-    <p class="note">Cycle scope inside the picker with <span class="k">Ctrl-R</span>: <code>global → host → session → directory</code>. Default scope is <code>global</code>.</p>
+    <p class="note">Cycle scope inside the picker with <span class="k">Ctrl-R</span>: <code>global → session → directory</code>. Default scope is <code>global</code>.</p>
   </div>
 
   <div class="card">

--- a/docs/terminal-cheatsheet.html
+++ b/docs/terminal-cheatsheet.html
@@ -557,7 +557,7 @@
       <tr><td class="key"><span class="k">Ctrl-R</span></td><td class="desc">atuin history picker — full screen-aware popup with scope cycling</td></tr>
       <tr><td class="key"><span class="k">Up</span></td><td class="desc">fish native history-search (atuin's up-arrow binding disabled via <code>--disable-up-arrow</code>)</td></tr>
     </table>
-    <p class="note">Cycle scope inside the picker with <span class="k">Ctrl-R</span>: <code>global → session → directory</code>. Default scope is <code>global</code>.</p>
+    <p class="note">Cycle scope inside the picker with <span class="k">Ctrl-R</span>: <code>session → workspace → global</code>. Default scope is <code>session</code>; <code>workspace</code> is the current git repo (skipped outside a repo).</p>
   </div>
 
   <div class="card">
@@ -565,10 +565,10 @@
     <table>
       <tr><td class="key"><span class="k">Enter</span></td><td class="desc">paste selected command to commandline (does not run)</td></tr>
       <tr><td class="key"><span class="k">Tab</span></td><td class="desc">run selected command immediately</td></tr>
-      <tr><td class="key"><span class="k">Ctrl-R</span></td><td class="desc">cycle scope (global → host → session → directory)</td></tr>
+      <tr><td class="key"><span class="k">Ctrl-R</span></td><td class="desc">cycle scope (session → workspace → global)</td></tr>
       <tr><td class="key"><span class="k">Ctrl-S</span></td><td class="desc">toggle exact / fuzzy match</td></tr>
       <tr><td class="key"><span class="k">Ctrl-N</span> / <span class="k">Ctrl-P</span></td><td class="desc">next / prev match (arrows work too)</td></tr>
-      <tr><td class="key"><span class="k">Esc</span></td><td class="desc">cancel</td></tr>
+      <tr><td class="key"><span class="k">Esc</span></td><td class="desc">return typed query to the prompt (<code>exit_mode = "return-query"</code>); Ctrl+C / Ctrl+D discard</td></tr>
       <tr><td class="key"><code>cwd:.</code></td><td class="desc">filter syntax — restrict to current directory</td></tr>
     </table>
   </div>

--- a/docs/terminal-cheatsheet.html
+++ b/docs/terminal-cheatsheet.html
@@ -594,7 +594,7 @@
     <table>
       <tr><td class="key"><span class="k">Ctrl-R</span></td><td class="desc warn">REPLACED by <a href="#atuin">atuin</a> — fzf no longer owns Ctrl-R</td></tr>
       <tr><td class="key"><span class="k">Ctrl-T</span></td><td class="desc">file picker → inserts paths at the cursor</td></tr>
-      <tr><td class="key"><span class="k">Alt-C</span></td><td class="desc warn">UNBOUND — Alt is reserved for Polish diacritics</td></tr>
+      <tr><td class="key"><span class="k">Alt-C</span></td><td class="desc">cd into directory under cursor (left-Option in Ghostty; right-Option still types Polish)</td></tr>
     </table>
     <p class="note">Tab-complete works through fzf for <code>kill **&lt;Tab&gt;</code>, <code>cd **&lt;Tab&gt;</code>, <code>ssh **&lt;Tab&gt;</code>, etc.</p>
   </div>

--- a/docs/terminal-cheatsheet.html
+++ b/docs/terminal-cheatsheet.html
@@ -576,7 +576,7 @@
   <div class="card">
     <h3>Notes</h3>
     <table>
-      <tr><td class="key">exit code</td><td class="desc">trailing column on each row — raw integer (<code>-1</code> = "completion never recorded"; <code>0</code> = success; anything else = the actual exit code), coloured green/red</td></tr>
+      <tr><td class="key">exit code</td><td class="desc">fixed-position column between datetime and command — raw integer (<code>-1</code> = "completion never recorded"; <code>0</code> = success; anything else = the actual exit code), coloured green/red</td></tr>
       <tr><td class="key"><code>~/.local/share/atuin/history.db</code></td><td class="desc">sqlite store; machine-global, outside the repo</td></tr>
       <tr><td class="key"><code>fish_history</code></td><td class="desc">still recorded in parallel; revert by deleting <code>45-atuin.fish</code></td></tr>
       <tr><td class="key"><code>atuin import fish</code></td><td class="desc">one-time backfill from existing fish history</td></tr>

--- a/docs/tmux-cheatsheet.html
+++ b/docs/tmux-cheatsheet.html
@@ -87,7 +87,7 @@
     <ul class="compact">
       <li><strong>Hand-rolled status bar.</strong> No catppuccin/powerline plugins.</li>
       <li><strong>Prefix is <code>C-a</code></strong>, not <code>C-Space</code>.</li>
-      <li><strong>No <code>bind -n M-*</code></strong> — Alt is reserved for Polish diacritics.</li>
+      <li><strong>Prefix nav by choice.</strong> <code>bind -n M-*</code> is safe with Ghostty's <code>macos-option-as-alt = left</code>, but pane nav uses <code>&lt;prefix&gt; h/j/k/l</code>.</li>
       <li><strong>Worktree status segment</strong> uses <code>git rev-parse --git-dir</code> vs <code>--git-common-dir</code>. Don't replace with <code>git worktree list</code> parsing.</li>
     </ul>
   </div>

--- a/scripts/test-ghostty-config.sh
+++ b/scripts/test-ghostty-config.sh
@@ -1,0 +1,20 @@
+#!/opt/homebrew/bin/bash
+# Smoke test: Ghostty parses the live config.ghostty without errors.
+# Validates the symlinked-to-repo config plus machine-local includes
+# (font.ghostty, theme.ghostty, etc.). Run after editing any tracked
+# Ghostty config or modifying the includes via theme-set / font-set.
+set -euo pipefail
+
+if ! command -v ghostty >/dev/null 2>&1; then
+  echo "⏭️  ghostty not installed — skipping (brew install --cask ghostty)"
+  exit 0
+fi
+
+if out=$(ghostty +validate-config 2>&1); then
+  echo "✅ ghostty config validates clean"
+  exit 0
+fi
+
+echo "❌ ghostty config has errors:"
+echo "$out"
+exit 1


### PR DESCRIPTION
## 🎯 Summary

A single Ghostty setting (`macos-option-as-alt = left`) splits the Option key so **left = Alt-for-tools** and **right = Polish-diacritics**. That one change cascades into a broad sweep of related work: TUI Alt-shortcuts start firing for the first time, the cross-tool "Alt is reserved" doctrine that pervaded the repo is walked back, and the atuin picker gets an overhaul now that the Up arrow can return to fish.

## 🧱 Changes by area

### ⌨️ Ghostty (`.config/ghostty/config.ghostty`)
- 🅰️ `macos-option-as-alt = left` — left-Option emits ESC-prefixed byte sequences (the "Alt+key" encoding atuin / fish-readline / vim-nvim / tmux read for word-jump, row-N shortcuts, line-move, etc.). Right-Option stays bound to the macOS Polish layout for `ą ć ę ł ń ó ś ź ż`.
- 🚫 `keybind = alt+arrow_left=unbind` / `alt+arrow_right=unbind` — Ghostty's defaults map these to `esc:b` / `esc:f` (readline word-jump synthesis). With them on, tmux only saw `M-b` / `M-f` instead of the Alt+Left/Right CSI sequence, so `<prefix> M-Left/Right` pane resize was silent. Unbinding lets the raw CSI form reach tmux.

### 🪟 tmux (`.config/tmux/tmux.conf`)
- 🔁 `set -g extended-keys on` — required so tmux parses the CSI-u / modifyOtherKeys form (`ESC [1;3A`) Ghostty sends for modifier+arrow combos. Without it, `<prefix> M-arrows` resize bindings never fired.
- 📝 Pane-nav comment rewritten from "Alt is reserved" to "prefix by choice — `bind -n M-*` is safe but not wired today" — `bind -n M-h/j/k/l` would now work fine but `<prefix> h/j/k/l` is well-tuned muscle memory.

### 🪂 nvim (`.config/nvim/lua/config/keymaps.lua`)
- ➕ Re-enable LazyVim's `<A-j>` / `<A-k>` line-move defaults. The previous `pcall(del, …, "<A-j>")` block was a Polish-Alt collision workaround; with left-Option distinct from Polish, it's no longer needed.

### 🐟 fish (`.config/fish/conf.d/40-plugins.fish`)
- ➕ Restore fzf's default Alt-C "cd into subdir" widget — the `bind -e \ec` unbind was a Polish-Alt workaround.

### 🔍 atuin (`.config/atuin/config.toml` + `.config/fish/conf.d/45-atuin.fish`)
- ⬆️ `--disable-up-arrow` — Up arrow returns to fish's native history-search (prefix-matched previous-command). atuin's session-scoped mini-picker on Up felt redundant against fish's built-in; the full screen-aware picker stays on Ctrl-R.
- 🎯 `workspaces = true` + `filter_mode = "session"` + `filters = ["session", "workspace", "global"]` — session-first scope cycle (narrow → repo-aware → wide). Drops `directory` (workspace is the repo-aware superset) and `host` (single-machine).
- 🎚️ `show_help = false`, `show_tabs = false`, `show_preview = false` — strips ~6 rows of chrome out of the 20-row inline popup, so the result list density roughly doubles.
- ⎋ `exit_mode = "return-query"` — Esc returns the typed query to the prompt instead of clearing it.
- 📅 `columns = ["datetime", "exit", "command"]` — timestamp on the left, raw exit-code integer in a fixed-position scan column (colour-coded green/red — **not** a glyph; that was a mischaracterisation in early commits), command expands last. Note: atuin's `command()` renderer ignores its allocated width and draws to the row edge, so a trailing column after `command` can't be right-pinned — `exit` sits before `command` for that reason.

### 📝 Cross-repo documentation cleanup
- The "Alt is reserved for Polish diacritics — never `bind -n M-*`" doctrine is removed from CLAUDE.md (tmux + tmux-fingers sections), README.md (keymap quick-ref), and three cheatsheets (nvim, tmux, terminal).
- New canonical **"Option key is split: left = Alt, right = Polish"** bullet in CLAUDE.md spells out the supported setting, the alternatives that were tried and rejected (`right_cmd` keybinds, `key-remap = right_cmd=alt`), the two companion settings (`extended-keys on`, `alt+arrow=unbind`), the trade-offs, and the list of in-repo consumers.

### 🛂 Smoke test
- `scripts/test-ghostty-config.sh` — thin wrapper around `ghostty +validate-config` matching the shape of the other tests; skips cleanly if Ghostty isn't installed. Added to CLAUDE.md's "Verify changes" list.

## 🐌 What this replaces (and why each cheaper path failed)

The motivating problem: atuin's row-N picker shortcuts (`Alt+5` to paste row 5, etc.) didn't fire on this machine. Three plausible workarounds, each broken for a different reason — diagnostic chain documented inline in the Ghostty config:

1. 🚫 **`ctrl_n_shortcuts = true`** (atuin's documented workaround) — fundamentally broken in any terminal. `Ctrl+digit` has no clean ASCII control-set encoding:
   - `Ctrl+3` sends ESC → atuin reads it as Escape and **closes the picker**
   - `Ctrl+1` / `Ctrl+9` / `Ctrl+0` strip the modifier and pass the bare digit
   - Only `Ctrl+4`..`Ctrl+7` map to legacy control bytes (FS/GS/RS/US) atuin can route — 4 of 10 shortcuts work
   - Upstream tracker: [atuinsh/atuin#1577](https://github.com/atuinsh/atuin/issues/1577)
2. 🚫 **`keybind = right_cmd+N=esc:N`** — Ghostty 1.3 rejects sided modifiers in `keybind` triggers (`error.InvalidFormat`). Sided names work in `key-remap` only.
3. 🚫 **`key-remap = right_cmd=alt`** — rewrites Ghostty's internal keybind matching but **not byte emission**, so the modifier is silently dropped and apps only see the bare key. Docs warn about this inverse case (`option+a` still produces `å` under `option=ctrl`).

✅ **`macos-option-as-alt = left`** operates at the byte-emission layer and Ghostty distinguishes left/right Option natively for it. Supported, single-line, works end-to-end.

## ⚖️ Trade-offs / migration notes

- ✅ Left-Option in TUIs: emits Alt+key for atuin, fish, vim/nvim, tmux. Right-Option: still types Polish diacritics. The two physical keys split cleanly.
- ⚠️ **Left-Option no longer types Polish *inside Ghostty*.** Outside Ghostty (other apps), both Options still produce Polish via the OS layout. Since right-Option was already the dominant typing hand here, this is effectively free.
- ⚠️ **Alt+Left/Right at the shell prompt no longer triggers readline word-jump.** Use `Alt+b` / `Alt+f` instead — always worked, now reliably reaches readline via left-Option. The Ghostty unbind is necessary so tmux's `<prefix> M-Left/Right` resize sees the raw CSI sequence.

## 🧪 Test plan

- [x] `scripts/test-fish-loads.sh` — passes (fish config still loads clean)
- [x] `scripts/test-ghostty-config.sh` — passes (`ghostty +validate-config` clean)
- [x] Reload Ghostty (`cmd+ctrl+shift+r`) and reload tmux (`<prefix> r`)
- [x] Ctrl-R atuin picker → `Left-Option+5` selects row 5; chrome stripped (no help/tabs/preview rows); each row shows `datetime exit command`; Esc returns typed query to prompt
- [x] Atuin Ctrl-R scope cycle: `session → workspace → global` (workspace skipped outside a repo)
- [x] Up arrow at fish prompt → fish native prefix-match previous-command (no atuin mini-picker)
- [x] `Left-Option+f` / `Left-Option+b` at fish prompt → forward / backward by word
- [x] fzf Alt-C → cd into subdir picker (left-Option) — was UNBOUND before
- [x] nvim: `Left-Option+j` / `Left-Option+k` in normal/insert/visual → move current line/selection
- [x] tmux: `<prefix> Left-Option+Up/Down/Left/Right` → pane resize 5 in each direction (all four arrows, not just Up/Down — was the original pre-fix bug)
- [x] tmux: `<prefix> Left-Option+1`..`7` → layout select
- [x] `Right-Option+l` still produces `ł`; full `ą ć ę ł ń ó ś ź ż` set intact via right Option

## 📜 Commits (12)

1. `c8ec809` 🅰️ ghostty: route left Option to Alt for TUI shortcuts
2. `c9afa80` 🪂 nvim: re-enable LazyVim `<A-j>` / `<A-k>` line-move
3. `4ef1e56` 🧹 remove Alt-as-Polish restrictions across the repo
4. `4082482` 🔁 tmux + ghostty: unlock `<prefix> M-arrows` for pane resize
5. `a438f77` ⬆️ atuin: release the Up arrow back to fish
6. `8a8016e` 🎚️ atuin: strip picker chrome + keep query on Esc
7. `b617c99` 🎯 atuin: session-first picker scope cycle with workspace mode
8. `18f8eb6` 📅 atuin: datetime+command+exit row, exit pinned to the right *(self-corrected by #10 — atuin's column renderer can't right-pin after `command`)*
9. `955c2a5` ↩️ atuin: move `exit` before `command` (renderer can't right-pin)
10. `e6af52a` 🛂 ghostty: smoke test + canonical Option-key rule in CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)