### PR TITLE
🐧 sandbox: penguin glyph respects the prompt chip color

### DIFF
--- a/sandbox/install-linux.sh
+++ b/sandbox/install-linux.sh
@@ -69,15 +69,18 @@ generate_starship() {
   sed -e 's/^format = """\$directory/format = """$container$directory/' \
       -e 's/^right_format = "\$status\$cmd_duration"$/right_format = "$git_branch$git_status$status$cmd_duration"/' \
       "$src" > "$tmp"
-  # Sandbox-only modules. [container] self-gates on /.dockerenv (empty on Mac).
-  # ANSI color names resolve to each theme's palette key when defined, ANSI
-  # fallback otherwise — auto-adapts across themes, no per-theme color authoring.
+  # Sandbox-only modules. [container] self-gates on /.dockerenv (empty on Mac);
+  # it reuses the directory chip's palette keys (fg:base3 bg:pastel_rose, defined
+  # in every theme) so the penguin sits *inside* the flush-left prompt chip rather
+  # than floating on the terminal's default bg. git_branch/git_status use ANSI
+  # color names, which resolve to each theme's palette key when defined and fall
+  # back to ANSI otherwise — auto-adapting across themes, no per-theme authoring.
   cat >> "$tmp" <<'STARSHIP_EOF'
 
 [container]
-format = "[$symbol ]($style)"
+format = "[ $symbol]($style)"
 symbol = ""
-style  = "bold yellow"
+style  = "fg:base3 bg:pastel_rose"
 
 [git_branch]
 format = "[$symbol$branch]($style) "


### PR DESCRIPTION
## 🎯 Summary
- The sandbox starship `[container]` penguin used `bold yellow` (fixed fg, no bg), so it floated to the **left** of the flush-left directory chip on the terminal's default background — not respecting the per-theme prompt colors.
- Now reuses the directory chip's palette keys `fg:base3 bg:pastel_rose` (defined in every theme), so the penguin sits **inside** the chip and auto-tracks each theme — including nord's greenish `pastel_rose` (`#8fbcbb`).
- Tweaked the container `format` to `[ $symbol]` so the glyph picks up the chip's leading pad instead of leaving a double gap.

## 🔍 Why
- Regression from #284, which introduced the generated container glyph with a hardcoded ANSI color.

## ✅ Test plan
- [ ] `scripts/test-sandbox.sh` host-side tier passes (shellcheck, Guard A/B, theme-flip for nord + latte).
- [ ] In a rebuilt sandbox (`sandbox reup <name>`), the penguin renders inside the prompt chip across themes (nord → dark-on-teal, solarized → cream-on-rose).