### PR TITLE
🤫 bd: document stealth-mode posture, drop bd prime hook setup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -618,30 +618,27 @@ Personal multi-theme, multi-font setup for Ghostty + tmux + vim + fish. `theme-s
   (`link_tracked_entries` only touches tracked files).
 - **`bd` is the beads issue tracker** (raw command, no alias). Distributed
   graph issue tracker for AI agents, Dolt-backed. Installed via `Brewfile`
-  (`brew "beads"`); the global Claude Code `SessionStart` + `PreCompact`
-  hooks in `~/.claude/settings.json` are a one-time manual step run after
-  first `brew bundle` via `bd setup claude --global` (see README
-  "Manual extras"). Deliberately not automated from `bootstrap.sh` — that
-  file does not write to `~/.claude/`. `bd prime` injects 1–2k tokens of
-  workflow context at session start (and again on context compaction) and
-  no-ops in projects without a `.beads/` directory, so the global hooks
-  are safe in every session. **Quirks of `bd setup claude --global` in
-  this repo:** (1) when CLAUDE.md is present in cwd, `bd setup` also
-  appends a "BEADS INTEGRATION v:1" section to it on every run —
-  reverted here because it preempts policy decisions still deferred (see
-  below) and contradicts existing conventions (TodoWrite/TaskCreate use,
-  MEMORY.md, PR-based workflow); (2) `bd setup claude --global --check`
-  therefore exits 1 with a "CLAUDE.md exists but no beads section found"
-  warning, even though the hooks side is correctly installed — ignore the
-  warning until the policy decision lands. **Don't run `bd init` here
-  yet** (or anywhere) — three policy decisions are deferred to follow-up
-  issues opened against #244: #246 (memory-layer niche — bd vs
-  episodic-memory MCP, per-project MEMORY.md auto-memory, and
-  `.superpowers/` specs+plans), #247 (AGENTS.md vs CLAUDE.md handling on
-  first `bd init` — bd writes AGENTS.md by default, and `bd setup`
-  clobbers CLAUDE.md on every run, see quirks above), #248 (`.beads/`
-  gitignore stance — bd's design intent is committed, for Dolt team sync;
-  we have not committed yet). Pin those before any `bd init`.
+  (`brew "beads"`). This repo is initialised in **stealth mode**
+  (`bd init --stealth`): `.beads/` and `.claude/settings.local.json` are
+  added to `.git/info/exclude` — local-only state, never tracked or
+  committed, invisible to collaborators. `.beads/config.yaml` carries
+  `no-git-ops: true`. The embedded Dolt DB name (`bd_198_nord` here) is
+  auto-derived from the branch active at init time and is just a local
+  label. Re-init **only** via `bd init --stealth`; a non-stealth re-init
+  would expose `.beads/` to git and contradict the stealth posture.
+  **Don't use bd's memory layer** — no `bd remember`, no `bd memories`,
+  no `bd forget`. Memory lives in
+  `~/.claude/projects/-Users-martinciu-code-dotfiles/memory/` (indexed
+  by `MEMORY.md`); that's the only memory system to read or write here.
+  **Don't install the `bd prime` SessionStart / PreCompact hooks** that
+  `bd setup claude --global` wires up. `bd prime` injects ~1–2k tokens
+  of context per session (mandatory beads-for-all-task-tracking,
+  "🚨 SESSION CLOSE PROTOCOL 🚨", a ban on TodoWrite/TaskCreate, etc.)
+  that contradicts this repo's actual conventions (TodoWrite/TaskCreate
+  task tracking, auto-memory, PR-based workflow). If a prior install
+  left those hooks in `~/.claude/settings.json`, remove them. The
+  `bd setup claude --global` step is **not** part of fresh-machine setup
+  — strike it from the README's "Manual extras" if still present.
 - **`diff` aliased to `difft`** (guarded). For ad-hoc, non-git
   comparisons. Git diffs unaffected (still `delta`); `vimdiff`
   unaffected (separate alias). Escape: `command diff`, `\diff`,

--- a/README.md
+++ b/README.md
@@ -71,26 +71,7 @@ git config --global delta.line-numbers true
 git config --global include.path "~/.config/themes/delta-current.gitconfig"
 ```
 
-**4. beads — wire global Claude Code hook.** `brew bundle` installs `bd`,
-but the global `SessionStart` + `PreCompact` hooks into
-`~/.claude/settings.json` are a one-time manual step (deliberately not
-automated from `bootstrap.sh` — that file does not write to
-`~/.claude/`):
-
-```sh
-# One-time: install the global SessionStart + PreCompact hooks that run `bd prime`
-bd setup claude --global
-
-# Verify (hooks side; CLAUDE.md warning is expected — see project CLAUDE.md note)
-bd setup claude --global --check
-```
-
-`bd prime` no-ops in projects without a `.beads/` directory, so these hooks
-are safe in every session. `bd init` is **not** part of fresh-machine
-setup — running it is a per-project decision, currently gated on the
-follow-up issues opened against #244.
-
-**5. `atuin import fish`** — one-time backfill of existing fish history
+**4. `atuin import fish`** — one-time backfill of existing fish history
 into the atuin sqlite store. Run after `brew bundle` (which installs
 atuin) and after `bootstrap.sh` (which symlinks `~/.config/atuin/`):
 


### PR DESCRIPTION
## 📝 Summary

- 🥷 Rewrite the **bd bullet in `CLAUDE.md`** to reflect current state: `bd init --stealth` has been run; `.beads/` + `.claude/settings.local.json` live in `.git/info/exclude` (never tracked, never committed); `.beads/config.yaml` has `no-git-ops: true`. **Don't** use `bd memories` — auto-memory under `~/.claude/projects/.../memory/` is the only memory layer. **Don't** install the `bd prime` SessionStart / PreCompact hooks; their injected workflow (beads-for-all-task-tracking, SESSION CLOSE PROTOCOL, ban on TodoWrite/TaskCreate) contradicts this repo's actual conventions.
- 🗑️ Drop the obsolete #244 / #246 / #247 / #248 deferral paragraph from `CLAUDE.md` — all three policy questions are answered by stealth-init + no-memories + no-prime-hook.
- 📖 Remove `README.md` "Manual extras" item #4 (`bd setup claude --global`); renumber `atuin import fish` from #5 → #4.

## ✅ Test plan

- [ ] 📄 Docs-only diff — no scripts, configs, or symlinks touched.
- [ ] 🔍 \`grep -nE 'bd setup|bd prime|bd init|beads' README.md\` returns empty.
- [ ] 🔍 \`grep -n '#244\\|#246\\|#247\\|#248' CLAUDE.md\` returns empty.
- [ ] 🧪 \`scripts/test-helpers.sh\` still passes (sanity).