### PR TITLE
🪱 worktrunk: drop redundant pre-remove .beads/ cleanup hook

### DIFF
--- a/.config/worktrunk/config.toml
+++ b/.config/worktrunk/config.toml
@@ -274,21 +274,12 @@ trust-mise = "mise trust --yes 2>/dev/null || true"
 [[pre-remove]]
 save-shared = "wt -C {{ primary_worktree_path }} step copy-ignored --from {{ branch }}"
 
-# Clean up worktree-local bd database on wt remove. No-op in repos
-# without .beads/, so safe to keep enabled everywhere. Personal
-# infrastructure for the /mc:* workflow — kept out of any project
-# wt.toml so teammates don't inherit bd-specific hooks. Separate
-# stage from save-shared so the gitignored-flow-back completes before
-# .beads/ is deleted (ordering doesn't actually matter — .beads/ is
-# excluded from copy-ignored below — but the separation is explicit).
-[[pre-remove]]
-beads = "[ -d .beads ] && rm -rf .beads || true"
-
 # Prevent `wt step copy-ignored` from propagating .beads/ between
-# worktrees. Without this, post-start would carry .beads/ from
-# primary into each new worktree (shadowing main's shared DB if you
-# ever switch to that mode), and pre-remove save-shared would flow
-# a worktree's .beads/ back to primary on teardown (clobbering the
-# real DB). Combines with project-config excludes.
+# worktrees. With repo-wide (shared-mode) bd, main has the only
+# .beads/ and all worktrees walk up to find it. Without this exclude,
+# post-start would copy that .beads/ into each new worktree —
+# shadowing main's DB on every bd call from the worktree — and
+# pre-remove save-shared would flow the stale worktree DB back to
+# main, clobbering real state. Load-bearing.
 [step.copy-ignored]
 exclude = [".beads/"]


### PR DESCRIPTION
## 🎯 Summary
- 🗑️ Drop `[[pre-remove]] beads = "[ -d .beads ] && rm -rf .beads || true"` — a no-op under shared-mode bd, where only main has `.beads/` and worktrees walk up to find it
- 📝 Rewrite the `step.copy-ignored.exclude` comment to describe the shared-mode reality (main owns the DB, worktrees never have their own `.beads/`) instead of the older per-worktree-DB hazard

## 🤔 Why
The cleanup hook predates the shared-mode decision. Worktrees never get their own `.beads/` anymore, so there's nothing for `rm -rf .beads` to remove. The exclude entry is what actually keeps the gitignored flow from clobbering main's DB on `wt remove` — that one stays load-bearing.

## ✅ Test plan
- [ ] `scripts/test-wt-pre-remove-save.sh` still passes
- [ ] Spin up a worktree, touch gitignored content, `wt remove` it — primary's `.beads/` untouched and gitignored flow-back still works