### PR TITLE
🪱 worktrunk: isolate per-worktree .beads/ from copy-ignored flow

### DIFF
--- a/.config/worktrunk/config.toml
+++ b/.config/worktrunk/config.toml
@@ -271,5 +271,24 @@ trust-mise = "mise trust --yes 2>/dev/null || true"
 # diverged in the worktree. Accepted trade-off — package-manager
 # operations inside worktrees are rare; if it bites, revisit
 # (see .superpowers/specs/2026-05-04-wt-pre-remove-symmetric-copy-ignored-design.md).
-[pre-remove]
+[[pre-remove]]
 save-shared = "wt -C {{ primary_worktree_path }} step copy-ignored --from {{ branch }}"
+
+# Clean up worktree-local bd database on wt remove. No-op in repos
+# without .beads/, so safe to keep enabled everywhere. Personal
+# infrastructure for the /mc:* workflow — kept out of any project
+# wt.toml so teammates don't inherit bd-specific hooks. Separate
+# stage from save-shared so the gitignored-flow-back completes before
+# .beads/ is deleted (ordering doesn't actually matter — .beads/ is
+# excluded from copy-ignored below — but the separation is explicit).
+[[pre-remove]]
+beads = "[ -d .beads ] && rm -rf .beads || true"
+
+# Prevent `wt step copy-ignored` from propagating .beads/ between
+# worktrees. Without this, post-start would carry .beads/ from
+# primary into each new worktree (shadowing main's shared DB if you
+# ever switch to that mode), and pre-remove save-shared would flow
+# a worktree's .beads/ back to primary on teardown (clobbering the
+# real DB). Combines with project-config excludes.
+[step.copy-ignored]
+exclude = [".beads/"]


### PR DESCRIPTION
## 🎯 Summary

- 🧹 Add `[[pre-remove]] beads` hook that deletes `.beads/` on `wt remove` (no-op in repos without `.beads/`).
- 🚧 Add `[step.copy-ignored] exclude = [".beads/"]` so worktrunk's gitignored-flow never carries a worktree's bd database into primary on teardown or out of primary on worktree creation.
- 🔀 Convert `[pre-remove]` to the `[[pre-remove]]` array-of-tables form so the existing `save-shared` and the new beads cleanup coexist as separate stages.

## 🤔 Why

`bd` stores its sqlite database at `.beads/` inside the cwd. Without these guards:

- `[post-start] copy = "wt step copy-ignored"` would carry `.beads/` from primary into each new worktree, shadowing main's shared DB if that mode is ever used.
- `[pre-remove] save-shared` would flow a worktree's `.beads/` back to primary on teardown, clobbering the real DB.

The hook lives in the user-global `~/.config/worktrunk/config.toml` (not project-local `wt.toml`) so teammates don't inherit bd-specific behavior.

## ✅ Test plan

- [ ] `wt switch --create test-beads` in a repo without `.beads/` — confirm no `.beads/` materializes in the new worktree.
- [ ] `mkdir .beads && touch .beads/x` in a worktree, then `wt remove test-beads` — confirm the worktree is removed and `.beads/` did NOT propagate back to primary.
- [ ] `scripts/test-wt-pre-remove-save.sh` still passes (existing save-shared behavior unchanged).