### PR TITLE
🛡️ sandbox: explicit create verb; bare attach errors on absent name

### DIFF
--- a/.config/fish/completions/sandbox.fish
+++ b/.config/fish/completions/sandbox.fish
@@ -18,11 +18,13 @@ complete -c sandbox -n __sandbox_needs_command -f -a stop -d 'Stop a sandbox (ke
 complete -c sandbox -n __sandbox_needs_command -f -a rm -d 'Remove a sandbox + volume'
 complete -c sandbox -n __sandbox_needs_command -f -a machine -d 'OrbStack machine (trusted only)'
 complete -c sandbox -n __sandbox_needs_command -f -a reup -d 'Recreate a container with new flags (keep volume)'
+complete -c sandbox -n __sandbox_needs_command -f -a create -d 'Provision a new sandbox'
+complete -c sandbox -n __sandbox_needs_command -f -a help -d 'Show help'
 # Existing sandbox names are also valid first args (reattach).
 complete -c sandbox -n __sandbox_needs_command -f -a '(__sandbox_names)' -d 'sandbox'
 
-# Name args for stop/rm/reup.
-complete -c sandbox -n '__fish_seen_subcommand_from stop rm reup' -f -a '(__sandbox_names)'
+# Name args for stop/rm/reup/create.
+complete -c sandbox -n '__fish_seen_subcommand_from stop rm reup create' -f -a '(__sandbox_names)'
 
 # machine subcommands.
 complete -c sandbox -n '__fish_seen_subcommand_from machine' -f -a 'create ssh rm'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -700,6 +700,12 @@ Personal multi-theme, multi-font setup for Ghostty + tmux + vim + fish. `theme-s
   run-time flags (`-p`/`--mount`/`-e`/etc.) while preserving its `/home/dev`
   volume; the bare `sandbox <name>` path warns (pointing at `reup`) when
   creation-time flags hit an already-existing container.
+  `sandbox create <name>` is the only path that provisions a sandbox; bare
+  `sandbox <name>` only **attaches** to an existing one and errors (creating
+  nothing) when it doesn't exist, so subcommand typos (`sandbox help`,
+  `sandbox lst`) can't leak junk containers. `create` is create-**or**-attach
+  (a subcommand-colliding name like `create build` is reachable only via
+  `create` re-run). `help` is a real subcommand (exits 0).
   Secrets are never baked in (templates seed empty files inside; inject at
   runtime via `--env-file`/`-e`). Build requires `GITHUB_TOKEN` (aqua/github
   backends hit the GitHub releases API). Out of scope: tmux, sesh, s, gh,

--- a/bin/sandbox
+++ b/bin/sandbox
@@ -20,7 +20,7 @@ DOTFILES="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # Defaults (overridable by flags).
 MEMORY="2g"; CPUS="2"; PIDS="512"
-PORT=""; MOUNT_DIR=""; ENV_FILE=""; EPHEMERAL=0
+PORT=""; MOUNT_DIR=""; ENV_FILE=""; EPHEMERAL=0; ALLOW_CREATE=0
 declare -a EXTRA_ENV=()
 declare -a FLAGS_PASSED=()   # creation-time flags as typed, for the "use reup" hint
 
@@ -29,7 +29,8 @@ die() { echo "sandbox: $*" >&2; exit 1; }
 usage() {
   cat <<'EOF' >&2
 Usage:
-  sandbox <name> [cmd...]        create/reattach a named sandbox, drop into fish (or run cmd)
+  sandbox create <name> [cmd...] provision a new named sandbox, drop into fish (or run cmd)
+  sandbox <name> [cmd...]        attach to an existing sandbox (errors if it doesn't exist)
   sandbox reup <name> [flags]    recreate the container with new flags (keeps volume/state)
   sandbox build                  (re)build the image
   sandbox ls                     list sandboxes
@@ -37,6 +38,7 @@ Usage:
   sandbox rm <name>              remove a sandbox AND its volume
   sandbox machine <create|ssh|rm> <name>   OrbStack machine (TRUSTED CODE ONLY)
   sandbox machine ls                       list OrbStack machines
+  sandbox help                   show this help
 
 Flags (for `sandbox <name>` and `sandbox reup <name>`):
   --rm                 ephemeral throwaway (no named volume)
@@ -46,7 +48,7 @@ Flags (for `sandbox <name>` and `sandbox reup <name>`):
   -e KEY=VAL           pass a single env var (repeatable)
   --memory V --cpus V  resource limits (default 2g / 2)
 EOF
-  exit 1
+  exit "${1:-1}"
 }
 
 command -v docker >/dev/null 2>&1 || die "docker not found (is OrbStack installed/running?)"
@@ -110,16 +112,30 @@ cmd_run() {
   local name="$1"; shift || true
   [ -n "$name" ] || usage
   name="${name#sandbox-}"   # tolerate the docker name shown by `sandbox ls`
+
+  # Resolve existence first, before any image build, so a typo'd name never
+  # triggers a multi-minute rebuild just to error. The ephemeral path has no
+  # named container and is exempt from the create gate.
+  local cname="" exists=0
+  if [ "$EPHEMERAL" -eq 0 ]; then
+    cname="sandbox-$name"
+    docker container inspect "$cname" >/dev/null 2>&1 && exists=1
+    if [ "$exists" -eq 0 ] && [ "$ALLOW_CREATE" -eq 0 ]; then
+      die "no such sandbox '$name' — run 'sandbox create $name' to make it, or 'sandbox --help' for commands"
+    fi
+  fi
+
   ensure_image
   assemble_run_args
+
   if [ "$EPHEMERAL" -eq 1 ]; then
     if [ "$#" -gt 0 ]; then
       exec docker run -it --rm "${RUN_ARGS[@]}" "$IMAGE" fish -c "$*"
     fi
     exec docker run -it --rm "${RUN_ARGS[@]}" "$IMAGE" fish
   fi
-  local cname="sandbox-$name"
-  if ! docker container inspect "$cname" >/dev/null 2>&1; then
+
+  if [ "$exists" -eq 0 ]; then
     create_container "$cname" "$name"
   else
     # Container already exists: -p/--mount/-e/etc. are baked in at creation and
@@ -257,7 +273,8 @@ case "$1" in
   rm)    shift; cmd_rm "${1:-}"; exit 0 ;;
   machine) shift; cmd_machine "$@"; exit 0 ;;
   reup)  MODE=reup; shift ;;   # fall through to the parser, then cmd_reup
-  -h|--help) usage ;;
+  create) ALLOW_CREATE=1; shift ;;   # explicit create-or-attach; fall through to the parser
+  help|-h|--help) usage 0 ;;
 esac
 
 NAME=""

--- a/scripts/test-sandbox.sh
+++ b/scripts/test-sandbox.sh
@@ -69,12 +69,14 @@ out="$(SANDBOX_IMAGE=sandbox:test bin/sandbox "$rname" -p "$rport" true 2>&1 || 
 pass "ignored-flags warning"
 
 # 10. help is a real subcommand: prints usage, exits 0, creates nothing.
+docker rm -f sandbox-help >/dev/null 2>&1 || true   # remove any leftover from a prior run
 rc=0; out="$(SANDBOX_IMAGE=sandbox:test bin/sandbox help 2>&1)" || rc=$?
 [[ "$rc" -eq 0 && "$out" == *Usage* ]] || fail "help: rc=$rc out=$out"
 docker container inspect sandbox-help >/dev/null 2>&1 && fail "help created a container"
 pass "help prints usage, creates nothing"
 
 # 11. A bogus subcommand errors non-zero and creates nothing.
+docker rm -f sandbox-lst >/dev/null 2>&1 || true   # remove any leftover from a prior run
 rc=0; out="$(SANDBOX_IMAGE=sandbox:test bin/sandbox lst 2>&1)" || rc=$?
 [[ "$rc" -ne 0 && "$out" == *"no such sandbox"* ]] || fail "bogus token: rc=$rc out=$out"
 docker container inspect sandbox-lst >/dev/null 2>&1 && fail "bogus token created a container"

--- a/scripts/test-sandbox.sh
+++ b/scripts/test-sandbox.sh
@@ -68,4 +68,33 @@ out="$(SANDBOX_IMAGE=sandbox:test bin/sandbox "$rname" -p "$rport" true 2>&1 || 
 [[ "$out" == *"flags ignored"* && "$out" == *"sandbox reup"* ]] || fail "missing ignored-flags warning: $out"
 pass "ignored-flags warning"
 
+# 10. help is a real subcommand: prints usage, exits 0, creates nothing.
+rc=0; out="$(SANDBOX_IMAGE=sandbox:test bin/sandbox help 2>&1)" || rc=$?
+[[ "$rc" -eq 0 && "$out" == *Usage* ]] || fail "help: rc=$rc out=$out"
+docker container inspect sandbox-help >/dev/null 2>&1 && fail "help created a container"
+pass "help prints usage, creates nothing"
+
+# 11. A bogus subcommand errors non-zero and creates nothing.
+rc=0; out="$(SANDBOX_IMAGE=sandbox:test bin/sandbox lst 2>&1)" || rc=$?
+[[ "$rc" -ne 0 && "$out" == *"no such sandbox"* ]] || fail "bogus token: rc=$rc out=$out"
+docker container inspect sandbox-lst >/dev/null 2>&1 && fail "bogus token created a container"
+pass "bogus subcommand errors, creates nothing"
+
+# 12. create provisions; bare attach re-enters; bare on an absent name errors + creates nothing.
+ctname="createtest"; ctcont="sandbox-$ctname"
+# Extend cleanup to also clear the create-test container + volume (keeps step 6/7 resources too).
+trap 'docker rm -f "$cid" "$rcont" "$ctcont" >/dev/null 2>&1 || true; docker volume rm sandbox-selftest "$rcont" "$ctcont" >/dev/null 2>&1 || true' EXIT
+docker rm -f "$ctcont" >/dev/null 2>&1 || true
+docker volume rm "$ctcont" >/dev/null 2>&1 || true
+SANDBOX_IMAGE=sandbox:test bin/sandbox create "$ctname" true >/dev/null 2>&1 || true
+docker container inspect "$ctcont" >/dev/null 2>&1 || fail "create did not provision $ctcont"
+pass "create provisions a sandbox"
+out="$(SANDBOX_IMAGE=sandbox:test bin/sandbox "$ctname" true 2>&1 || true)"
+[[ "$out" != *"no such sandbox"* ]] || fail "bare attach errored on existing: $out"
+pass "bare attach re-enters existing sandbox"
+rc=0; out="$(SANDBOX_IMAGE=sandbox:test bin/sandbox "nope-$$" 2>&1)" || rc=$?
+[[ "$rc" -ne 0 && "$out" == *"no such sandbox"* ]] || fail "bare absent: rc=$rc out=$out"
+docker container inspect "sandbox-nope-$$" >/dev/null 2>&1 && fail "bare absent created a container"
+pass "bare attach on absent errors, creates nothing"
+
 echo "✅ all sandbox smoke checks passed"


### PR DESCRIPTION
## Summary

- Adds `sandbox create <name>` as the only provisioning path; bare `sandbox <name>` now attaches to an **existing** container only — errors (creating nothing) if it doesn't exist
- Subcommand typos like `sandbox lst` or `sandbox help` no longer leak junk containers + volumes
- Adds `sandbox help` as a real subcommand (exits 0, prints usage); fish completions and CLAUDE.md updated to match

## Implementation

- `ALLOW_CREATE=0` default in `bin/sandbox`; `create` arm in the dispatch `case` sets it to `1`
- `cmd_run` resolves container existence **before** `ensure_image` — a typo'd name never triggers a multi-minute image rebuild
- `help|-h|--help` folded into a single arm calling `usage 0` (parameterized exit code)
- Smoke test extended with sections 10–12: help/bogus-token/create+attach+absent assertions

## Test Plan

- [x] `shellcheck` passes on `bin/sandbox` and `scripts/test-sandbox.sh`
- [x] `fish -n` passes on the completions
- [x] Full `scripts/test-sandbox.sh` suite green (all 15 checks, including sections 10–12)
- [x] `sandbox help` → usage, exit 0, no container created
- [x] `sandbox lst` → "no such sandbox 'lst' — run 'sandbox create lst'…", exit 1
- [x] `sandbox create <name>` → provisions; bare `sandbox <name>` → re-enters; bare on absent → errors

Parent: #274