### PR TITLE
📜 Add CONTRIBUTING / Code of Conduct / SECURITY governance docs

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+marcin.ciunelis@gmail.com.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,55 @@
+# Contributing to dotfiles
+
+Thanks for your interest in this repo.
+
+This is a personal setup maintained by one person in spare time — a
+multi-theme, multi-font configuration for Ghostty + tmux + vim + fish, wired
+together with manual symlinks. It's deliberately opinionated and tailored to
+my own machines, and that focus is what keeps it coherent.
+
+## Pull requests
+
+**I'm not accepting external pull requests.** Please don't open one — I'd hate
+for you to spend hours on a change I can't merge. With a single maintainer and
+limited review bandwidth, taking on outside code would mean either rushing
+reviews or letting PRs go stale, and the personal, tightly-tailored scope is
+something I want to protect.
+
+That's not a brush-off — there's a better way to help.
+
+## Issues are welcome
+
+Bug reports **and** feature requests are genuinely welcome, and they shape
+where this setup goes next. Opening an issue is the real way to influence the
+repo — far more effective than a pull request would be.
+
+- **Found a bug?** Open an issue.
+- **Want a feature, or a different default?** Open an issue and make the case.
+
+### Filing a good issue
+
+A little detail goes a long way:
+
+- What you ran, and what you expected versus what actually happened.
+- Your OS and terminal (this setup targets macOS + Ghostty).
+- Which tool, theme, or font is involved (e.g. `theme-set`, `font-set`, or a
+  specific config file).
+- The output of any relevant `scripts/test-*.sh` smoke test, if one applies.
+- Minimal steps to reproduce, if you can.
+
+## Want to change it yourself?
+
+This repo is MIT-licensed — fork it freely and make it your own. The
+[Setup (new machine)](README.md#setup-new-machine) section of the README has
+everything you need to get a local checkout running, and `CLAUDE.md` documents
+the conventions (symlink model, shell and scripting standards).
+
+## Security
+
+Please don't file security reports publicly. Report vulnerabilities privately
+through GitHub's advisory flow — see [`SECURITY.md`](SECURITY.md).
+
+## Code of conduct
+
+This project follows the [Contributor Covenant](CODE_OF_CONDUCT.md). By taking
+part, you agree to uphold it.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,12 @@
+# Security policy
+
+dotfiles is a personal config repo. A vulnerability typically means malicious
+config or snippet injection, secrets accidentally committed in `*.template`
+files, or `bootstrap.sh` doing something unexpected on a fresh machine.
+
+## Reporting
+
+Report vulnerabilities through GitHub's private advisory:
+https://github.com/martinciu/dotfiles/security/advisories/new
+
+Do not file public issues for security reports.


### PR DESCRIPTION
## 📋 Summary

Adds the three standard community/governance docs at the repo root so GitHub surfaces them in its community-standards UI. Ported and adapted from the sibling `ccpulse` repo.

## 📝 Changes

- 📜 **`CODE_OF_CONDUCT.md`** — Contributor Covenant v2.0, verbatim (project-agnostic; enforcement contact is my email).
- 🔒 **`SECURITY.md`** — concise dotfiles threat model (malicious config/snippet injection, secrets in `*.template`, `bootstrap.sh` surprises) + private GitHub advisory reporting.
- 🤝 **`CONTRIBUTING.md`** — single-maintainer stance (no external PRs; issues genuinely welcome), dotfiles-flavored "filing a good issue", lean MIT/fork pointer to the README setup section, plus Security + Code-of-Conduct footers.

## ✅ Verification

- `CODE_OF_CONDUCT.md` is byte-identical to the source (`diff` clean); enforcement contact present.
- `SECURITY.md` carries the `martinciu/dotfiles` advisory URL; no source-repo-specific residue.
- `CONTRIBUTING.md` links resolve: `README.md#setup-new-machine` heading exists, and the `SECURITY.md` / `CODE_OF_CONDUCT.md` footers point at the new sibling files.
- Global residue sweep across all three files comes back empty.

Closes #295