### PR TITLE
📜 nvimpager: smooth, colored paging for glow

### DIFF
--- a/.config/fish/conf.d/00-env.fish
+++ b/.config/fish/conf.d/00-env.fish
@@ -31,6 +31,14 @@ if command -q bat
     set -gx MANROFFOPT -c
 end
 
+# nvimpager as the general $PAGER — smooth, colored paging (e.g. glow's
+# markdown ANSI). man (MANPAGER=bat above) and git (core.pager=delta) win for
+# their own output. Guarded so non-Mac shells (the Linux sandbox, where
+# nvimpager isn't installed) stay clean.
+if command -q nvimpager
+    set -gx PAGER nvimpager
+end
+
 fish_add_path -gPm $HOME/.local/bin $HOME/.cargo/bin
 
 # Ghostty exports COLORTERM=truecolor on the Mac, but `docker exec` forwards

--- a/.config/nvimpager/init.lua
+++ b/.config/nvimpager/init.lua
@@ -1,0 +1,23 @@
+-- nvimpager loads THIS file as its config — NOT ~/.config/nvim. To get the
+-- same smooth scroll as nvim, reuse the snacks.nvim that nvim's lazy already
+-- installed. nvimpager rewrites neovim's stdpath(), so the path is hardcoded
+-- to nvim's lazy dir rather than derived via stdpath("data").
+local M = {}
+
+-- Enable snacks.scroll by reusing nvim's lazy-installed copy. Returns true if
+-- snacks was found and enabled, false if it is absent (fresh machine before
+-- nvim's first launch) — paging still works, just without animation.
+-- snacks_path is injectable so the smoke test can drive both branches.
+function M.enable_scroll(snacks_path)
+  snacks_path = snacks_path or vim.fn.expand("~/.local/share/nvim/lazy/snacks.nvim")
+  if not (vim.uv or vim.loop).fs_stat(snacks_path) then
+    return false
+  end
+  vim.opt.runtimepath:append(snacks_path)
+  require("snacks").setup({ scroll = { enabled = true } })
+  return true
+end
+
+M.enable_scroll()
+
+return M

--- a/Brewfile
+++ b/Brewfile
@@ -40,6 +40,7 @@ brew "bat"                      # syntax-highlighted cat / man pager backend
 brew "git-delta"                # git diff/log/blame pager
 brew "difftastic"               # syntactic diff for ad-hoc compares (non-git)
 brew "glow"                     # render markdown to ANSI
+brew "nvimpager"                # neovim as $PAGER: smooth, colored paging (glow)
 brew "tailspin"                 # syntax-highlighted log viewer (tspin)
 brew "vivid"                    # generates LS_COLORS palettes
 brew "starship"                 # cross-shell prompt engine (Rust); replaces powerlevel10k

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -564,11 +564,30 @@ Personal multi-theme, multi-font setup for Ghostty + tmux + vim + fish. `theme-s
   `alias less='bat …'` and don't set `$PAGER=bat` globally.
 - **`md` renders markdown via `glow`**, style at
   `.config/glow/glamour.json`. **`mdp` is `md -p`** — same render
-  through real `less` (glow spawns the pager as a subprocess; the
-  `less` wrapper doesn't apply). Alias passes `--style` directly
+  through `$PAGER` (= `nvimpager`; see the nvimpager bullet below). glow
+  spawns the pager as a subprocess, so the fish `less` wrapper doesn't
+  apply. Alias passes `--style` directly
   because glow on macOS reads its yml from
   `~/Library/Preferences/glow/`, not `~/.config/glow/`. Don't swap to
   `mdcat`/`frogmouth` (`mdcat` archived 2025-01-10).
+- **`nvimpager` is the global `$PAGER`** (`set -gx PAGER nvimpager` in
+  `.config/fish/conf.d/00-env.fish`, guarded on `command -q nvimpager`),
+  giving smooth, colored paging for glow output (`md` / `mdp` / bare
+  `glow` all route through it via glow's `pager: true`). It loads its
+  **own** `~/.config/nvimpager/init.lua` — *not* the nvim config — which
+  reuses nvim's lazy-installed `snacks.nvim` (runtimepath append +
+  `require('snacks').setup({ scroll = { enabled = true } })`) so paging
+  animates with the same `snacks.scroll` feel as nvim. **Graceful no-op
+  gotcha:** the snacks reuse is guarded by an existence check on
+  `~/.local/share/nvim/lazy/snacks.nvim`; on a fresh machine before
+  nvim's first launch the animation is absent but paging still works.
+  The path is hardcoded (not `stdpath('data')`) because nvimpager
+  rewrites neovim's `stdpath()`. Content color comes from glow's ANSI
+  decoded against Ghostty's palette — no colorscheme, no `theme-set`
+  coupling (auto-adapts like fzf/atuin). `man` (`MANPAGER=bat`) and
+  `git` (`core.pager=delta`) are unaffected. Whole-dir symlink (only
+  tracked `init.lua`; runtime state under `~/.local/share/nvimpager/`).
+  Smoke test: `scripts/test-nvimpager.sh`.
 - **`top` aliased to `btop`** (guarded). Theme `solarized_dark` via
   `.config/btop/btop.conf` (only `color_theme`, `theme_background = False`,
   `vim_keys = True` pinned). macOS `top` reachable via `command top`.
@@ -764,6 +783,7 @@ is `nvim-cheatsheet.html`).
 - nvim plugin smoke: `scripts/test-nvim.sh`
 - Theme switch smoke: `scripts/test-theme-switch.sh`
 - Sandbox smoke: `scripts/test-sandbox.sh`
+- nvimpager smoke: `scripts/test-nvimpager.sh`
 
 ## First-time setup on a new machine
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -159,6 +159,11 @@ link ".config/procs"   "$HOME/.config/procs"
 # --- xh (modern HTTP client; Solarized via default_options)
 link ".config/xh"      "$HOME/.config/xh"
 
+# --- nvimpager (neovim as $PAGER; smooth + colored paging for glow)
+# ~/.config/nvimpager/ holds only the tracked init.lua; nvimpager's runtime
+# state lives under ~/.local/share/nvimpager/, so a whole-dir symlink is safe.
+link ".config/nvimpager" "$HOME/.config/nvimpager"
+
 link ".config/atuin"   "$HOME/.config/atuin"
 
 # --- gh-dash (TUI for PRs/issues/notifications; switchable theme)

--- a/scripts/test-nvimpager.sh
+++ b/scripts/test-nvimpager.sh
@@ -1,0 +1,60 @@
+#!/opt/homebrew/bin/bash
+# Smoke test: nvimpager is installed, its init.lua compiles and executes
+# without Lua errors, and the snacks.scroll reuse enables when snacks is
+# present and no-ops cleanly when it is absent. Run after editing
+# .config/nvimpager/ or the PAGER wiring in .config/fish/conf.d/00-env.fish.
+set -euo pipefail
+
+DOTFILES="$(cd "$(dirname "$0")/.." && pwd)"
+INIT="$DOTFILES/.config/nvimpager/init.lua"
+
+if [ ! -f "$INIT" ]; then
+  echo "❌ $INIT missing"
+  exit 1
+fi
+
+if ! command -v nvimpager >/dev/null 2>&1; then
+  echo "⏭️  nvimpager not installed — skipping (brew install nvimpager)"
+  exit 0
+fi
+
+fail=0
+
+# 1. Guard branches: load init.lua headless and assert enable_scroll() is
+#    false for an absent path and true for the real snacks path (when present).
+lua_script=$(mktemp /tmp/nvimpager-test.XXXXXX.lua)
+trap 'rm -f "$lua_script"' EXIT
+cat >"$lua_script" <<'LUA'
+local M = assert(loadfile(vim.env.NVIMPAGER_INIT))()
+assert(M.enable_scroll("/nonexistent/snacks.nvim") == false,
+  "absent snacks path must return false")
+local real = vim.fn.expand("~/.local/share/nvim/lazy/snacks.nvim")
+if (vim.uv or vim.loop).fs_stat(real) then
+  assert(M.enable_scroll(real) == true, "present snacks path must return true")
+end
+io.write("guard-ok\n")
+LUA
+
+if ! out=$(NVIMPAGER_INIT="$INIT" nvim --clean -l "$lua_script" 2>&1); then
+  echo "❌ nvimpager init.lua guard check failed:"
+  echo "$out"
+  fail=1
+elif ! printf '%s' "$out" | grep -q 'guard-ok'; then
+  echo "❌ nvimpager init.lua guard check did not assert cleanly:"
+  echo "$out"
+  fail=1
+fi
+
+# 2. End-to-end cat mode: the real nvimpager binary loads init.lua and echoes
+#    piped content (proves init executes under nvimpager itself).
+if ! out=$(printf '# hello\n\nworld\n' | nvimpager -c 2>/tmp/nvimpager-cat-err); then
+  echo "❌ nvimpager cat-mode exited non-zero:"
+  cat /tmp/nvimpager-cat-err
+  fail=1
+elif ! printf '%s' "$out" | grep -q 'hello'; then
+  echo "❌ nvimpager cat-mode did not echo input content"
+  fail=1
+fi
+
+[ $fail -eq 0 ] && echo "✅ nvimpager smoke passed"
+exit $fail


### PR DESCRIPTION
## Summary

- 🍺 Adds `nvimpager` to Brewfile and sets it as the global `$PAGER` in fish (guarded on `command -q nvimpager` so the Linux sandbox stays clean)
- 🌀 Ships `.config/nvimpager/init.lua` that reuses nvim's lazy-installed `snacks.nvim` for scroll animation — guarded by an existence check so it gracefully no-ops on fresh machines before nvim's first launch
- 🔗 Wires a whole-dir bootstrap symlink for `~/.config/nvimpager`; amends the stale `mdp` clause in CLAUDE.md and adds the full convention bullet + verify-changes entry

## How it works

`glow` (used by `md`/`mdp`) spawns `$PAGER` as a subprocess, so setting `PAGER=nvimpager` gives colored, animated paging with no glow changes needed. `man` (`MANPAGER=bat`) and `git` (`core.pager=delta`) are unaffected — they override `$PAGER` for their own output.

`~/.config/nvimpager/init.lua` appends nvim's lazy dir to `runtimepath` and calls `require('snacks').setup({ scroll = { enabled = true } })`. The snacks path is hardcoded (not `stdpath('data')`) because nvimpager rewrites neovim's `stdpath()`. The `enable_scroll(snacks_path)` function is injectable for the smoke test to exercise both branches.

## Test plan

- ✅ `scripts/test-nvimpager.sh` — guard branches (absent/present snacks path) + cat-mode echo
- ✅ `scripts/test-fish-loads.sh` — 00-env.fish parses clean
- ⚠️ Manual: `mdp README.md` in Ghostty → colors render, scrolling animates; `man ls` → bat; `git diff HEAD~1` → delta

Closes #276