### PR TITLE
🔁 sandbox: add reup verb to recreate container with new flags

### DIFF
--- a/.config/fish/completions/sandbox.fish
+++ b/.config/fish/completions/sandbox.fish
@@ -17,11 +17,12 @@ complete -c sandbox -n __sandbox_needs_command -f -a ls -d 'List sandboxes'
 complete -c sandbox -n __sandbox_needs_command -f -a stop -d 'Stop a sandbox (keep volume)'
 complete -c sandbox -n __sandbox_needs_command -f -a rm -d 'Remove a sandbox + volume'
 complete -c sandbox -n __sandbox_needs_command -f -a machine -d 'OrbStack machine (trusted only)'
+complete -c sandbox -n __sandbox_needs_command -f -a reup -d 'Recreate a container with new flags (keep volume)'
 # Existing sandbox names are also valid first args (reattach).
 complete -c sandbox -n __sandbox_needs_command -f -a '(__sandbox_names)' -d 'sandbox'
 
-# Name args for stop/rm.
-complete -c sandbox -n '__fish_seen_subcommand_from stop rm' -f -a '(__sandbox_names)'
+# Name args for stop/rm/reup.
+complete -c sandbox -n '__fish_seen_subcommand_from stop rm reup' -f -a '(__sandbox_names)'
 
 # machine subcommands.
 complete -c sandbox -n '__fish_seen_subcommand_from machine' -f -a 'create ssh rm'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -696,6 +696,10 @@ Personal multi-theme, multi-font setup for Ghostty + tmux + vim + fish. `theme-s
   Two modes: **container** (no host mounts — safe for untrusted code;
   named volume holds state; image rebuilds on a content-hash mismatch) and
   **machine** (OrbStack VM mounts the Mac home — **trusted code only**).
+  `sandbox reup <name> [flags]` recreates a sandbox's container with new
+  run-time flags (`-p`/`--mount`/`-e`/etc.) while preserving its `/home/dev`
+  volume; the bare `sandbox <name>` path warns (pointing at `reup`) when
+  creation-time flags hit an already-existing container.
   Secrets are never baked in (templates seed empty files inside; inject at
   runtime via `--env-file`/`-e`). Build requires `GITHUB_TOKEN` (aqua/github
   backends hit the GitHub releases API). Out of scope: tmux, sesh, s, gh,

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ sandbox build           # (re)build the image
 sandbox ls              # list all sandboxes
 sandbox stop <name>     # stop (keep volume/state)
 sandbox rm <name>       # remove container + volume
+sandbox reup <name>     # recreate container with new flags (keep volume/state)
 sandbox machine create <name>   # OrbStack machine — Mac home mounted
 sandbox machine ssh <name>      # SSH into machine (fish shell)
 sandbox machine ls              # list OrbStack machines
@@ -181,9 +182,9 @@ sandbox machine rm <name>       # delete machine
 ```
 
 Container names round-trip: `sandbox ls` shows the bare `<name>`, which is what
-`stop`/`rm`/reattach take (a pasted `sandbox-<name>` is accepted too).
+`stop`/`rm`/`reup` take (a pasted `sandbox-<name>` is accepted too).
 
-**Flags** (for `sandbox <name>`):
+**Flags** (for `sandbox <name>` and `sandbox reup <name>`):
 
 ```
 --rm               ephemeral throwaway (no named volume)
@@ -194,6 +195,13 @@ Container names round-trip: `sandbox ls` shows the bare `<name>`, which is what
 --memory V         memory limit (default 2g)
 --cpus V           CPU limit (default 2)
 ```
+
+Flags only take effect when a container is **created**. To change them on an
+existing sandbox without losing `/home/dev` state, use `sandbox reup <name>
+<flags>` — it `docker rm -f`s the container only, then recreates it re-attached
+to the same volume. Passing flags to a bare `sandbox <name>` whose container
+already exists prints a warning pointing you at `reup` (the flags are otherwise
+silently ignored).
 
 **Multi-shell:** open N Mac-tmux panes and run `sandbox <name>` in each —
 they all `docker exec` into the same persistent container.

