### PR TITLE
🫘 bd: track patched fish completion (keep-order override)

### DIFF
--- a/.config/fish/completions/bd.fish
+++ b/.config/fish/completions/bd.fish
@@ -1,0 +1,235 @@
+# fish completion for bd                                   -*- shell-script -*-
+
+function __bd_debug
+    set -l file "$BASH_COMP_DEBUG_FILE"
+    if test -n "$file"
+        echo "$argv" >> $file
+    end
+end
+
+function __bd_perform_completion
+    __bd_debug "Starting __bd_perform_completion"
+
+    # Extract all args except the last one
+    set -l args (commandline -opc)
+    # Extract the last arg and escape it in case it is a space
+    set -l lastArg (string escape -- (commandline -ct))
+
+    __bd_debug "args: $args"
+    __bd_debug "last arg: $lastArg"
+
+    # Disable ActiveHelp which is not supported for fish shell
+    set -l requestComp "BD_ACTIVE_HELP=0 $args[1] __complete $args[2..-1] $lastArg"
+
+    __bd_debug "Calling $requestComp"
+    set -l results (eval $requestComp 2> /dev/null)
+
+    # Some programs may output extra empty lines after the directive.
+    # Let's ignore them or else it will break completion.
+    # Ref: https://github.com/spf13/cobra/issues/1279
+    for line in $results[-1..1]
+        if test (string trim -- $line) = ""
+            # Found an empty line, remove it
+            set results $results[1..-2]
+        else
+            # Found non-empty line, we have our proper output
+            break
+        end
+    end
+
+    set -l comps $results[1..-2]
+    set -l directiveLine $results[-1]
+
+    # For Fish, when completing a flag with an = (e.g., <program> -n=<TAB>)
+    # completions must be prefixed with the flag
+    set -l flagPrefix (string match -r -- '-.*=' "$lastArg")
+
+    __bd_debug "Comps: $comps"
+    __bd_debug "DirectiveLine: $directiveLine"
+    __bd_debug "flagPrefix: $flagPrefix"
+
+    for comp in $comps
+        printf "%s%s\n" "$flagPrefix" "$comp"
+    end
+
+    printf "%s\n" "$directiveLine"
+end
+
+# this function limits calls to __bd_perform_completion, by caching the result behind $__bd_perform_completion_once_result
+function __bd_perform_completion_once
+    __bd_debug "Starting __bd_perform_completion_once"
+
+    if test -n "$__bd_perform_completion_once_result"
+        __bd_debug "Seems like a valid result already exists, skipping __bd_perform_completion"
+        return 0
+    end
+
+    set --global __bd_perform_completion_once_result (__bd_perform_completion)
+    if test -z "$__bd_perform_completion_once_result"
+        __bd_debug "No completions, probably due to a failure"
+        return 1
+    end
+
+    __bd_debug "Performed completions and set __bd_perform_completion_once_result"
+    return 0
+end
+
+# this function is used to clear the $__bd_perform_completion_once_result variable after completions are run
+function __bd_clear_perform_completion_once_result
+    __bd_debug ""
+    __bd_debug "========= clearing previously set __bd_perform_completion_once_result variable =========="
+    set --erase __bd_perform_completion_once_result
+    __bd_debug "Successfully erased the variable __bd_perform_completion_once_result"
+end
+
+function __bd_requires_order_preservation
+    __bd_debug ""
+    __bd_debug "========= checking if order preservation is required =========="
+
+    __bd_perform_completion_once
+    if test -z "$__bd_perform_completion_once_result"
+        __bd_debug "Error determining if order preservation is required"
+        return 1
+    end
+
+    set -l directive (string sub --start 2 $__bd_perform_completion_once_result[-1])
+    __bd_debug "Directive is: $directive"
+
+    set -l shellCompDirectiveKeepOrder 32
+    set -l keeporder (math (math --scale 0 $directive / $shellCompDirectiveKeepOrder) % 2)
+    __bd_debug "Keeporder is: $keeporder"
+
+    if test $keeporder -ne 0
+        __bd_debug "This does require order preservation"
+        return 0
+    end
+
+    __bd_debug "This doesn't require order preservation"
+    return 1
+end
+
+
+# This function does two things:
+# - Obtain the completions and store them in the global __bd_comp_results
+# - Return false if file completion should be performed
+function __bd_prepare_completions
+    __bd_debug ""
+    __bd_debug "========= starting completion logic =========="
+
+    # Start fresh
+    set --erase __bd_comp_results
+
+    __bd_perform_completion_once
+    __bd_debug "Completion results: $__bd_perform_completion_once_result"
+
+    if test -z "$__bd_perform_completion_once_result"
+        __bd_debug "No completion, probably due to a failure"
+        # Might as well do file completion, in case it helps
+        return 1
+    end
+
+    set -l directive (string sub --start 2 $__bd_perform_completion_once_result[-1])
+    set --global __bd_comp_results $__bd_perform_completion_once_result[1..-2]
+
+    __bd_debug "Completions are: $__bd_comp_results"
+    __bd_debug "Directive is: $directive"
+
+    set -l shellCompDirectiveError 1
+    set -l shellCompDirectiveNoSpace 2
+    set -l shellCompDirectiveNoFileComp 4
+    set -l shellCompDirectiveFilterFileExt 8
+    set -l shellCompDirectiveFilterDirs 16
+
+    if test -z "$directive"
+        set directive 0
+    end
+
+    set -l compErr (math (math --scale 0 $directive / $shellCompDirectiveError) % 2)
+    if test $compErr -eq 1
+        __bd_debug "Received error directive: aborting."
+        # Might as well do file completion, in case it helps
+        return 1
+    end
+
+    set -l filefilter (math (math --scale 0 $directive / $shellCompDirectiveFilterFileExt) % 2)
+    set -l dirfilter (math (math --scale 0 $directive / $shellCompDirectiveFilterDirs) % 2)
+    if test $filefilter -eq 1; or test $dirfilter -eq 1
+        __bd_debug "File extension filtering or directory filtering not supported"
+        # Do full file completion instead
+        return 1
+    end
+
+    set -l nospace (math (math --scale 0 $directive / $shellCompDirectiveNoSpace) % 2)
+    set -l nofiles (math (math --scale 0 $directive / $shellCompDirectiveNoFileComp) % 2)
+
+    __bd_debug "nospace: $nospace, nofiles: $nofiles"
+
+    # If we want to prevent a space, or if file completion is NOT disabled,
+    # we need to count the number of valid completions.
+    # To do so, we will filter on prefix as the completions we have received
+    # may not already be filtered so as to allow fish to match on different
+    # criteria than the prefix.
+    if test $nospace -ne 0; or test $nofiles -eq 0
+        set -l prefix (commandline -t | string escape --style=regex)
+        __bd_debug "prefix: $prefix"
+
+        set -l completions (string match -r -- "^$prefix.*" $__bd_comp_results)
+        set --global __bd_comp_results $completions
+        __bd_debug "Filtered completions are: $__bd_comp_results"
+
+        # Important not to quote the variable for count to work
+        set -l numComps (count $__bd_comp_results)
+        __bd_debug "numComps: $numComps"
+
+        if test $numComps -eq 1; and test $nospace -ne 0
+            # We must first split on \t to get rid of the descriptions to be
+            # able to check what the actual completion will be.
+            # We don't need descriptions anyway since there is only a single
+            # real completion which the shell will expand immediately.
+            set -l split (string split --max 1 \t $__bd_comp_results[1])
+
+            # Fish won't add a space if the completion ends with any
+            # of the following characters: @=/:.,
+            set -l lastChar (string sub -s -1 -- $split)
+            if not string match -r -q "[@=/:.,]" -- "$lastChar"
+                # In other cases, to support the "nospace" directive we trick the shell
+                # by outputting an extra, longer completion.
+                __bd_debug "Adding second completion to perform nospace directive"
+                set --global __bd_comp_results $split[1] $split[1].
+                __bd_debug "Completions are now: $__bd_comp_results"
+            end
+        end
+
+        if test $numComps -eq 0; and test $nofiles -eq 0
+            # To be consistent with bash and zsh, we only trigger file
+            # completion when there are no other completions
+            __bd_debug "Requesting file completion"
+            return 1
+        end
+    end
+
+    return 0
+end
+
+# Since Fish completions are only loaded once the user triggers them, we trigger them ourselves
+# so we can properly delete any completions provided by another script.
+# Only do this if the program can be found, or else fish may print some errors; besides,
+# the existing completions will only be loaded if the program can be found.
+if type -q "bd"
+    # The space after the program name is essential to trigger completion for the program
+    # and not completion of the program name itself.
+    # Also, we use '> /dev/null 2>&1' since '&>' is not supported in older versions of fish.
+    complete --do-complete "bd " > /dev/null 2>&1
+end
+
+# Remove any pre-existing completions for the program since we will be handling all of them.
+complete -c bd -e
+
+# this will get called after the two calls below and clear the $__bd_perform_completion_once_result global
+complete -c bd -n '__bd_clear_perform_completion_once_result'
+# LOCAL PATCH (not part of `bd completion fish` output): always use -k so fish
+# preserves bd's natural ordering instead of alphabetizing the candidate list.
+# bd ranks beads with open / recent items first; fish's alphabetical default
+# buries them mid-list (e.g. `gxm` lands after `7e8.*` and before `krm`).
+# Regenerate from `bd completion fish` if bd's protocol changes.
+complete -k -c bd -n '__bd_prepare_completions' -f -a '$__bd_comp_results'


