### PR TITLE
🌐 atuin: default to global scope, cycle global → session → workspace

### DIFF
--- a/.config/atuin/config.toml
+++ b/.config/atuin/config.toml
@@ -20,6 +20,7 @@ workspaces = true
 # easier to scan than a preview of the highlighted command, and the
 # help/tab rows are static once you know the cycle.
 inline_height = 20
+style = "auto"
 show_help = false
 show_tabs = false
 show_preview = false

--- a/.config/atuin/config.toml
+++ b/.config/atuin/config.toml
@@ -3,7 +3,7 @@
 #   - Ctrl-R opens atuin's picker (scope cycles inside it)
 #   - Up arrow stays on fish's native history-search (disabled in
 #     `.config/fish/conf.d/45-atuin.fish` via `--disable-up-arrow`)
-#   - default scope = global (atuin default); Ctrl-R cycles within picker
+#   - default scope = global; Ctrl-R cycles within picker
 #   - Enter pastes to commandline; Tab runs immediately (fzf-parity)
 #   - inline popup (~20 rows), keeps tmux statusbar visible
 #   - default ANSI-palette theme; auto-adapts via Ghostty's 16-color palette
@@ -24,9 +24,9 @@ show_help = false
 show_tabs = false
 show_preview = false
 
-# Default scope on Ctrl-R open. Session-first so the most recent
-# commands from this shell surface immediately; Ctrl-R widens.
-filter_mode = "session"
+# Default scope on Ctrl-R open. Global-first so every command is in
+# reach without cycling; Ctrl-R narrows to session, then workspace.
+filter_mode = "global"
 
 # Enter = paste to commandline (fzf parity); Tab = run immediately.
 enter_accept = false
@@ -38,11 +38,11 @@ exit_mode = "return-query"
 
 
 # Cycle order inside the picker (Ctrl-R cycles through these).
-# session → workspace → global, narrow-to-wide; `directory` is
+# global → session → workspace, wide-to-narrow; `directory` is
 # dropped (workspace is the repo-aware superset that's more useful
 # than cwd-only filtering).
 [search]
-filters = ["session", "workspace", "global"]
+filters = ["global", "session", "workspace"]
 
 # Per-row visible columns. `exit` sits before `command` because
 # atuin's `command()` renderer ignores its allocated width and draws

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,9 +50,9 @@ Personal multi-theme, multi-font setup for Ghostty + tmux + vim + fish. `theme-s
   (machine-global, outside the repo — worktrunk's copy-ignored never
   touches it). fish's own `~/.local/share/fish/fish_history` keeps
   recording in parallel (cheap revert: delete `45-atuin.fish`).
-  Picker UX locked in: `filter_mode = "session"` (narrow first; the
-  most recent commands from this shell surface immediately) with
-  Ctrl-R cycling `session → workspace → global` inside the picker.
+  Picker UX locked in: `filter_mode = "global"` (wide first; every
+  command is in reach without cycling) with Ctrl-R cycling
+  `global → session → workspace` inside the picker.
   `workspaces = true` enables the `workspace` scope (current git
   repo); skipped silently when cwd is outside any repo.
   `enter_accept = false`


### PR DESCRIPTION
## 📋 Summary

- 🌐 Flip atuin's default `filter_mode` from `session` to `global` so Ctrl-R surfaces full history first
- 🔄 Reorder picker cycle from `session → workspace → global` (narrow-to-wide) to `global → session → workspace` (wide-to-narrow)
- 📝 Update project CLAUDE.md to match

## 🧪 Test plan

- [ ] Open a new fish shell, press Ctrl-R → picker opens on global scope
- [ ] Press Ctrl-R inside the picker → narrows to session
- [ ] Press Ctrl-R again → narrows to workspace (when inside a git repo)
- [ ] Press Ctrl-R again → wraps back to global