--- a/bin/sandbox
+++ b/bin/sandbox
@@ -4,7 +4,8 @@
 # .superpowers/specs/2026-05-21-containerized-sandbox.md for design rationale.
 set -euo pipefail
 
-IMAGE="sandbox:latest"
+# Default image; overridable (e.g. tests pin a throwaway tag, power users pin a build).
+IMAGE="${SANDBOX_IMAGE:-sandbox:latest}"
 
 # Resolve the repo root by following this script's symlink (~/.local/bin/sandbox
 # -> repo/bin/sandbox), so the build context is the repo that owns this script.
@@ -85,6 +86,24 @@ assemble_run_args() {
   local kv; for kv in "${EXTRA_ENV[@]}"; do RUN_ARGS+=(-e "$kv"); done
 }
 
+# Create the persistent container with the assembled RUN_ARGS and the named
+# state volume. Shared by cmd_run (first create) and cmd_reup (recreate).
+create_container() {
+  local cname="$1" name="$2"
+  docker run -d --name "$cname" --label sandbox=1 \
+    "${RUN_ARGS[@]}" -v "sandbox-${name}:/home/dev" "$IMAGE" >/dev/null
+}
+
+# Drop into fish inside the container, or run a one-shot command, then exec
+# (replaces this process) — always the last thing a run/reup does.
+exec_into() {
+  local cname="$1"; shift
+  if [ "$#" -gt 0 ]; then
+    exec docker exec -it "$cname" fish -c "$*"
+  fi
+  exec docker exec -it "$cname" fish
+}
+
 cmd_run() {
   local name="$1"; shift || true
   [ -n "$name" ] || usage
@@ -99,15 +118,11 @@ cmd_run() {
   fi
   local cname="sandbox-$name"
   if ! docker container inspect "$cname" >/dev/null 2>&1; then
-    docker run -d --name "$cname" --label sandbox=1 \
-      "${RUN_ARGS[@]}" -v "sandbox-${name}:/home/dev" "$IMAGE" >/dev/null
+    create_container "$cname" "$name"
   elif [ -z "$(docker ps -q -f "name=^${cname}$")" ]; then
     docker start "$cname" >/dev/null
   fi
-  if [ "$#" -gt 0 ]; then
-    exec docker exec -it "$cname" fish -c "$*"
-  fi
-  exec docker exec -it "$cname" fish
+  exec_into "$cname" "$@"
 }
 
 cmd_build() { build_image; }

--- a/bin/sandbox
+++ b/bin/sandbox
@@ -29,6 +29,7 @@ usage() {
   cat <<'EOF' >&2
 Usage:
   sandbox <name> [cmd...]        create/reattach a named sandbox, drop into fish (or run cmd)
+  sandbox reup <name> [flags]    recreate the container with new flags (keeps volume/state)
   sandbox build                  (re)build the image
   sandbox ls                     list sandboxes
   sandbox stop <name>            stop a sandbox (keeps its volume/state)
@@ -122,6 +123,26 @@ cmd_run() {
   elif [ -z "$(docker ps -q -f "name=^${cname}$")" ]; then
     docker start "$cname" >/dev/null
   fi
+  exec_into "$cname" "$@"
+}
+
+
+# Recreate an existing sandbox's container with new run-time flags, keeping its
+# /home/dev volume. Requires a live (running or stopped) container — the volume
+# alone is not enough. See .superpowers/specs/2026-05-22-sandbox-reup.md.
+cmd_reup() {
+  local name="$1"; shift || true
+  [ -n "$name" ] || usage
+  name="${name#sandbox-}"
+  [ "$EPHEMERAL" -eq 0 ] || die "reup does not support --rm"
+  local cname="sandbox-$name"
+  docker container inspect "$cname" >/dev/null 2>&1 \
+    || die "no such sandbox '$name' (try: sandbox ls)"
+  ensure_image
+  assemble_run_args
+  echo "sandbox: recreating container $cname (volume preserved)" >&2
+  docker rm -f "$cname" >/dev/null
+  create_container "$cname" "$name"
   exec_into "$cname" "$@"
 }
 
@@ -220,12 +241,14 @@ cmd_machine() {
 
 # --- arg parsing -------------------------------------------------------------
 [ "$#" -ge 1 ] || usage
+MODE=run
 case "$1" in
   build) cmd_build; exit 0 ;;
   ls)    cmd_ls; exit 0 ;;
   stop)  shift; cmd_stop "${1:-}"; exit 0 ;;
   rm)    shift; cmd_rm "${1:-}"; exit 0 ;;
   machine) shift; cmd_machine "$@"; exit 0 ;;