### PR DESCRIPTION
## 🐞 The papercut

`bd show <TAB>` (and every other bd subcommand that takes an issue ID)
alphabetizes the candidate list. The open/recent bead — usually the one
you're trying to pick — lands mid-list:

    ccpulse-114
    ccpulse-7e8
    ccpulse-7e8.1
    ccpulse-7e8.10
    ...
    ccpulse-gxm    ← only OPEN bead, but buried alphabetically
    ccpulse-krm
    ...

## 🔍 Root cause

Cobra's fish-completion scaffold reads bd's `__complete` directive bits.
`KeepOrder` is bit 32. bd emits `4` (NoFileComp only), so the scaffold
takes the non-`-k` branch and fish sorts alphabetically — discarding
bd's own ranking, which already puts open/recent beads first.

## 🩹 Fix

Collapse the two terminal `complete -c bd ...` registrations into one
`-k` form. bd's natural order wins, fish doesn't alphabetize:

```diff
-complete -c bd -n 'not __bd_requires_order_preservation && __bd_prepare_completions' -f -a '$__bd_comp_results'
-complete -k -c bd -n '__bd_requires_order_preservation && __bd_prepare_completions' -f -a '$__bd_comp_results'
+# LOCAL PATCH ... preserve bd's natural ordering instead of alphabetizing.
+complete -k -c bd -n '__bd_prepare_completions' -f -a '$__bd_comp_results'
```

Zero perf overhead. (Toyed with `bd list --status open --json` as a
hard filter, but it's 700–1100ms per `<TAB>` press — not worth it.)

## 📦 Why tracked now

Was untracked because the file is 95% auto-generated by
`bd completion fish`. The local patch invalidates that — without
tracking, the patch is reset on every regen. Marker comment at the
patch site flags the bit to re-apply on bd upgrades.

## 🧪 Test plan

- [x] Patched file passes `fish -c 'source .config/fish/completions/bd.fish'` clean.
- [x] `fish -c 'complete -C "bd show "'` in a ccpulse worktree returns `ccpulse-gxm` first (open bead).
- [x] Other bd completions (subcommands, flags) still work — `bd <TAB>` enumerates `assign`, `children`, etc.
- [ ] Survives next `brew upgrade beads` (will validate when it happens).

## ⬆️ Upstream alternative

beads should emit `ShellCompDirectiveKeepOrder` (bit 32) — a one-line
Go change in the relevant `ValidArgsFunction`. If that lands, this
file can drop back to plain `bd completion fish` output and become
untracked again. Worth a beads issue post-merge.