### PR TITLE
✨ ccstatusline: thinking-effort chip + git cache TTL

### DIFF
--- a/.config/ccstatusline/settings.json
+++ b/.config/ccstatusline/settings.json
@@ -8,6 +8,11 @@
         "backgroundColor": "bgBrightMagenta"
       },
       {
+        "id": "4830ad63-ce5a-4842-a2b5-52b6d664515d",
+        "type": "thinking-effort",
+        "backgroundColor": "bgBrightBlue"
+      },
+      {
         "id": "a83ffe56-6074-4e7d-826b-e4f89c4904f7",
         "type": "context-percentage",
         "backgroundColor": "bgBrightWhite"
@@ -30,6 +35,7 @@
   "defaultPadding": " ",
   "inheritSeparatorColors": false,
   "globalBold": false,
+  "gitCacheTtlSeconds": 5,
   "minimalistMode": true,
   "powerline": {
     "enabled": true,


### PR DESCRIPTION
## ✨ Summary

- Add a `thinking-effort` widget to the ccstatusline, rendered as a bright-blue (`bgBrightBlue`) chip between the model and context-percentage chips.
- Set `gitCacheTtlSeconds: 5` so git status lookups are cached for 5s instead of re-shelling on every status-line repaint.

## 🧪 Test plan

- [ ] Reload Claude Code and confirm the thinking-effort chip renders between the model and context chips.
- [ ] Confirm git status info still updates within ~5s.