### PR TITLE
🎨 nvimpager: follow theme-set by applying the active nvim colorscheme

### DIFF
--- a/.config/nvimpager/init.lua
+++ b/.config/nvimpager/init.lua
@@ -18,6 +18,37 @@ function M.enable_scroll(snacks_path)
   return true
 end
 
+-- Apply the active nvim colorscheme so paged output matches the theme-set
+-- stack. Reuses nvim's resolver (config.theme) as the single source of truth,
+-- then globs nvim's lazy plugin dirs onto runtimepath so :colorscheme can find
+-- the resolved scheme. No setup() — palette only. lazy_root is injectable so
+-- the smoke test can drive the present/absent branches. Returns true if a
+-- colorscheme was applied, false on a fresh machine (no lazy dir) or if nvim's
+-- config has moved (config.theme unrequireable) — paging still works either way.
+function M.apply_theme(lazy_root)
+  lazy_root = lazy_root or vim.fn.expand("~/.local/share/nvim/lazy")
+  local nvim_lua = vim.fn.expand("~/.config/nvim/lua")
+  package.path = nvim_lua .. "/?.lua;" .. nvim_lua .. "/?/init.lua;" .. package.path
+  local ok, theme = pcall(require, "config.theme")
+  if not ok then
+    return false
+  end
+  local dirs = vim.fn.glob(lazy_root .. "/*", false, true)
+  if #dirs == 0 then
+    return false
+  end
+  for _, dir in ipairs(dirs) do
+    vim.opt.runtimepath:append(dir)
+  end
+  -- nvimpager cat-mode emits 24-bit SGR only when termguicolors is on; headless
+  -- nvim defaults it off. Schemes like solarized8 define gui colors but no cterm
+  -- fallback and don't self-enable it, so without this the default theme pages
+  -- with no color at all. Forcing it on renders every theme's true palette.
+  vim.o.termguicolors = true
+  return pcall(vim.cmd.colorscheme, theme.current())
+end
+
 M.enable_scroll()
+M.apply_theme()
 
 return M

--- a/scripts/test-nvimpager.sh
+++ b/scripts/test-nvimpager.sh
@@ -32,6 +32,15 @@ local real = vim.fn.expand("~/.local/share/nvim/lazy/snacks.nvim")
 if (vim.uv or vim.loop).fs_stat(real) then
   assert(M.enable_scroll(real) == true, "present snacks path must return true")
 end
+-- apply_theme: empty/absent lazy dir returns false without touching colorscheme.
+assert(M.apply_theme("/nonexistent/lazy") == false,
+  "absent lazy dir must return false")
+-- present lazy dir: a colorscheme is applied and recorded in vim.g.colors_name.
+local lazy = vim.fn.expand("~/.local/share/nvim/lazy")
+if #vim.fn.glob(lazy .. "/*", false, true) > 0 then
+  assert(M.apply_theme() == true, "present lazy dir must apply a colorscheme")
+  assert(vim.g.colors_name ~= nil, "colors_name must be set after apply_theme")
+end
 io.write("guard-ok\n")
 LUA
 
@@ -54,6 +63,29 @@ if ! out=$(printf '# hello\n\nworld\n' | nvimpager -c 2>/tmp/nvimpager-cat-err);
 elif ! printf '%s' "$out" | grep -q 'hello'; then
   echo "❌ nvimpager cat-mode did not echo input content"
   fail=1
+fi
+
+# 3. Cat-mode color: with a theme applied, output carries the colorscheme's
+#    24-bit palette (Normal fg as a truecolor SGR `38;2;`). Gated on lazy
+#    plugins being installed — a fresh machine before nvim's first launch has
+#    none, so the pager correctly stays on terminal default colors.
+#    nvimpager reads its config from $XDG_CONFIG_HOME/nvimpager/init.lua; point
+#    that at the repo's $INIT so this exercises the file under test even from a
+#    worktree (where ~/.config/nvimpager symlinks to the primary checkout).
+LAZY="$HOME/.local/share/nvim/lazy"
+if [ -d "$LAZY" ] && [ -n "$(ls -A "$LAZY" 2>/dev/null)" ]; then
+  cfgdir=$(mktemp -d /tmp/nvimpager-cfg.XXXXXX)
+  trap 'rm -f "$lua_script"; rm -rf "$cfgdir"' EXIT
+  mkdir -p "$cfgdir/nvimpager"
+  ln -s "$INIT" "$cfgdir/nvimpager/init.lua"
+  if ! out=$(printf 'local x = 1\n' | XDG_CONFIG_HOME="$cfgdir" nvimpager -c 2>/tmp/nvimpager-color-err); then
+    echo "❌ nvimpager cat-mode (color) exited non-zero:"
+    cat /tmp/nvimpager-color-err
+    fail=1
+  elif ! printf '%s' "$out" | grep -q '38;2;'; then
+    echo "❌ nvimpager cat-mode did not emit the theme's 24-bit palette (38;2;)"
+    fail=1
+  fi
 fi
 
 [ $fail -eq 0 ] && echo "✅ nvimpager smoke passed"


### PR DESCRIPTION
## 🎨 Summary

Make `nvimpager` (the global `$PAGER`) adopt the active nvim colorscheme so paged output matches the rest of the `theme-set` stack.

- 🧩 New `M.apply_theme()` in `.config/nvimpager/init.lua`: reuses `config.theme` as the single source of truth, globs nvim's lazy plugin dirs onto `runtimepath`, enables `termguicolors`, then `:colorscheme`s the resolved theme. Palette only — no `setup()`.
- 🆕 Fresh-machine-safe: empty-glob early return (no lazy dir → paging still works, just colorless), and `pcall(require, "config.theme")` degrades if nvim's config moves.
- 🔁 No `theme-set` coupling — each pager launch is a fresh process, so theme switches are picked up automatically.

## 🐛 Gaps caught while smoke-testing (fixed inline)

- 🌈 **`termguicolors`** — applying the colorscheme alone wasn't enough. The default `solarized` theme defines only gui colors with no cterm fallback, so cat-mode emitted *no color at all* on a fresh machine. Forcing `termguicolors = true` makes truecolor deterministic across all 10 themes.
- 🧪 **Worktree-aware test** — bare `nvimpager -c` loads `~/.config/nvimpager`, which symlinks to the primary checkout and can't see unmerged worktree changes. The color assertion now injects the file under test via `XDG_CONFIG_HOME`, mirroring the headless guard's `NVIMPAGER_INIT`.

## ✅ Test plan

- [x] `scripts/test-nvimpager.sh` → `✅ nvimpager smoke passed` (headless `apply_theme` branches + end-to-end cat-mode 24-bit color)
- [x] Manual spot-check: `printf 'local x = 1\n' | nvimpager -c` emits `38;2;224;222;244` / `48;2;35;33;54` (rose-pine-moon Normal fg/bg)

Closes #282.