### PR TITLE
⚙️ sandbox: first GitHub Actions CI (build + smoke, arm64)

### DIFF
--- a/.github/workflows/sandbox.yml
+++ b/.github/workflows/sandbox.yml
@@ -1,0 +1,43 @@
+name: sandbox
+
+on:
+  pull_request:
+    paths:
+      - 'sandbox/**'
+      - 'bin/sandbox'
+      - 'scripts/test-sandbox.sh'
+      - '.config/nvim/**'
+      - '.config/fish/**'
+      - '.config/themes/**'
+      - '.config/glow/**'
+      - '.config/lnav/configs/installed/**'
+      - '.config/worktrunk/config.toml'
+      - '.config/starship-*.toml'
+      - '.hadolint.yaml'
+      - '.github/workflows/sandbox.yml'
+  schedule:
+    - cron: '17 7 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  sandbox:
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install fish
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends fish
+
+      - name: Lint Dockerfile (hadolint)
+        run: docker run --rm -v "$PWD:/repo" -w /repo hadolint/hadolint hadolint sandbox/Dockerfile
+
+      - name: Sandbox smoke (build + runtime asserts)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash scripts/test-sandbox.sh

--- a/.github/workflows/sandbox.yml
+++ b/.github/workflows/sandbox.yml
@@ -37,6 +37,14 @@ jobs:
       - name: Lint Dockerfile (hadolint)
         run: docker run --rm -v "$PWD:/repo" -w /repo hadolint/hadolint hadolint sandbox/Dockerfile
 
+      # The bash scripts hardcode `#!/opt/homebrew/bin/bash` (Apple-Silicon
+      # convention). test-sandbox.sh calls `bin/sandbox` by its shebang, so the
+      # runner needs bash 5 at that path — Linux's system bash already is 5.x.
+      - name: Provide bash at the Homebrew shebang path
+        run: |
+          sudo mkdir -p /opt/homebrew/bin
+          sudo ln -sf "$(command -v bash)" /opt/homebrew/bin/bash
+
       - name: Sandbox smoke (build + runtime asserts)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,2 @@
+ignored:
+  - DL3008  # don't pin apt versions in a sandbox that tracks current packages

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,7 +240,8 @@ bootstrap defaults. See "Switchable themes" / "Switchable Ghostty fonts" below.
   symlinked): `stage_theme` injects a container-gated penguin glyph + native
   git branch/status into a copy of the active `starship-<theme>.toml`, so the
   in-sandbox prompt shows container + git context while the Mac's shared tomls
-  stay git-less (#280). Smoke: `scripts/test-sandbox.sh`.
+  stay git-less (#280). Smoke: `scripts/test-sandbox.sh` (also run in CI:
+  `.github/workflows/sandbox.yml`, arm64, on sandbox-path PRs + nightly).
 
 ## Where things live
 

--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -9,7 +9,7 @@ ARG UID=1000
 RUN apt-get update \
  && apt-get install -y --no-install-recommends ca-certificates curl sudo \
  && rm -rf /var/lib/apt/lists/* \
- && useradd -m -u ${UID} -s /bin/bash ${USER} \
+ && useradd -lm -u ${UID} -s /bin/bash ${USER} \
  && echo "${USER} ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/${USER} \
  && chmod 0440 /etc/sudoers.d/${USER}
 

--- a/scripts/test-sandbox.sh
+++ b/scripts/test-sandbox.sh
@@ -50,7 +50,7 @@ theme_flip_test() {
   cp .config/starship-*.toml "$tmp/.config/"
 
   # Full-coverage theme: every tool overlays off the floor.
-  HOME="$tmp" bash sandbox/install-linux.sh theme nord
+  HOME="$tmp" XDG_CONFIG_HOME="$tmp/.config" bash sandbox/install-linux.sh theme nord
   ! [ -L "$tmp/.config/starship.toml" ] \
     || { echo "❌ nord starship should be a generated real file, not a symlink"; rm -rf "$tmp"; exit 1; }
   grep -q '^palette = "nord"' "$tmp/.config/starship.toml" \
@@ -86,7 +86,7 @@ theme_flip_test() {
     || { echo "❌ nord BAT_THEME"; rm -rf "$tmp"; exit 1; }
 
   # Partial-coverage theme (Latte): starship overlays, delta/glow hold the floor.
-  HOME="$tmp" bash sandbox/install-linux.sh theme latte
+  HOME="$tmp" XDG_CONFIG_HOME="$tmp/.config" bash sandbox/install-linux.sh theme latte
   grep -q '^palette = "catppuccin_latte"' "$tmp/.config/starship.toml" \
     || { echo "❌ latte starship palette"; rm -rf "$tmp"; exit 1; }
   grep -q '^\[git_branch\]' "$tmp/.config/starship.toml" \


### PR DESCRIPTION
## 🎯 What

The repo's first GitHub Actions workflow, scoped to the sandbox only:
build the container image and run the existing smoke + lint checks so
upstream/tooling drift can't silently break the sandbox between local
rebuilds.

## 🔧 How

- 🧱 `.github/workflows/sandbox.yml` — single job on free `ubuntu-24.04-arm`
  (matches the Apple-Silicon target). Installs `fish`, runs
  `hadolint sandbox/Dockerfile`, then `bash scripts/test-sandbox.sh`
  (build + all docker runtime asserts). `GITHUB_TOKEN` is passed through
  for mise's GH-API calls.
- 🪶 `.hadolint.yaml` — ignores `DL3008` (don't pin apt versions in a
  sandbox that tracks current packages).
- 🐧 `sandbox/Dockerfile` — one-line `useradd -lm` fix for `DL3046`.
- 🚫 No build cache, no `shfmt`, no `push:` trigger — see the why below.

## 🤔 Why these choices

- 🌙 **Path filter + nightly, no cache.** Builds run only on sandbox-file
  changes plus nightly; the nightly run *wants* a cold build to catch
  drift on the `latest`-pinned mise tools — a cache would hide exactly
  that. Keeps `scripts/test-sandbox.sh` the single source of truth.
- ✂️ **No shfmt.** The scripts' deliberate compact style (joined `;`
  statements, one-liner functions) can't pass `shfmt -d`, and shfmt
  can't be configured to leave it alone. `shellcheck` (run by the
  script) covers correctness.

## 🧪 Test plan

- [ ] hadolint job green (validated locally: clean with the config + fix)
- [ ] workflow validates under actionlint (validated locally)
- [ ] sandbox smoke job builds the image + passes all runtime asserts on arm64
- [ ] nightly schedule + manual `workflow_dispatch` both trigger

## ⚠️ Note

First CI may surface the perpetually-queued "Claude" check-suite; disable
per the known `check-suites/preferences` fix if it appears.

Closes #285