### PR TITLE
🐧 sandbox: show container glyph + git branch in starship prompt

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -714,6 +714,15 @@ Personal multi-theme, multi-font setup for Ghostty + tmux + vim + fish. `theme-s
   named-theme tools (bat, delta, glow, vivid, lnav, nvim, starship) on every
   container entry, tracking the host's current theme with no rebuild (#273);
   only an in-container theme *switcher* is out.
+  The sandbox starship prompt is the one theme tool whose config is **generated**,
+  not symlinked: `stage_theme` injects a container-gated penguin glyph
+  (`[container]`, self-gates on `/.dockerenv`) and native
+  `[git_branch]`/`[git_status]` into a copy of the active `starship-<theme>.toml`,
+  so the in-sandbox prompt surfaces container + git context (branch +
+  dirty/ahead-behind) while the Mac's shared tomls stay git-less and unchanged.
+  Injected modules use ANSI color names (auto-adapt per theme); the directory
+  chip keeps each theme's `pastel_rose`. `scripts/test-sandbox.sh` guards both
+  the no-leak invariant and the exact lines the generator rewrites (#280).
 
 ## Where things live
 

--- a/sandbox/install-linux.sh
+++ b/sandbox/install-linux.sh
@@ -76,7 +76,7 @@ generate_starship() {
 
 [container]
 format = "[$symbol ]($style)"
-symbol = ""
+symbol = ""
 style  = "bold yellow"
 
 [git_branch]

--- a/sandbox/install-linux.sh
+++ b/sandbox/install-linux.sh
@@ -51,6 +51,47 @@ stage_config() {
   fi
 }
 
+# Generate (not symlink) the sandbox starship config from the active theme.
+# The Mac prompt deliberately omits git and any container glyph; those additions
+# live ONLY here, injected into a copy of the read-only starship-<name>.toml, so
+# the shared per-theme tomls (used directly by the Mac) never gain them. This is
+# the starship analog of the gh-dash generate-by-concatenation pattern. Portable
+# across BSD sed (macOS smoke test) and GNU sed (container).
+generate_starship() {
+  local cfg="$1" name="$2"
+  local src="$cfg/starship-$name.toml"
+  [ -f "$src" ] || src="$cfg/starship-solarized.toml"
+  local tmp; tmp="$(mktemp)"
+  # Prepend $container to the directory line; fold git into right_format.
+  # SC2016: single-quote guards are intentional — these are starship token
+  # references, not shell variables; we don't want expansion.
+  # shellcheck disable=SC2016
+  sed -e 's/^format = """\$directory/format = """$container$directory/' \
+      -e 's/^right_format = "\$status\$cmd_duration"$/right_format = "$git_branch$git_status$status$cmd_duration"/' \
+      "$src" > "$tmp"
+  # Sandbox-only modules. [container] self-gates on /.dockerenv (empty on Mac).
+  # ANSI color names resolve to each theme's palette key when defined, ANSI
+  # fallback otherwise — auto-adapts across themes, no per-theme color authoring.
+  cat >> "$tmp" <<'STARSHIP_EOF'
+
+[container]
+format = "[$symbol ]($style)"
+symbol = ""
+style  = "bold yellow"
+
+[git_branch]
+format = "[$symbol$branch]($style) "
+style  = "bold purple"
+
+[git_status]
+style = "bold red"
+STARSHIP_EOF
+  # Atomic replace. Never `>` directly onto starship.toml: at build time / on a
+  # re-applied volume it may still be a symlink to the pristine in-image source,
+  # and `>` would follow it and corrupt that source.
+  mv -f "$tmp" "$cfg/starship.toml"
+}
+
 stage_theme() {
   # Bash port of theme-set.fish, scoped to the sandbox toolset (no tmux,
   # ghostty, gh-dash, or fonts). Solarized floor + existence-guarded overlay,
@@ -75,7 +116,6 @@ stage_theme() {
   # Solarized floor (relative targets resolve within each link's dir).
   ln -sfn solarized.tmux            "$cfg/themes/current.tmux"
   ln -sfn delta-solarized.gitconfig "$cfg/themes/delta-current.gitconfig"
-  ln -sfn starship-solarized.toml   "$cfg/starship.toml"
   ln -sfn glamour-solarized.json    "$cfg/glow/glamour.json"
   ln -sfn theme-solarized.json      "$cfg/lnav/configs/installed/theme.json"
 
@@ -84,8 +124,7 @@ stage_theme() {
     && ln -sfn "$name.tmux" "$cfg/themes/current.tmux"
   [ -f "$cfg/themes/delta-$name.gitconfig" ] \
     && ln -sfn "delta-$name.gitconfig" "$cfg/themes/delta-current.gitconfig"
-  [ -f "$cfg/starship-$name.toml" ] \
-    && ln -sfn "starship-$name.toml" "$cfg/starship.toml"
+  generate_starship "$cfg" "$name"
   [ -f "$cfg/glow/glamour-$name.json" ] \
     && ln -sfn "glamour-$name.json" "$cfg/glow/glamour.json"
   [ -f "$cfg/lnav/configs/installed/theme-$name.json" ] \

--- a/scripts/test-sandbox.sh
+++ b/scripts/test-sandbox.sh
@@ -65,6 +65,11 @@ theme_flip_test() {
     grep -q "^\[$blk\]" "$tmp/.config/starship.toml" \
       || { echo "❌ nord starship missing [$blk]"; rm -rf "$tmp"; exit 1; }
   done
+  # The penguin (U+F17C, UTF-8 EF 85 BC) must survive into [container].symbol.
+  # printf'd bytes keep this source ASCII-only — a raw glyph here risks the same
+  # silent stripping the generated symbol once suffered.
+  grep -qF "symbol = \"$(printf '\357\205\274')\"" "$tmp/.config/starship.toml" \
+    || { echo "❌ nord starship missing penguin glyph (U+F17C) in [container].symbol"; rm -rf "$tmp"; exit 1; }
   [ "$(readlink "$tmp/.config/themes/current.tmux")" = "nord.tmux" ] \
     || { echo "❌ nord current.tmux"; rm -rf "$tmp"; exit 1; }
   [ "$(readlink "$tmp/.config/themes/delta-current.gitconfig")" = "delta-nord.gitconfig" ] \
@@ -122,6 +127,9 @@ out="$(docker run --rm sandbox:test bash -lc 'cat ~/.config/starship.toml')"
 [[ "$out" == *'palette = "solarized_dark"'* ]] || fail "theme floor palette: $out"
 [[ "$out" == *'[container]'* ]] || fail "theme floor missing [container]"
 [[ "$out" == *'[git_branch]'* ]] || fail "theme floor missing [git_branch]"
+# Penguin (U+F17C, UTF-8 EF 85 BC) must reach the in-image generated symbol —
+# module-name checks above pass even when the glyph is stripped, so assert the byte.
+[[ "$out" == *"symbol = \"$(printf '\357\205\274')\""* ]] || fail "theme floor missing penguin glyph (U+F17C)"
 pass "theme floor default (generated)"
 
 out="$(docker run --rm sandbox:test bash -lc '

--- a/scripts/test-sandbox.sh
+++ b/scripts/test-sandbox.sh
@@ -17,6 +17,29 @@ fish -n .config/fish/completions/sandbox.fish || fail "completions parse"
 fish -n .config/fish/conf.d/00-env.fish || fail "00-env parse"
 pass "fish parse"
 
+# Guard A — Mac-unchanged: the shared per-theme tomls must NOT carry git or
+# container modules. Those live only in the generated sandbox config; a leak
+# here would change the Mac prompt.
+for f in .config/starship-*.toml; do
+  # shellcheck disable=SC2016
+  ! grep -qE '^\[(container|git_branch|git_status)\]|\$container|\$git_branch' "$f" \
+    || fail "Mac leak: $f carries a sandbox-only module"
+done
+pass "Mac starship tomls carry no git/container modules"
+
+# Guard B — transform-target drift: generate_starship's sed targets exact lines
+# shared by all 10 tomls. If a theme's format/right_format drifts, injection
+# would silently no-op. Fail loudly instead.
+for f in .config/starship-*.toml; do
+  # shellcheck disable=SC2016
+  grep -q '^format = """\$directory' "$f" \
+    || fail "transform drift: $f format line changed"
+  # shellcheck disable=SC2016
+  grep -q '^right_format = "\$status\$cmd_duration"$' "$f" \
+    || fail "transform drift: $f right_format line changed"
+done
+pass "all starship tomls share the transform-target lines"
+
 # Theme flip logic (no docker) — Solarized floor + guarded overlay + delta wiring.
 theme_flip_test() {
   local tmp; tmp="$(mktemp -d)"
@@ -28,8 +51,20 @@ theme_flip_test() {
 
   # Full-coverage theme: every tool overlays off the floor.
   HOME="$tmp" bash sandbox/install-linux.sh theme nord
-  [ "$(readlink "$tmp/.config/starship.toml")" = "starship-nord.toml" ] \
-    || { echo "❌ nord starship: $(readlink "$tmp/.config/starship.toml")"; rm -rf "$tmp"; exit 1; }
+  ! [ -L "$tmp/.config/starship.toml" ] \
+    || { echo "❌ nord starship should be a generated real file, not a symlink"; rm -rf "$tmp"; exit 1; }
+  grep -q '^palette = "nord"' "$tmp/.config/starship.toml" \
+    || { echo "❌ nord starship palette"; rm -rf "$tmp"; exit 1; }
+  # shellcheck disable=SC2016
+  grep -q '^format = """\$container\$directory' "$tmp/.config/starship.toml" \
+    || { echo "❌ nord starship: \$container not in format"; rm -rf "$tmp"; exit 1; }
+  # shellcheck disable=SC2016
+  grep -q '^right_format = "\$git_branch\$git_status\$status\$cmd_duration"$' "$tmp/.config/starship.toml" \
+    || { echo "❌ nord starship right_format"; rm -rf "$tmp"; exit 1; }
+  for blk in container git_branch git_status; do
+    grep -q "^\[$blk\]" "$tmp/.config/starship.toml" \
+      || { echo "❌ nord starship missing [$blk]"; rm -rf "$tmp"; exit 1; }
+  done
   [ "$(readlink "$tmp/.config/themes/current.tmux")" = "nord.tmux" ] \
     || { echo "❌ nord current.tmux"; rm -rf "$tmp"; exit 1; }
   [ "$(readlink "$tmp/.config/themes/delta-current.gitconfig")" = "delta-nord.gitconfig" ] \
@@ -47,8 +82,10 @@ theme_flip_test() {
 
   # Partial-coverage theme (Latte): starship overlays, delta/glow hold the floor.
   HOME="$tmp" bash sandbox/install-linux.sh theme latte
-  [ "$(readlink "$tmp/.config/starship.toml")" = "starship-latte.toml" ] \
-    || { echo "❌ latte starship overlay"; rm -rf "$tmp"; exit 1; }
+  grep -q '^palette = "catppuccin_latte"' "$tmp/.config/starship.toml" \
+    || { echo "❌ latte starship palette"; rm -rf "$tmp"; exit 1; }
+  grep -q '^\[git_branch\]' "$tmp/.config/starship.toml" \
+    || { echo "❌ latte starship git_branch"; rm -rf "$tmp"; exit 1; }
   [ "$(readlink "$tmp/.config/glow/glamour.json")" = "glamour-solarized.json" ] \
     || { echo "❌ latte glow floor"; rm -rf "$tmp"; exit 1; }
   [ "$(readlink "$tmp/.config/themes/delta-current.gitconfig")" = "delta-solarized.gitconfig" ] \
@@ -81,27 +118,31 @@ pass "nvim"
 
 # Theme apply in the built image: floor default, full-coverage overlay, and
 # Latte partial-coverage degradation.
-out="$(docker run --rm sandbox:test bash -lc 'readlink ~/.config/starship.toml')"
-[[ "$out" == "starship-solarized.toml" ]] || fail "theme floor default: $out"
-pass "theme floor default"
+out="$(docker run --rm sandbox:test bash -lc 'cat ~/.config/starship.toml')"
+[[ "$out" == *'palette = "solarized_dark"'* ]] || fail "theme floor palette: $out"
+[[ "$out" == *'[container]'* ]] || fail "theme floor missing [container]"
+[[ "$out" == *'[git_branch]'* ]] || fail "theme floor missing [git_branch]"
+pass "theme floor default (generated)"
 
 out="$(docker run --rm sandbox:test bash -lc '
   bash ~/.sandbox/install-linux.sh theme nord >/dev/null 2>&1
-  echo "starship=$(readlink ~/.config/starship.toml)"
+  echo "palette=$(grep -m1 "^palette = " ~/.config/starship.toml)"
+  echo "gitbranch=$(grep -c "^\[git_branch\]" ~/.config/starship.toml)"
   echo "bat=$(fish -c "echo \$BAT_THEME" 2>/dev/null)"
   echo "git=$(grep -c "pager = delta" ~/.gitconfig)"')"
-[[ "$out" == *"starship=starship-nord.toml"* ]] || fail "theme nord starship: $out"
+[[ "$out" == *'palette = "nord"'* ]] || fail "theme nord starship palette: $out"
+[[ "$out" == *"gitbranch=1"* ]] || fail "theme nord starship git_branch: $out"
 [[ "$out" == *"bat=Nord"* ]] || fail "theme nord bat: $out"
 [[ "$out" == *"git=1"* ]] || fail "theme nord delta gitconfig: $out"
-pass "theme apply (nord)"
+pass "theme apply (nord, generated)"
 
 out="$(docker run --rm sandbox:test bash -lc '
   bash ~/.sandbox/install-linux.sh theme latte >/dev/null 2>&1
-  echo "starship=$(readlink ~/.config/starship.toml)"
+  echo "palette=$(grep -m1 "^palette = " ~/.config/starship.toml)"
   echo "glow=$(readlink ~/.config/glow/glamour.json)"')"
-[[ "$out" == *"starship=starship-latte.toml"* ]] || fail "theme latte overlay: $out"
+[[ "$out" == *'palette = "catppuccin_latte"'* ]] || fail "theme latte starship palette: $out"
 [[ "$out" == *"glow=glamour-solarized.json"* ]] || fail "theme latte glow floor: $out"
-pass "theme degrade (latte)"
+pass "theme degrade (latte, generated)"
 
 # 6. Isolation: a default container has NO host bind-mount.
 cid="$(docker run -d --rm --cap-drop ALL --security-opt no-new-privileges \


### PR DESCRIPTION
## 🎯 Summary

- Generate (not symlink) the sandbox starship config in `stage_theme`: inject a container-gated penguin glyph (`[container]`, self-gates on `/.dockerenv`) and native `[git_branch]`/`[git_status]` into a copy of the active `starship-<theme>.toml`
- Mac's shared per-theme tomls stay git-less and unchanged — the additions live only in the generated copy
- Two new regression guards in the smoke test: Mac-leak check (shared tomls must never gain container/git modules) and transform-target drift check (sed targets must stay present in all 10 tomls)

## 🧪 Test Plan

- [x] `shellcheck sandbox/install-linux.sh scripts/test-sandbox.sh` — clean
- [x] No-docker theme flip test: `starship.toml` is a generated real file (not symlink) with correct `palette`, `$container` in format, `$git_branch/$git_status` in `right_format`, and all three module sections present
- [x] Docker floor: `[container]` and `[git_branch]` present in generated solarized config
- [x] Docker nord apply: palette + git_branch count correct
- [x] Docker latte degrade: palette correct, glow stays on solarized floor
- [x] All 21 sandbox smoke checks pass end-to-end

Closes #280
Parent: #269