+  reup)  MODE=reup; shift ;;   # fall through to the parser, then cmd_reup
   -h|--help) usage ;;
 esac
 
@@ -248,4 +271,8 @@ while [ "$#" -gt 0 ]; do
     *) if [ -z "$NAME" ]; then NAME="$1"; else REST+=("$1"); fi; shift ;;
   esac
 done
-cmd_run "$NAME" "${REST[@]}"
+if [ "$MODE" = reup ]; then
+  cmd_reup "$NAME" "${REST[@]}"
+else
+  cmd_run "$NAME" "${REST[@]}"
+fi

--- a/bin/sandbox
+++ b/bin/sandbox
@@ -38,7 +38,7 @@ Usage:
   sandbox machine <create|ssh|rm> <name>   OrbStack machine (TRUSTED CODE ONLY)
   sandbox machine ls                       list OrbStack machines
 
-Flags (for `sandbox <name>`):
+Flags (for `sandbox <name>` and `sandbox reup <name>`):
   --rm                 ephemeral throwaway (no named volume)
   -p PORT              publish PORT to 127.0.0.1 only (LAN off)
   --mount DIR          bind-mount ONE dir at /home/dev/mnt
@@ -125,7 +125,7 @@ cmd_run() {
     # Container already exists: -p/--mount/-e/etc. are baked in at creation and
     # cannot be applied now. Point the user at reup instead of silently dropping.
     if [ "${#FLAGS_PASSED[@]}" -gt 0 ]; then
-      echo "sandbox: flags ignored (container exists): ${FLAGS_PASSED[*]} — run: sandbox reup $name ${FLAGS_PASSED[*]}" >&2
+      echo "sandbox: flags ignored (container exists): ${FLAGS_PASSED[*]} — run: sandbox reup $name ${FLAGS_PASSED[*]@Q}" >&2
     fi
     if [ -z "$(docker ps -q -f "name=^${cname}$")" ]; then
       docker start "$cname" >/dev/null
@@ -133,7 +133,6 @@ cmd_run() {
   fi
   exec_into "$cname" "$@"
 }
-
 
 # Recreate an existing sandbox's container with new run-time flags, keeping its
 # /home/dev volume. Requires a live (running or stopped) container — the volume

--- a/bin/sandbox
+++ b/bin/sandbox
@@ -217,6 +217,7 @@ cmd_machine() {
       # mise walks up and merges the Mac's global ~/.config/mise/config.toml over
       # the home mount, pulling in non-sandbox tools (ruby, npm:*). Running from
       # the machine home keeps mise to the copied sandbox config only.
+      # shellcheck disable=SC2016  # intentional: single-quotes inside are verbatim orb bash literal
       orb -m "$name" bash -lc '
         export GITHUB_TOKEN="'"${GITHUB_TOKEN:-}"'"
         cd "$HOME"

--- a/bin/sandbox
+++ b/bin/sandbox
@@ -22,6 +22,7 @@ DOTFILES="$(cd "$SCRIPT_DIR/.." && pwd)"
 MEMORY="2g"; CPUS="2"; PIDS="512"
 PORT=""; MOUNT_DIR=""; ENV_FILE=""; EPHEMERAL=0
 declare -a EXTRA_ENV=()
+declare -a FLAGS_PASSED=()   # creation-time flags as typed, for the "use reup" hint
 
 die() { echo "sandbox: $*" >&2; exit 1; }
 
@@ -120,8 +121,15 @@ cmd_run() {
   local cname="sandbox-$name"
   if ! docker container inspect "$cname" >/dev/null 2>&1; then
     create_container "$cname" "$name"
-  elif [ -z "$(docker ps -q -f "name=^${cname}$")" ]; then
-    docker start "$cname" >/dev/null
+  else
+    # Container already exists: -p/--mount/-e/etc. are baked in at creation and
+    # cannot be applied now. Point the user at reup instead of silently dropping.
+    if [ "${#FLAGS_PASSED[@]}" -gt 0 ]; then
+      echo "sandbox: flags ignored (container exists): ${FLAGS_PASSED[*]} — run: sandbox reup $name ${FLAGS_PASSED[*]}" >&2
+    fi
+    if [ -z "$(docker ps -q -f "name=^${cname}$")" ]; then
+      docker start "$cname" >/dev/null
+    fi
   fi
   exec_into "$cname" "$@"
 }
@@ -257,12 +265,12 @@ declare -a REST=()
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --rm) EPHEMERAL=1; shift ;;
-    -p) PORT="${2:?-p needs a PORT}"; shift 2 ;;
-    --mount) MOUNT_DIR="${2:?--mount needs a DIR}"; shift 2 ;;
-    --env-file) ENV_FILE="${2:?--env-file needs a FILE}"; shift 2 ;;
-    -e) EXTRA_ENV+=("${2:?-e needs KEY=VAL}"); shift 2 ;;
-    --memory) MEMORY="${2:?}"; shift 2 ;;
-    --cpus) CPUS="${2:?}"; shift 2 ;;
+    -p) PORT="${2:?-p needs a PORT}"; FLAGS_PASSED+=(-p "$2"); shift 2 ;;
+    --mount) MOUNT_DIR="${2:?--mount needs a DIR}"; FLAGS_PASSED+=(--mount "$2"); shift 2 ;;
+    --env-file) ENV_FILE="${2:?--env-file needs a FILE}"; FLAGS_PASSED+=(--env-file "$2"); shift 2 ;;
+    -e) EXTRA_ENV+=("${2:?-e needs KEY=VAL}"); FLAGS_PASSED+=(-e "$2"); shift 2 ;;
+    --memory) MEMORY="${2:?}"; FLAGS_PASSED+=(--memory "$2"); shift 2 ;;
+    --cpus) CPUS="${2:?}"; FLAGS_PASSED+=(--cpus "$2"); shift 2 ;;
     --) shift; REST+=("$@"); break ;;
     -*)
       # Once NAME is set, trailing flags/args are the command — pass them through.

