### PR TITLE
🤫 theme-set: skip tmux repaint when FISH_DOTFILES_TEST is set

### DIFF
--- a/.config/fish/functions/theme-set.fish
+++ b/.config/fish/functions/theme-set.fish
@@ -83,8 +83,13 @@ function theme-set --description 'Switch colour scheme between solarized, mocha,
     set -Ux VIVID_THEME $vivid_theme
 
     # tmux: re-source config + force status redraw (silent if no server).
-    tmux source-file ~/.config/tmux/tmux.conf 2>/dev/null
-    tmux refresh-client -S                    2>/dev/null
+    # Gated on FISH_DOTFILES_TEST so the test harness doesn't repaint the
+    # live status bar on every flip (same intent as the __ghostty_reload
+    # suppression below).
+    if not set -q FISH_DOTFILES_TEST
+        tmux source-file ~/.config/tmux/tmux.conf 2>/dev/null
+        tmux refresh-client -S                    2>/dev/null
+    end
 
     echo "theme → $name"
     echo "  live:    tmux + helpers, starship (next prompt), glow, delta"


### PR DESCRIPTION
## 📝 Summary

- Gate the live tmux re-source + `refresh-client` calls inside `theme-set` on `FISH_DOTFILES_TEST`, so `scripts/test-theme-switch.sh` no longer repaints the active status bar through every theme on each flip.
- Matches the intent of the existing `__ghostty_reload` suppression — same flag, same reason (the test runs from inside a live Ghostty + tmux session).

## 🎯 Why

Running the theme-switch smoke test from a real tmux session flickered the status bar across all 8 themes several times per run, because each `theme-set` call ended with `tmux source-file ~/.config/tmux/tmux.conf` + `tmux refresh-client -S` and the symlinks under `.config/themes/` had just been flipped.

## ✅ Test plan

- [x] `scripts/test-theme-switch.sh` — 52 / 52 pass, status bar stays put during the run.
- [ ] Manual: run `theme-set mocha` interactively (no `FISH_DOTFILES_TEST`) and confirm the tmux status bar still repaints immediately.

## ⚠️ Caveats

- Symlinks under `~/.config/themes/` (and friends) still flip during the test; the test restores them at the end via `run_theme_set "$start_theme"`.
- `BAT_THEME` / `VIVID_THEME` are `set -Ux` so they briefly bounce across all fish shells during the run. Neither side-effect is visible the way the tmux repaint was.