### PR TITLE
🐳 sandbox: add nvimpager for Brewfile parity (#283)

### DIFF
--- a/.config/fish/conf.d/00-env.fish
+++ b/.config/fish/conf.d/00-env.fish
@@ -31,15 +31,17 @@ if command -q bat
     set -gx MANROFFOPT -c
 end
 
+fish_add_path -gPm $HOME/.local/bin $HOME/.cargo/bin
+
 # nvimpager as the general $PAGER — smooth, colored paging (e.g. glow's
 # markdown ANSI). man (MANPAGER=bat above) and git (core.pager=delta) win for
-# their own output. Guarded so non-Mac shells (the Linux sandbox, where
-# nvimpager isn't installed) stay clean.
+# their own output. Guarded so shells without nvimpager stay clean. MUST come
+# after the fish_add_path above: in the sandbox nvimpager is installed into
+# ~/.local/bin, so `command -q` only finds it once that dir is on PATH (on the
+# Mac it's a Homebrew path already present, so the order is moot there).
 if command -q nvimpager
     set -gx PAGER nvimpager
 end
-
-fish_add_path -gPm $HOME/.local/bin $HOME/.cargo/bin
 
 # Ghostty exports COLORTERM=truecolor on the Mac, but `docker exec` forwards
 # only TERM — so inside the sandbox COLORTERM is empty and 24-bit-gating tools

--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,7 @@
 .config/*
 !.config/fish
 !.config/nvim
+!.config/nvimpager
 !.config/worktrunk
 !.config/themes
 !.config/glow

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,8 +240,11 @@ bootstrap defaults. See "Switchable themes" / "Switchable Ghostty fonts" below.
   symlinked): `stage_theme` injects a container-gated penguin glyph + native
   git branch/status into a copy of the active `starship-<theme>.toml`, so the
   in-sandbox prompt shows container + git context while the Mac's shared tomls
-  stay git-less (#280). Smoke: `scripts/test-sandbox.sh` (also run in CI:
-  `.github/workflows/sandbox.yml`, arm64, on sandbox-path PRs + nightly).
+  stay git-less (#280). **nvimpager** is the sole non-mise sandbox tool —
+  `stage_nvimpager` clones it + `make install-no-man` (no prebuilt release
+  assets), config copied like nvim's (#283). Smoke: `scripts/test-sandbox.sh`
+  (also run in CI: `.github/workflows/sandbox.yml`, arm64, on sandbox-path PRs +
+  nightly).
 
 ## Where things live
 

--- a/bin/sandbox
+++ b/bin/sandbox
@@ -55,7 +55,7 @@ command -v docker >/dev/null 2>&1 || die "docker not found (is OrbStack installe
 
 sources_hash() {
   ( cd "$DOTFILES" \
-    && find sandbox .config/fish .config/nvim .config/worktrunk/config.toml \
+    && find sandbox .config/fish .config/nvim .config/nvimpager .config/worktrunk/config.toml \
             .config/themes .config/glow .config/lnav/configs/installed \
             .config/starship-solarized.toml .config/starship-mocha.toml \
             .config/starship-frappe.toml .config/starship-dracula.toml \
@@ -283,6 +283,7 @@ cmd_machine() {
         mkdir -p ~/.config/mise ~/.config/fish ~/.config/worktrunk ~/.sandbox
         cp -r '"$DOTFILES"'/.config/fish/. ~/.config/fish/
         cp -r '"$DOTFILES"'/.config/nvim ~/.config/nvim
+        cp -r '"$DOTFILES"'/.config/nvimpager ~/.config/nvimpager
         cp '"$DOTFILES"'/.config/worktrunk/config.toml ~/.config/worktrunk/config.toml
         cp '"$DOTFILES"'/sandbox/mise.toml ~/.config/mise/config.toml
         cp '"$DOTFILES"'/sandbox/install-linux.sh ~/.sandbox/install-linux.sh

--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -29,9 +29,19 @@ RUN --mount=type=secret,id=github_token,mode=0444 \
     GITHUB_TOKEN="$(cat /run/secrets/github_token 2>/dev/null || true)" \
     bash /home/${USER}/.sandbox/install-linux.sh mise
 
+# --- nvimpager binary. Not a mise/aqua tool (no prebuilt release assets) —
+# clone + make install-no-man into ~/.local. Needs only base's git/make +
+# network; independent of nvim config. Frozen at this layer's first build like
+# the mise "latest" tools (re-clones only when the layer cache busts).
+RUN bash /home/${USER}/.sandbox/install-linux.sh nvimpager
+
 # --- nvim config + build-time plugin bake. Busts only when nvim config changes.
 COPY --chown=${USER}:${USER} .config/nvim /home/${USER}/.config/nvim
 RUN bash /home/${USER}/.sandbox/install-linux.sh nvim
+
+# --- nvimpager config (its own init.lua, NOT nvim's). Reuses the baked nvim
+# lazy dir at runtime for snacks scroll + theme. Cheap layer.
+COPY --chown=${USER}:${USER} .config/nvimpager /home/${USER}/.config/nvimpager
 
 # --- fish + worktrunk config last (cheapest to rebuild) + seed/shell wiring.
 COPY --chown=${USER}:${USER} .config/fish /home/${USER}/.config/fish

--- a/sandbox/install-linux.sh
+++ b/sandbox/install-linux.sh
@@ -26,6 +26,21 @@ stage_mise() {
   "$MISE" reshim
 }
 
+stage_nvimpager() {
+  # nvimpager isn't a mise/aqua tool and ships no prebuilt binaries — it's a
+  # bash script + lua runtime installed via the upstream makefile. Clone the
+  # default branch (tracks latest, matching mise.toml's "latest everywhere"),
+  # then `make install-no-man` (skips the scdoc man-page dep) into
+  # PREFIX=$HOME/.local so the binary lands on PATH (fish_add_path in
+  # 00-env.fish) without sudo. Needs only git + make (base stage) + network;
+  # nvim is NOT required at build time (`nvimpager -v` doesn't invoke nvim).
+  local tmp
+  tmp="$(mktemp -d)"
+  git clone --depth 1 https://github.com/lucc/nvimpager "$tmp/nvimpager"
+  make -C "$tmp/nvimpager" install-no-man PREFIX="$HOME/.local"
+  rm -rf "$tmp"
+}
+
 stage_nvim() {
   # Build-time plugin bake so nvim opens instantly/offline in every container.
   # theme.lua falls back to solarized when ~/.config/themes/current.tmux is
@@ -163,9 +178,10 @@ GITEOF
 case "${1:-all}" in
   base) stage_base ;;
   mise) stage_mise ;;
+  nvimpager) stage_nvimpager ;;
   nvim) stage_nvim ;;
   config) stage_config ;;
   theme) stage_theme "$@" ;;
-  all) stage_base; stage_mise; stage_nvim; stage_config; stage_theme ;;
-  *) echo "usage: install-linux.sh [base|mise|nvim|config|theme|all]" >&2; exit 1 ;;
+  all) stage_base; stage_mise; stage_nvimpager; stage_nvim; stage_config; stage_theme ;;
+  *) echo "usage: install-linux.sh [base|mise|nvimpager|nvim|config|theme|all]" >&2; exit 1 ;;
 esac

--- a/sandbox/mise.toml
+++ b/sandbox/mise.toml
@@ -3,6 +3,9 @@
 # theme is baked + applied at container entry (#273).
 # Installed by `install-linux.sh mise` at build time. "latest" is acceptable
 # for v1; a committed lockfile for reproducibility is a follow-up.
+# NOTE: nvimpager is the one Brewfile-parity tool NOT installed here — it ships
+# no prebuilt release assets, so install-linux.sh's stage_nvimpager clones it +
+# `make install-no-man` instead (#283).
 [tools]
 node = "lts"
 go = "latest"

--- a/scripts/test-sandbox.sh
+++ b/scripts/test-sandbox.sh
@@ -121,6 +121,23 @@ docker run --rm sandbox:test bash -lc '$HOME/.local/bin/mise exec -- nvim --head
   || fail "nvim headless"
 pass "nvim"
 
+# 5b. nvimpager: on PATH, $PAGER resolves to it, init.lua present, cat-mode
+# echoes piped content, and cat-mode emits the active theme's 24-bit palette
+# (38;2;) — the color proxy proves nvimpager's init.lua reached the baked nvim
+# lazy dir (snacks/theme reuse, the headline risk of this change). Run via fish
+# so mise is active (nvim on PATH) and COLORTERM=truecolor is backfilled; the
+# floor (solarized) theme is already applied from the build.
+out="$(docker run --rm sandbox:test fish -c '
+  type -q nvimpager; and echo ONPATH
+  test "$PAGER" = nvimpager; and echo PAGER
+  test -f ~/.config/nvimpager/init.lua; and echo INIT
+  printf "# hello\n" | nvimpager -c | string match -q "*hello*"; and echo CAT
+  printf "local x = 1\n" | nvimpager -c | string match -q "*38;2;*"; and echo COLOR')"
+for tok in ONPATH PAGER INIT CAT COLOR; do
+  [[ "$out" == *"$tok"* ]] || fail "nvimpager: missing $tok (got: $out)"
+done
+pass "nvimpager (on PATH, \$PAGER, init.lua, cat-mode, color proxy)"
+
 # Theme apply in the built image: floor default, full-coverage overlay, and
 # Latte partial-coverage degradation.
 out="$(docker run --rm sandbox:test bash -lc 'cat ~/.config/starship.toml')"


### PR DESCRIPTION
## 🎯 What
Installs nvimpager in the sandbox (container + OrbStack machine) so `$PAGER`
resolves to it, with its init.lua reusing the baked nvim `lazy/` dir — matching
the Mac. Closes #283.

## 🔧 How
- 🐳 `stage_nvimpager` clones `lucc/nvimpager` + `make install-no-man PREFIX=~/.local`
  (no prebuilt release assets, so it's the sole non-mise sandbox tool)
- 🐳 Dockerfile: binary RUN after the mise stage + config COPY after the nvim bake
- 🐳 `bin/sandbox`: `.config/nvimpager` added to the content hash + machine-path cp
- 🐳 `.dockerignore`: allowlist `!.config/nvimpager` (build context is trimmed to an allowlist)
- 🐟 `00-env.fish`: set `$PAGER` after `fish_add_path` so the `~/.local/bin`
  install is found (Mac uses a Homebrew path, so order was moot there)
- 📝 docs: mise.toml header + CLAUDE.md sandbox bullet

## 🧪 Test plan
- ✅ `scripts/test-sandbox.sh` — builds the image, asserts nvimpager on PATH,
  `$PAGER`, init.lua present, cat-mode echo, and 24-bit color proxy (proves
  init.lua reached the baked nvim lazy dir)
- ✅ `scripts/test-nvimpager.sh` — Mac-side regression guard
- ✅ shellcheck + `fish -n` clean