### PR TITLE
🎨 themes: switch Rosé Pine Main + Moon to dark-on-accent chip text

### DIFF
--- a/.config/themes/rose-pine-moon.tmux
+++ b/.config/themes/rose-pine-moon.tmux
@@ -1,6 +1,6 @@
 # Rose Pine Moon palette (rosepinetheme.com) — accessibility-tuned
 # medium-dark variant (2.5 contrast ratio). Structurally identical to
-# rose-pine.tmux: same role keys, same light-on-accent inversion.
+# rose-pine.tmux: same role keys, same dark-on-accent inversion.
 # Moon-specific hex diffs: brighter pine (#3e8fb0 vs Main's #31748f),
 # more terra-cotta rose (#ea9a97 vs Main's #ebbcba), shifted bases.
 
@@ -9,7 +9,7 @@ set -g @color_bar_bg          "#232136"
 set -g @color_deep_bg         "#2a273f"
 set -g @color_default_fg      "#e0def4"
 set -g @color_muted_fg        "#6e6a86"
-set -g @color_light_fg        "#e0def4"
+set -g @color_light_fg        "#232136"
 
 # Accents
 set -g @color_accent_yellow   "#f6c177"
@@ -21,10 +21,10 @@ set -g @color_accent_blue     "#3e8fb0"
 set -g @color_accent_cyan     "#9ccfd8"
 set -g @color_accent_green    "#9ccfd8"
 
-# Derived chip values — light-on-accent inversion; foam/love hexes
+# Derived chip values — dark-on-accent inversion; foam/love hexes
 # read as ins/del markers against the yellow chip.
 set -g @color_chip_main_ins_fg "#9ccfd8"
 set -g @color_chip_main_del_fg "#eb6f92"
-set -g @color_chip_main_neutral_fg "#e0def4"
+set -g @color_chip_main_neutral_fg "#232136"
 set -g @color_chip_wt_ins_fg   "#9ccfd8"
 set -g @color_chip_wt_del_fg   "#eb6f92"

--- a/.config/themes/rose-pine.tmux
+++ b/.config/themes/rose-pine.tmux
@@ -1,11 +1,8 @@
 # Rose Pine Main palette (rosepinetheme.com) — same role keys as
 # solarized.tmux / mocha.tmux / dracula.tmux / gruvbox.tmux /
 # tokyo-night.tmux / nord.tmux, Rose Pine hex.
-# Designed for light-on-accent chip text — diverges from
-# Mocha/Dracula/Gruvbox/Tokyo-Night's dark-on-accent and aligns with
-# Solarized/Nord's light-on-saturated. Reason: pine #31748f
-# (canonical Rose Pine "blue") at L≈37% is too dark for legible
-# dark-on-accent text; light text resolves it.
+# Designed for dark-on-accent chip text — aligns with
+# Mocha/Dracula/Gruvbox/Tokyo-Night pattern.
 # Rose Pine has no canonical green and no canonical orange.
 # accent_green collapses to foam (cyan stand-in); accent_orange and
 # accent_red collapse to love (single canonical pink). The in-palette
@@ -19,9 +16,9 @@ set -g @color_bar_bg          "#191724"
 set -g @color_deep_bg         "#1f1d2e"
 set -g @color_default_fg      "#e0def4"
 set -g @color_muted_fg        "#6e6a86"
-# light_fg is light (#e0def4 = text) — chip-text inversion for Rose
-# Pine's pine-driven session chip. Nord/Solarized pattern.
-set -g @color_light_fg        "#e0def4"
+# light_fg here is dark (#191724 = base) — chip-text inversion: pastel
+# chip bgs read better with dark text. Mocha/Dracula/Gruvbox pattern.
+set -g @color_light_fg        "#191724"
 
 # Accents
 set -g @color_accent_yellow   "#f6c177"
@@ -33,10 +30,10 @@ set -g @color_accent_blue     "#31748f"
 set -g @color_accent_cyan     "#9ccfd8"
 set -g @color_accent_green    "#9ccfd8"
 
-# Derived chip values — light-on-accent inversion; foam/love hexes
+# Derived chip values — dark-on-accent inversion; foam/love hexes
 # read as ins/del markers against the yellow chip.
 set -g @color_chip_main_ins_fg "#9ccfd8"
 set -g @color_chip_main_del_fg "#eb6f92"
-set -g @color_chip_main_neutral_fg "#e0def4"
+set -g @color_chip_main_neutral_fg "#191724"
 set -g @color_chip_wt_ins_fg   "#9ccfd8"
 set -g @color_chip_wt_del_fg   "#eb6f92"


### PR DESCRIPTION
## Summary

- Switch `@color_light_fg` from light text (`#e0def4`) to dark base color (`#191724` Main, `#232136` Moon) so tmux pin foreground renders black on pastel chip backgrounds
- Switch `@color_chip_main_neutral_fg` to match, fixing the white `/` separator between ins/del counts on the git chip
- Aligns both Rosé Pine palettes with the Mocha/Dracula/Gruvbox/Tokyo Night dark-on-accent pattern

## Test plan

- [ ] `theme-set rose-pine` — verify session chip, git chip, PR pin, Claude usage chips all show dark text on accent backgrounds
- [ ] `theme-set rose-pine-moon` — same checks
- [ ] Verify ins/del `/` separator on git chip is dark, not white
- [ ] Other themes unaffected