### PR TITLE
🔑 sandbox: export auto-populated GITHUB_TOKEN so build secret resolves

### DIFF
--- a/bin/sandbox
+++ b/bin/sandbox
@@ -71,9 +71,13 @@ image_stale() { [ "$(image_hash)" != "$(sources_hash)" ]; }
 build_image() {
   local h; h="$(sources_hash)"
   echo "sandbox: building $IMAGE ..." >&2
-  # Auto-populate from gh CLI if not already set.
-  [ -z "${GITHUB_TOKEN:-}" ] && command -v gh >/dev/null 2>&1 \
-    && GITHUB_TOKEN="$(gh auth token 2>/dev/null || true)"
+  # Auto-populate from gh CLI if not already set. Must export: the secret is
+  # passed via `--secret env=GITHUB_TOKEN`, which docker reads from the process
+  # environment, not from an unexported shell variable.
+  if [ -z "${GITHUB_TOKEN:-}" ] && command -v gh >/dev/null 2>&1; then
+    GITHUB_TOKEN="$(gh auth token 2>/dev/null || true)"
+    export GITHUB_TOKEN
+  fi
   local -a secret_args=()
   [ -n "${GITHUB_TOKEN:-}" ] && secret_args=(--secret "id=github_token,env=GITHUB_TOKEN")
   docker build -f "$DOTFILES/sandbox/Dockerfile" "${secret_args[@]}" \


### PR DESCRIPTION
## 🐛 Problem

Running `sandbox build` without manually prefixing `GITHUB_TOKEN=(gh auth token)` left mise rate-limited against the GitHub releases API. The wrapper's auto-populate looked correct but never worked.

The build passes the token to docker with `--secret id=github_token,env=GITHUB_TOKEN`, and `env=` reads the value from the **process environment**. The auto-populate used a bare (unexported) shell assignment, so docker never inherited it and the secret came through empty. Only the manual prefix worked, because the shell exported it into the `sandbox` process env.

Pre-existing since the sandbox first landed (#269); the `machine create` path was unaffected because it interpolates the value inline.

## 🔧 Fix

- ➕ `export` the auto-populated `GITHUB_TOKEN` so docker's `--secret env=...` can see it.
- 🧹 Split declare/assign to satisfy shellcheck SC2155.

## ✅ Test plan

- [x] 🧪 Confirmed a bare assignment is **not** inherited by a child process; with `export` it is.
- [x] 🔍 `shellcheck bin/sandbox` clean.
- [ ] 🐳 `sandbox build` (no manual token prefix) completes without GH rate-limiting.