### PR TITLE
🎯 tmux usage cluster: suppress overreach alarm on low-confidence projections

### DIFF
--- a/.config/tmux/bin/tmux-claude-usage
+++ b/.config/tmux/bin/tmux-claude-usage
@@ -42,16 +42,21 @@ fire=$(printf '\xef\x81\xad')      # U+F06D nf-fa-fire
 
 # Returns the overreach decoration to insert after a chip's percentage.
 # Output is meant to be appended directly to a chip body (leading space
-# included). Returns empty string when the chip is not overreaching.
+# included). Returns empty string when the chip is not overreaching OR when
+# ccpulse reports the projection as low-confidence (issue #252) — an early-
+# window slope extrapolated from a tiny sample produces noisy false alarms.
 #
 #   args: $1 = will_overreach ("true" | "false" | "")
 #         $2 = projected_pct_at_reset (integer string, or "")
-#   stdout: " <fire> → N%"  when $1 == "true" and $2 non-empty
-#           " <fire>"        when $1 == "true" and $2 empty
+#         $3 = confidence ("ok" | "low" | "") — only an explicit "low"
+#              suppresses; empty/absent (older ccpulse) defaults to show.
+#   stdout: " <fire> → N%"  when $1 == "true", $3 != "low", and $2 non-empty
+#           " <fire>"        when $1 == "true", $3 != "low", and $2 empty
 #           ""                otherwise
 format_overreach_suffix() {
-  local will=$1 pct=$2
+  local will=$1 pct=$2 conf=$3
   [ "$will" = "true" ] || { printf ''; return 0; }
+  [ "$conf" = "low" ]  && { printf ''; return 0; }
   if [ -n "$pct" ]; then
     printf ' %s \xe2\x86\x92 %s%%' "$fire" "$pct"
   else

--- a/.config/tmux/bin/tmux-claude-usage
+++ b/.config/tmux/bin/tmux-claude-usage
@@ -96,7 +96,9 @@ mapfile -t _fields < <(printf '%s' "$json" | jq -r '
     (.projection.five_hour.will_overreach            // ""),
     (.projection.five_hour.projected_pct_at_reset    // ""),
     (.projection.seven_day.will_overreach            // ""),
-    (.projection.seven_day.projected_pct_at_reset    // "")
+    (.projection.seven_day.projected_pct_at_reset    // ""),
+    (.projection.five_hour.confidence                // ""),
+    (.projection.seven_day.confidence                // "")
   ] | .[]
 ') || exit 0
 pct_5h=${_fields[0]}
@@ -107,6 +109,8 @@ over_5h=${_fields[4]}
 proj_5h=${_fields[5]}
 over_7d=${_fields[6]}
 proj_7d=${_fields[7]}
+conf_5h=${_fields[8]}
+conf_7d=${_fields[9]}
 
 [ -z "${pct_5h:-}" ]    && exit 0
 [ -z "${mins_5h:-}" ]   && exit 0
@@ -154,13 +158,13 @@ threshold=80
 # 5h body: always full (rendered in the yellow chip).
 body_5h=$(printf '%s %d%%%s • %s' \
   "$hourglass" "$pct_5h" \
-  "$(format_overreach_suffix "$over_5h" "$proj_5h")" \
+  "$(format_overreach_suffix "$over_5h" "$proj_5h" "$conf_5h")" \
   "$reset_5h")
 
 # 7d body: robot + calendar + pct, with optional reset when pct >= threshold.
 # Robot glyph is the cluster's "this is Claude" anchor (was its own chip
 # pre-merge); calendar remains the 7d-window anchor.
-over_7d_suffix=$(format_overreach_suffix "$over_7d" "$proj_7d")
+over_7d_suffix=$(format_overreach_suffix "$over_7d" "$proj_7d" "$conf_7d")
 if [ "$pct_7d" -ge "$threshold" ]; then
   # Expanded body: pct + (optional overreach decoration) + • <reset>.
   body_7d=$(printf '%s %s %d%%%s • %s' \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,10 +57,13 @@ bootstrap defaults. See "Switchable themes" / "Switchable Ghostty fonts" below.
 - **tmux Claude usage cluster** in `status-left` (`tmux-claude-usage`, parses
   `ccpulse status --json` each 5s tick). Two chips: violet 7d weekly + yellow
   5h block, each showing `<pct>%` + reset. Overreach decoration (fire +
-  projected %) when `projection.<window>.will_overreach`; 7d chip auto-expands
-  at pct≥80 or on overreach. Graceful degradation: missing `projection` keeps
-  the cluster (drops the decoration); missing any of the 4 core fields hides it
-  atomically.
+  projected %) when `projection.<window>.will_overreach` **and**
+  `projection.<window>.confidence != "low"` — a low-confidence projection
+  (noisy early-window extrapolation) neither decorates nor auto-expands;
+  default-to-ok when the field is absent (older ccpulse). 7d chip auto-expands
+  at pct≥80 or on a trusted overreach. Graceful degradation: missing
+  `projection` keeps the cluster (drops the decoration); missing any of the 4
+  core fields hides it atomically.
 - **tmux prefix `C-a`** (`C-Space` clashes with macOS input-source switch).
   Pane nav `<prefix> h/j/k/l`; splits `|` `-`. **Cycling pairs are
   single-canonical** (one combo per motion): windows `,`/`.`, sessions

--- a/scripts/test-tmux-claude-usage.sh
+++ b/scripts/test-tmux-claude-usage.sh
@@ -400,6 +400,67 @@ assert_contains     "$got" "21% "$'\xef\x81\xad' "null projected_pct + overreach
 assert_not_contains "$got" $'\xe2\x86\x92'        "null projected_pct + overreach: no arrow glyph"
 teardown_sandbox
 
+# ─── Confidence gating (issue #252) ──────────
+# Case: 7d overreach but confidence "low" (53-min-in 187% scenario). Expect the
+# decoration fully suppressed: no fire glyph, and the chip stays COMPACT (pct<80
+# so no auto-expand from a now-empty suffix). pct still renders.
+setup_sandbox
+cat > "$TEST_BIN/ccpulse" <<'STUB'
+#!/opt/homebrew/bin/bash
+cat <<'JSON'
+{"percent":8,"minutes_to_reset":217,"quota":{"five_hour":{"utilization":8,"resets_at":"2026-05-09T21:10:00Z"},"seven_day":{"utilization":21,"resets_at":"2099-12-31T00:00:00Z"}},"projection":{"five_hour":{"will_overreach":false,"projected_pct_at_reset":34,"confidence":"ok"},"seven_day":{"will_overreach":true,"projected_pct_at_reset":187,"confidence":"low"}}}
+JSON
+STUB
+chmod +x "$TEST_BIN/ccpulse"
+got=$(run_helper)
+assert_contains     "$got" "21%"            "7d low-confidence overreach: pct still visible"
+assert_not_contains "$got" $'\xef\x81\xad'  "7d low-confidence overreach: fire glyph suppressed"
+assert_not_contains "$got" "21% • "         "7d low-confidence overreach: no auto-expand (stays compact)"
+teardown_sandbox
+
+# Case: same 7d overreach but confidence "ok" — regression guard that trusted
+# projections still render the decoration.
+setup_sandbox
+cat > "$TEST_BIN/ccpulse" <<'STUB'
+#!/opt/homebrew/bin/bash
+cat <<'JSON'
+{"percent":8,"minutes_to_reset":217,"quota":{"five_hour":{"utilization":8,"resets_at":"2026-05-09T21:10:00Z"},"seven_day":{"utilization":21,"resets_at":"2099-12-31T00:00:00Z"}},"projection":{"five_hour":{"will_overreach":false,"projected_pct_at_reset":34,"confidence":"ok"},"seven_day":{"will_overreach":true,"projected_pct_at_reset":187,"confidence":"ok"}}}
+JSON
+STUB
+chmod +x "$TEST_BIN/ccpulse"
+got=$(run_helper)
+assert_contains "$got" "21% "$'\xef\x81\xad'" "$'\xe2\x86\x92'" 187%" "7d ok-confidence overreach: '21% 🔥 → 187%' shown"
+teardown_sandbox
+
+# Case: 5h overreach with confidence "low" (7d not overreaching) — 5h gate works,
+# no fire glyph anywhere.
+setup_sandbox
+cat > "$TEST_BIN/ccpulse" <<'STUB'
+#!/opt/homebrew/bin/bash
+cat <<'JSON'
+{"percent":8,"minutes_to_reset":217,"quota":{"five_hour":{"utilization":8,"resets_at":"2026-05-09T21:10:00Z"},"seven_day":{"utilization":21,"resets_at":"2099-12-31T00:00:00Z"}},"projection":{"five_hour":{"will_overreach":true,"projected_pct_at_reset":120,"confidence":"low"},"seven_day":{"will_overreach":false,"projected_pct_at_reset":34,"confidence":"ok"}}}
+JSON
+STUB
+chmod +x "$TEST_BIN/ccpulse"
+got=$(run_helper)
+assert_contains     "$got" "8%"             "5h low-confidence overreach: pct still visible"
+assert_not_contains "$got" $'\xef\x81\xad'  "5h low-confidence overreach: fire glyph suppressed"
+teardown_sandbox
+
+# Case: 7d overreach with NO confidence key at all (older ccpulse). Default-to-ok
+# means the decoration still shows — explicit graceful-degradation coverage.
+setup_sandbox
+cat > "$TEST_BIN/ccpulse" <<'STUB'
+#!/opt/homebrew/bin/bash
+cat <<'JSON'
+{"percent":8,"minutes_to_reset":217,"quota":{"five_hour":{"utilization":8,"resets_at":"2026-05-09T21:10:00Z"},"seven_day":{"utilization":21,"resets_at":"2099-12-31T00:00:00Z"}},"projection":{"five_hour":{"will_overreach":false,"projected_pct_at_reset":34},"seven_day":{"will_overreach":true,"projected_pct_at_reset":187}}}
+JSON
+STUB
+chmod +x "$TEST_BIN/ccpulse"
+got=$(run_helper)
+assert_contains "$got" "21% "$'\xef\x81\xad'" "$'\xe2\x86\x92'" 187%" "missing confidence key: decoration still shown (default-to-ok)"
+teardown_sandbox
+
 # Case: both chips overreach simultaneously. Assert two distinct
 # fire-glyph occurrences and that the body bodies fit (rough printable-
 # length check, stripping tmux #[...] segments).

--- a/scripts/test-tmux-claude-usage.sh
+++ b/scripts/test-tmux-claude-usage.sh
@@ -148,12 +148,21 @@ unset -f format_reset
 fire_glyph=$'\xef\x81\xad'
 arrow_glyph=$'\xe2\x86\x92'
 
-assert_eq "$(format_overreach_suffix true 120)"  " ${fire_glyph} ${arrow_glyph} 120%" "format_overreach_suffix(true, 120)"
-assert_eq "$(format_overreach_suffix true 252)"  " ${fire_glyph} ${arrow_glyph} 252%" "format_overreach_suffix(true, 252)"
-assert_eq "$(format_overreach_suffix true '')"   " ${fire_glyph}"                     "format_overreach_suffix(true, '') — null projected_pct"
-assert_eq "$(format_overreach_suffix false 120)" ""                                    "format_overreach_suffix(false, 120)"
-assert_eq "$(format_overreach_suffix '' 120)"    ""                                    "format_overreach_suffix('', 120)"
-assert_eq "$(format_overreach_suffix false '')"  ""                                    "format_overreach_suffix(false, '')"
+# Existing show-path calls now pass an explicit confidence (3rd arg). Required:
+# the harness runs under `set -u`, so once the function references $3 a missing
+# arg would abort with "unbound variable".
+assert_eq "$(format_overreach_suffix true 120 ok)"  " ${fire_glyph} ${arrow_glyph} 120%" "format_overreach_suffix(true, 120, ok)"
+assert_eq "$(format_overreach_suffix true 252 ok)"  " ${fire_glyph} ${arrow_glyph} 252%" "format_overreach_suffix(true, 252, ok)"
+assert_eq "$(format_overreach_suffix true '' ok)"   " ${fire_glyph}"                     "format_overreach_suffix(true, '', ok) — null projected_pct"
+assert_eq "$(format_overreach_suffix false 120 ok)" ""                                    "format_overreach_suffix(false, 120, ok)"
+assert_eq "$(format_overreach_suffix '' 120 ok)"    ""                                    "format_overreach_suffix('', 120, ok)"
+assert_eq "$(format_overreach_suffix false '' ok)"  ""                                    "format_overreach_suffix(false, '', ok)"
+
+# Confidence gate (issue #252): explicit "low" suppresses; empty/"ok" show.
+assert_eq "$(format_overreach_suffix true 187 low)" ""                                    "gate: low confidence suppresses suffix"
+assert_eq "$(format_overreach_suffix true 187 ok)"  " ${fire_glyph} ${arrow_glyph} 187%" "gate: ok confidence shows suffix"
+assert_eq "$(format_overreach_suffix true 187 '')"  " ${fire_glyph} ${arrow_glyph} 187%" "gate: empty confidence defaults to show (old ccpulse)"
+assert_eq "$(format_overreach_suffix true '' low)"  ""                                    "gate: low confidence suppresses even with null pct"
 unset -f format_overreach_suffix
 unset fire_glyph arrow_glyph
 


### PR DESCRIPTION
## 🎯 What

The tmux Claude-usage cluster fired its overreach decoration (🔥 + projected %)
off `projection.<window>.will_overreach` alone. Early in a window, ccpulse
extrapolates a steep slope from a tiny sample, producing noisy false alarms
(e.g. "→ 187%" 53 minutes into a 7-day window). This gates the decoration on
`projection.<window>.confidence`.

## 🔧 How

- `format_overreach_suffix` takes a 3rd `confidence` arg; an explicit `"low"`
  returns empty. Empty/`"ok"`/absent still shows (default-to-ok).
- The helper extracts both windows' `confidence` and passes them to each chip.
- The 7d auto-expand-on-overreach suppression falls out for free (empty suffix).

## ✅ Test plan

- `scripts/test-tmux-claude-usage.sh` — 72 pass (unit gate cases + low/ok/missing
  integration fixtures on both windows). Run outside a themed tmux session (or
  in CI) so the Solarized color fallbacks engage.
- 🔍 Smoke: low-confidence overreach renders no 🔥 and stays compact; ok-confidence
  and older-ccpulse (no `confidence` key) still decorate.

Closes #252