--- a/scripts/test-sandbox.sh
+++ b/scripts/test-sandbox.sh
@@ -19,10 +19,9 @@ pass "fish parse"
 
 command -v docker >/dev/null 2>&1 || { echo "⏭️  docker absent — skipping build/runtime asserts"; exit 0; }
 
-# 3. Build.
-local_args=()
-[ -n "${GITHUB_TOKEN:-}" ] && local_args=(--secret "id=github_token,env=GITHUB_TOKEN")
-docker build -f sandbox/Dockerfile "${local_args[@]}" -t sandbox:test . >/dev/null || fail "build"
+# 3. Build via the wrapper so the image carries the sandbox.srchash label —
+# the reup/run wrapper tests below then reuse it without ensure_image rebuilding.
+SANDBOX_IMAGE=sandbox:test bin/sandbox build >/dev/null || fail "build"
 pass "image build"
 
 # 4. fish + tools present.
@@ -42,5 +41,31 @@ trap 'docker rm -f "$cid" >/dev/null 2>&1 || true; docker volume rm sandbox-self
 binds="$(docker inspect "$cid" --format '{{range .Mounts}}{{.Type}} {{end}}')"
 [[ "$binds" != *bind* ]] || fail "unexpected host bind-mount: $binds"
 pass "no host bind-mount by default"
+
+# 7. reup: recreate the container with new flags, keeping the /home/dev volume.
+rname="reuptest"; rcont="sandbox-$rname"; rport=58080
+# Combined cleanup: also clears the step-6 isolation resources ($cid, sandbox-selftest).
+trap 'docker rm -f "$cid" "$rcont" >/dev/null 2>&1 || true; docker volume rm sandbox-selftest "$rcont" >/dev/null 2>&1 || true' EXIT
+docker rm -f "$rcont" >/dev/null 2>&1 || true
+docker volume rm "$rcont" >/dev/null 2>&1 || true
+docker run -d --name "$rcont" --label sandbox=1 -v "${rcont}:/home/dev" sandbox:test >/dev/null
+docker exec "$rcont" sh -c 'echo survived > /home/dev/sentinel'
+SANDBOX_IMAGE=sandbox:test bin/sandbox reup "$rname" -p "$rport" true >/dev/null 2>&1 || true
+got="$(docker exec "$rcont" cat /home/dev/sentinel 2>/dev/null || true)"
+[[ "$got" == survived ]] || fail "reup lost /home/dev state: '$got'"
+pass "reup keeps volume state"
+binds="$(docker inspect "$rcont" --format '{{json .HostConfig.PortBindings}}' 2>/dev/null || true)"
+[[ "$binds" == *127.0.0.1* && "$binds" == *"$rport"* ]] || fail "reup did not publish port: $binds"
+pass "reup applies new -p flag"
+
+# 8. reup on a nonexistent sandbox errors clearly with a non-zero exit.
+rc=0; out="$(bin/sandbox reup "nope-$$" 2>&1)" || rc=$?
+[[ "$rc" -ne 0 && "$out" == *"no such sandbox"* ]] || fail "reup nonexistent: rc=$rc out=$out"
+pass "reup nonexistent errors"
+
+# 9. Bare `sandbox <name>` warns when creation-time flags hit an existing container.
+out="$(SANDBOX_IMAGE=sandbox:test bin/sandbox "$rname" -p "$rport" true 2>&1 || true)"
+[[ "$out" == *"flags ignored"* && "$out" == *"sandbox reup"* ]] || fail "missing ignored-flags warning: $out"
+pass "ignored-flags warning"
 
 echo "✅ all sandbox smoke checks passed"


### PR DESCRIPTION
## Summary

- ♻️ Refactored `cmd_run` to extract `create_container` / `exec_into` helpers, shared by both the existing run path and the new `reup` verb; added `SANDBOX_IMAGE` env override so tests can pin a throwaway tag
- 🔁 Added `sandbox reup <name> [flags]` — requires a live container, emits a notice, `docker rm -f`s the container only, then recreates it re-attached to the same `/home/dev` volume with the new flags applied
- ⚠️ Added `FLAGS_PASSED` tracking so `sandbox <name>` warns users when creation-time flags hit an already-existing container, pointing them at `reup` instead of silently dropping the flags
- 🐟 Extended fish completions: `reup` verb at top level + existing sandbox names after `reup`
- 🧪 Extended smoke test: `reup keeps volume state`, `reup applies new -p flag`, `reup nonexistent errors`, `ignored-flags warning` (all four new checks pass); build step now uses the wrapper so the `sandbox.srchash` label is present
- 📝 Updated README lifecycle verbs, round-trip names note, flags heading + paragraph; updated CLAUDE.md sandbox bullet

Closes #271

## 🧪 Test Plan

- [x] `shellcheck bin/sandbox sandbox/install-linux.sh scripts/test-sandbox.sh` — clean
- [x] `fish -n .config/fish/completions/sandbox.fish` — exit 0
- [x] `scripts/test-sandbox.sh` — all ✅ including the four new reup/warning checks