### PR TITLE
📊 theme-set/font-set: --stats usage report + current-selection readout

### DIFF
--- a/.config/fish/completions/font-set.fish
+++ b/.config/fish/completions/font-set.fish
@@ -23,3 +23,8 @@ complete -c font-set -f -n 'test (count (commandline -opc)) -eq 2' \
 
 # 3rd positional: size — common values; any positive number works.
 complete -c font-set -f -n 'test (count (commandline -opc)) -eq 3' -a '10 11 12 13 13.5 14 15 16 18 20 22 24'
+
+# Flags.
+complete -c font-set -l stats -d 'Per-font usage report'
+complete -c font-set -l all   -d 'Include sub-minute selections in --stats'
+complete -c font-set -s h -l help -d 'Show usage'

--- a/.config/fish/completions/theme-set.fish
+++ b/.config/fish/completions/theme-set.fish
@@ -7,3 +7,8 @@ complete -c theme-set -f -n 'test (count (commandline -opc)) -eq 1' -a nord     
 complete -c theme-set -f -n 'test (count (commandline -opc)) -eq 1' -a latte       -d 'Catppuccin Latte (light)'
 complete -c theme-set -f -n 'test (count (commandline -opc)) -eq 1' -a rose-pine   -d 'Rose Pine Main'
 complete -c theme-set -f -n 'test (count (commandline -opc)) -eq 1' -a rose-pine-moon -d 'Rose Pine Moon (2.5 contrast)'
+
+# Flags (no positional name yet, or alongside).
+complete -c theme-set -l stats -d 'Per-theme usage report'
+complete -c theme-set -l all   -d 'Include sub-minute selections in --stats'
+complete -c theme-set -s h -l help -d 'Show usage'

--- a/.config/fish/functions/__font_set_current.fish
+++ b/.config/fish/functions/__font_set_current.fish
@@ -1,0 +1,5 @@
+function __font_set_current --description 'Active font family name from the font.ghostty symlink'
+    set -l link ~/.config/ghostty/font.ghostty
+    test -L "$link"; or return 0
+    string replace -r '^font-' '' (string replace -r '\.ghostty$' '' (readlink "$link"))
+end

--- a/.config/fish/functions/__font_set_names.fish
+++ b/.config/fish/functions/__font_set_names.fish
@@ -1,0 +1,6 @@
+function __font_set_names --description 'Canonical list of valid font-set names, one per line'
+    printf '%s\n' \
+        jetbrains fira cascadia monaspace iosevka \
+        hack meslo sauce ubuntu inconsolata \
+        departure bigblue 0xproto 3270 hurmit monofur dyslexic
+end

--- a/.config/fish/functions/__font_set_readout.fish
+++ b/.config/fish/functions/__font_set_readout.fish
@@ -20,7 +20,7 @@ function __font_set_readout --description 'Print current font family + weight + 
     else
         echo "font → $cur"
     end
-    set -l row (__theme_font_history font-set (__font_set_names) | string match -r "\t$cur\$" | tail -1)
+    set -l row (__theme_font_history font-set (__font_set_names) | string match -r "^.+\t$cur\$" | tail -1)
     if test -z "$row"
         echo "set: unknown (before history)"
         return 0

--- a/.config/fish/functions/__font_set_readout.fish
+++ b/.config/fish/functions/__font_set_readout.fish
@@ -1,0 +1,31 @@
+function __font_set_readout --description 'Print current font family + weight + size + when set'
+    set -l cur (__font_set_current)
+    if test -z "$cur"
+        echo "font → unknown (no active symlink)"
+        return 0
+    end
+    set -l extra
+    set -l wf ~/.config/ghostty/font-weight.ghostty
+    set -l sf ~/.config/ghostty/font-size.ghostty
+    if test -f "$wf"
+        set -l w (string replace -r '^font-style\s*=\s*' '' < "$wf" | string trim)
+        test -n "$w"; and set -a extra "weight $w"
+    end
+    if test -f "$sf"
+        set -l s (string replace -r '^font-size\s*=\s*' '' < "$sf" | string trim)
+        test -n "$s"; and set -a extra "size $s"
+    end
+    if test (count $extra) -gt 0
+        printf 'font → %s  (%s)\n' $cur (string join ', ' $extra)
+    else
+        echo "font → $cur"
+    end
+    set -l row (__theme_font_history font-set (__font_set_names) | string match -r "\t$cur\$" | tail -1)
+    if test -z "$row"
+        echo "set: unknown (before history)"
+        return 0
+    end
+    set -l ts (string split \t -- $row)[1]
+    set -l now (test -n "$THEME_FONT_STATS_NOW"; and echo $THEME_FONT_STATS_NOW; or date +%s)
+    printf 'set: %s (%s)\n' (date -r $ts '+%Y-%m-%d %H:%M') (__theme_font_ago (math -- "$now - $ts"))
+end

--- a/.config/fish/functions/__theme_font_ago.fish
+++ b/.config/fish/functions/__theme_font_ago.fish
@@ -1,0 +1,13 @@
+function __theme_font_ago --argument-names secs \
+        --description 'Format seconds as a single top-unit "N ago"'
+    set -l s (math -- "floor($secs)")
+    if test "$s" -lt 60
+        printf 'just now'
+    else if test "$s" -lt 3600
+        printf '%dm ago' (math -- "floor($s / 60)")
+    else if test "$s" -lt 86400
+        printf '%dh ago' (math -- "floor($s / 3600)")
+    else
+        printf '%dd ago' (math -- "floor($s / 86400)")
+    end
+end

--- a/.config/fish/functions/__theme_font_dur.fish
+++ b/.config/fish/functions/__theme_font_dur.fish
@@ -1,0 +1,18 @@
+function __theme_font_dur --argument-names secs \
+        --description 'Format seconds as 3d 9h 24m / 1h 5m / 1m 12s / 42s'
+    set -l s (math -- "floor($secs)")
+    test "$s" -lt 0; and set s 0
+    set -l d (math -- "floor($s / 86400)")
+    set -l h (math -- "floor($s % 86400 / 3600)")
+    set -l m (math -- "floor($s % 3600 / 60)")
+    set -l sec (math -- "$s % 60")
+    if test "$d" -gt 0
+        printf '%dd %dh %dm' $d $h $m
+    else if test "$h" -gt 0
+        printf '%dh %dm' $h $m
+    else if test "$m" -gt 0
+        printf '%dm %ds' $m $sec
+    else
+        printf '%ds' $sec
+    end
+end

--- a/.config/fish/functions/__theme_font_history.fish
+++ b/.config/fish/functions/__theme_font_history.fish
@@ -1,0 +1,29 @@
+function __theme_font_history --description 'Parse fish_history → sorted "epoch\tname" for valid names of a command'
+    set -l cmd $argv[1]
+    set -l valid $argv[2..-1]
+
+    set -l hist $FISH_HISTORY_FILE
+    test -z "$hist"; and set hist $__fish_user_data_dir/fish_history
+    test -f "$hist"; or set hist ~/.local/share/fish/fish_history
+    test -f "$hist"; or return 0
+
+    set -l rows
+    set -l pending_name
+    while read -l line
+        if set -l m (string match -r "^- cmd: $cmd (\S+)" -- $line)
+            # m[2] is the first token after the command name.
+            if contains -- $m[2] $valid
+                set pending_name $m[2]
+            else
+                set pending_name ''
+            end
+        else if test -n "$pending_name"
+            if set -l w (string match -r '^\s+when:\s+(\d+)' -- $line)
+                set -a rows "$w[2]"\t"$pending_name"
+                set pending_name ''
+            end
+        end
+    end <"$hist"
+
+    test (count $rows) -gt 0; and printf '%s\n' $rows | sort -n
+end

--- a/.config/fish/functions/__theme_font_stats_report.fish
+++ b/.config/fish/functions/__theme_font_stats_report.fish
@@ -72,5 +72,45 @@ function __theme_font_stats_report --description 'Aggregate theme/font history r
         return 0
     end
 
-    # Human rendering added in Task 5.
+    set -l c_dim ''; set -l c_cur ''; set -l c_reset ''
+    if isatty stdout
+        set c_dim (set_color brblack)
+        set c_cur (set_color --bold cyan)
+        set c_reset (set_color normal)
+    end
+
+    printf '%s%-16s %10s %6s %3s  %s%s\n' \
+        $c_dim $label total % sw 'last set' $c_reset
+
+    set -l hidden 0
+    for l in $sorted
+        set -l f (string split \t -- $l)
+        set -l total $f[1]; set -l last $f[2]; set -l name $f[3]; set -l sw $f[4]
+        if test "$all" != 1; and test "$total" -lt 60
+            set hidden (math $hidden + 1)
+            continue
+        end
+        set -l pct (math -- "round($total * 1000 / $span) / 10")
+        set -l when (date -r $last '+%Y-%m-%d %H:%M')
+        set -l ago (__theme_font_ago (math -- "$now - $last"))
+        set -l mark ''; set -l col ''; set -l colr ''
+        if test "$name" = "$current"
+            set mark ' ← current'; set col $c_cur; set colr $c_reset
+        end
+        printf '%s%-16s %10s %5s%% %3s  %s (%s)%s%s\n' \
+            $col $name (__theme_font_dur $total) $pct $sw $when $ago $mark $colr
+    end
+
+    test "$hidden" -gt 0; and test "$all" != 1; and \
+        printf '(%d short selections hidden — use --all)\n' $hidden
+
+    for name in $valid
+        if not contains -- $name $agg_names
+            printf '%-16s %10s %6s %3s  %s\n' $name — — 0 '— never'
+        end
+    end
+
+    set -l span_human (__theme_font_dur $span)
+    printf '\n%stracked window: %s → now (%s). Bootstrap defaults before the first switch are not counted. Durations are wall-clock between switches (include sleep/off time).%s\n' \
+        $c_dim (date -r $window_start '+%Y-%m-%d') $span_human $c_reset
 end

--- a/.config/fish/functions/__theme_font_stats_report.fish
+++ b/.config/fish/functions/__theme_font_stats_report.fish
@@ -1,0 +1,76 @@
+function __theme_font_stats_report --description 'Aggregate theme/font history rows into a usage report'
+    set -l raw 0
+    if test "$argv[1]" = --raw
+        set raw 1
+        set -e argv[1]
+    end
+    set -l label $argv[1]
+    set -l current $argv[2]
+    set -l all $argv[3]
+    set -l valid $argv[4..-1]
+
+    set -l now $THEME_FONT_STATS_NOW
+    test -z "$now"; and set now (date +%s)
+
+    # Read rows (epoch\tname), already sorted ascending by the parser.
+    set -l epochs
+    set -l names
+    while read -l line
+        test -z "$line"; and continue
+        set -a epochs (string split \t -- $line)[1]
+        set -a names (string split \t -- $line)[2]
+    end
+
+    if test (count $epochs) -eq 0
+        echo "$label: no history yet." >&2
+        return 0
+    end
+
+    set -l window_start $epochs[1]
+    set -l span (math -- "$now - $window_start")
+    test "$span" -lt 1; and set span 1
+
+    # Per-selection duration = gap to next; last → now. Aggregate by name.
+    set -l agg_names
+    set -l agg_total
+    set -l agg_sw
+    set -l agg_last
+    set -l n (count $epochs)
+    for i in (seq $n)
+        set -l start $epochs[$i]
+        set -l stop $now
+        test "$i" -lt "$n"; and set stop $epochs[(math $i + 1)]
+        set -l dur (math -- "$stop - $start")
+        test "$dur" -lt 0; and set dur 0
+        set -l name $names[$i]
+        set -l idx (contains -i -- $name $agg_names; or echo 0)
+        if test "$idx" -eq 0
+            set -a agg_names $name
+            set -a agg_total $dur
+            set -a agg_sw 1
+            set -a agg_last $start
+        else
+            set agg_total[$idx] (math -- "$agg_total[$idx] + $dur")
+            set agg_sw[$idx] (math -- "$agg_sw[$idx] + 1")
+            test "$start" -gt "$agg_last[$idx]"; and set agg_last[$idx] $start
+        end
+    end
+
+    # Build sortable lines: total<TAB>last<TAB>name<TAB>sw, sort by total desc
+    # then last desc (tie-break newest-first).
+    set -l lines
+    for i in (seq (count $agg_names))
+        set -a lines "$agg_total[$i]\t$agg_last[$i]\t$agg_names[$i]\t$agg_sw[$i]"
+    end
+    set -l sorted (printf '%b\n' $lines | sort -t\t -k1,1nr -k2,2nr)
+
+    if test "$raw" = 1
+        for l in $sorted
+            set -l f (string split \t -- $l)
+            printf '%s\t%s\t%s\t%s\n' $f[3] $f[1] $f[4] $f[2]
+        end
+        return 0
+    end
+
+    # Human rendering added in Task 5.
+end

--- a/.config/fish/functions/__theme_set_current.fish
+++ b/.config/fish/functions/__theme_set_current.fish
@@ -1,0 +1,5 @@
+function __theme_set_current --description 'Active theme name from the current.tmux symlink'
+    set -l link ~/.config/themes/current.tmux
+    test -L "$link"; or return 0
+    string replace -r '\.tmux$' '' (readlink "$link")
+end

--- a/.config/fish/functions/__theme_set_names.fish
+++ b/.config/fish/functions/__theme_set_names.fish
@@ -1,0 +1,5 @@
+function __theme_set_names --description 'Canonical list of valid theme-set names, one per line'
+    printf '%s\n' \
+        solarized mocha frappe dracula gruvbox \
+        tokyo-night nord latte rose-pine rose-pine-moon
+end

--- a/.config/fish/functions/__theme_set_readout.fish
+++ b/.config/fish/functions/__theme_set_readout.fish
@@ -5,7 +5,7 @@ function __theme_set_readout --description 'Print current theme + when it was se
         return 0
     end
     echo "theme → $cur"
-    set -l row (__theme_font_history theme-set (__theme_set_names) | string match -r "\t$cur\$" | tail -1)
+    set -l row (__theme_font_history theme-set (__theme_set_names) | string match -r "^.+\t$cur\$" | tail -1)
     if test -z "$row"
         echo "set: unknown (before history)"
         return 0

--- a/.config/fish/functions/__theme_set_readout.fish
+++ b/.config/fish/functions/__theme_set_readout.fish
@@ -1,0 +1,16 @@
+function __theme_set_readout --description 'Print current theme + when it was set'
+    set -l cur (__theme_set_current)
+    if test -z "$cur"
+        echo "theme → unknown (no active symlink)"
+        return 0
+    end
+    echo "theme → $cur"
+    set -l row (__theme_font_history theme-set (__theme_set_names) | string match -r "\t$cur\$" | tail -1)
+    if test -z "$row"
+        echo "set: unknown (before history)"
+        return 0
+    end
+    set -l ts (string split \t -- $row)[1]
+    set -l now (test -n "$THEME_FONT_STATS_NOW"; and echo $THEME_FONT_STATS_NOW; or date +%s)
+    printf 'set: %s (%s)\n' (date -r $ts '+%Y-%m-%d %H:%M') (__theme_font_ago (math -- "$now - $ts"))
+end

--- a/.config/fish/functions/font-set.fish
+++ b/.config/fish/functions/font-set.fish
@@ -1,19 +1,38 @@
-function font-set --description 'Switch Ghostty font (and optionally weight, size)'
+function font-set --description 'Switch Ghostty font; bare = show current, --stats = usage report'
+    set -l usage "Usage: font-set <name> [<weight>] [<size>]
+  name:   jetbrains|fira|cascadia|monaspace|iosevka|hack|meslo|sauce|ubuntu|inconsolata
+          departure|bigblue|0xproto|3270|hurmit|monofur|dyslexic
+  weight: per-font style name (Tab to discover); omit to keep current weight
+  size:   positive number; omit to keep current size
+  font-set                     show current font + when set
+  font-set --stats [--all]     per-font usage report"
+
+    if contains -- -h $argv; or contains -- --help $argv
+        echo $usage
+        return 0
+    end
+
+    if contains -- --stats $argv
+        set -l all 0
+        contains -- --all $argv; and set all 1
+        set -l cur (__font_set_current)
+        __theme_font_history font-set (__font_set_names) \
+            | __theme_font_stats_report FONT "$cur" $all (__font_set_names)
+        return 0
+    end
+
     set -l name $argv[1]
     set -l weight $argv[2]
     set -l size $argv[3]
-    switch $name
-        case jetbrains fira cascadia monaspace iosevka \
-             hack meslo sauce ubuntu inconsolata \
-             departure bigblue 0xproto 3270 hurmit monofur dyslexic
-            # OK
-        case '*'
-            echo "Usage: font-set <name> [<weight>] [<size>]" >&2
-            echo "  name:   jetbrains|fira|cascadia|monaspace|iosevka|hack|meslo|sauce|ubuntu|inconsolata" >&2
-            echo "          departure|bigblue|0xproto|3270|hurmit|monofur|dyslexic" >&2
-            echo "  weight: per-font style name (Tab to discover); omit to keep current weight" >&2
-            echo "  size:   positive number; omit to keep current size" >&2
-            return 1
+
+    if test -z "$name"
+        __font_set_readout
+        return 0
+    end
+
+    if not contains -- $name (__font_set_names)
+        echo $usage >&2
+        return 1
     end
 
     # Optional weight: must be one of the styles the picked font advertises.

--- a/.config/fish/functions/theme-set.fish
+++ b/.config/fish/functions/theme-set.fish
@@ -1,11 +1,35 @@
-function theme-set --description 'Switch colour scheme between solarized, mocha, frappe, dracula, gruvbox, tokyo-night, nord, latte, rose-pine, and rose-pine-moon'
+function theme-set --description 'Switch colour scheme; bare = show current, --stats = usage report'
+    set -l usage "Usage: theme-set <solarized|mocha|frappe|dracula|gruvbox|tokyo-night|nord|latte|rose-pine|rose-pine-moon>
+       theme-set            show current theme + when set
+       theme-set --stats [--all]   per-theme usage report"
+
+    # --help / -h
+    if contains -- -h $argv; or contains -- --help $argv
+        echo $usage
+        return 0
+    end
+
+    # --stats [--all]
+    if contains -- --stats $argv
+        set -l all 0
+        contains -- --all $argv; and set all 1
+        set -l cur (__theme_set_current)
+        __theme_font_history theme-set (__theme_set_names) \
+            | __theme_font_stats_report THEME "$cur" $all (__theme_set_names)
+        return 0
+    end
+
     set -l name $argv[1]
-    switch $name
-        case solarized mocha frappe dracula gruvbox tokyo-night nord latte rose-pine rose-pine-moon
-            # OK
-        case '*'
-            echo "Usage: theme-set <solarized|mocha|frappe|dracula|gruvbox|tokyo-night|nord|latte|rose-pine|rose-pine-moon>" >&2
-            return 1
+
+    # Bare invocation → current selection readout.
+    if test -z "$name"
+        __theme_set_readout
+        return 0
+    end
+
+    if not contains -- $name (__theme_set_names)
+        echo $usage >&2
+        return 1
     end
 
     set -l bat_theme

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -288,6 +288,7 @@ derivatives, re-run after swapping a source.
 - Brew deps (installed by bootstrap): `brew bundle check --file=$PROJECTS_HOME/dotfiles/Brewfile --verbose`
 - nvim plugin smoke: `scripts/test-nvim.sh`
 - Theme switch smoke: `scripts/test-theme-switch.sh`
+- Theme/font stats: `scripts/test-theme-font-stats.sh`
 - Sandbox smoke: `scripts/test-sandbox.sh`
 - nvimpager smoke: `scripts/test-nvimpager.sh`
 

--- a/docs/terminal-cheatsheet.html
+++ b/docs/terminal-cheatsheet.html
@@ -648,6 +648,8 @@
       <tr><td class="key"><code>theme-set tokyo-night</code></td><td class="desc">Tokyo Night Storm</td></tr>
       <tr><td class="key"><code>theme-set nord</code></td><td class="desc">Nord</td></tr>
       <tr><td class="key"><code>theme-set rose-pine</code> / <code>rose-pine-moon</code></td><td class="desc">Rosé Pine / Moon</td></tr>
+      <tr><td class="key"><code>theme-set</code></td><td class="desc">show current theme + when it was set</td></tr>
+      <tr><td class="key"><code>theme-set --stats</code> <span class="muted">[--all]</span></td><td class="desc">per-theme usage report (active time, %, switch count, last set)</td></tr>
     </table>
     <p class="note">10 themes total. The switch is live — open terminals, tmux, and nvim follow on next prompt / reload.</p>
   </div>
@@ -664,6 +666,8 @@
       <tr><td class="key"><code>font-set &lt;name&gt; bold</code></td><td class="desc">also set weight (per-font advertised weights)</td></tr>
       <tr><td class="key"><code>font-set &lt;name&gt; "" 15</code></td><td class="desc">keep weight, set size 15</td></tr>
       <tr><td class="key"><code>font-set &lt;Tab&gt;</code></td><td class="desc">completion lists all 17 Nerd Fonts</td></tr>
+      <tr><td class="key"><code>font-set</code></td><td class="desc">show current font (family + weight + size) + when set</td></tr>
+      <tr><td class="key"><code>font-set --stats</code> <span class="muted">[--all]</span></td><td class="desc">per-font usage report</td></tr>
     </table>
     <p class="note">17 switchable Nerd Fonts. Omit weight/size to keep the current value. No tmux/nvim/bat coupling — font is Ghostty-only.</p>
   </div>
@@ -802,7 +806,7 @@
 <span class="cmd">git log -p</span> | <span class="cmd">head</span>                 <span class="c"># should look styled</span></pre>
 
 <footer>
-  Built from <code>~/.config/fish/</code>, <code>Brewfile</code>, and project CLAUDE.md on 2026-05-23.
+  Built from <code>~/.config/fish/</code>, <code>Brewfile</code>, and project CLAUDE.md on 2026-05-25.
   Refresh after meaningful color-tooling changes.
 </footer>
 

--- a/scripts/test-theme-font-stats.sh
+++ b/scripts/test-theme-font-stats.sh
@@ -1,0 +1,73 @@
+#!/opt/homebrew/bin/bash
+# Smoke test for theme-set/font-set --stats + bare readout. Drives the pure
+# fish helpers directly with a fixture history and a fixed "now" so durations
+# are deterministic. Never touches live symlinks or the apply path.
+set -uo pipefail
+
+DOTFILES="$(cd "$(dirname "$0")/.." && pwd)"
+FISH_DIR="$DOTFILES/.config/fish"
+
+if ! command -v fish >/dev/null 2>&1; then
+  echo "⏭️  fish not installed — skipping"
+  exit 0
+fi
+
+pass=0
+fail=0
+fail_msgs=()
+
+# Run a fish snippet with our functions autoloaded from the repo (not ~/.config).
+fishrun() {
+  fish -c "set -p fish_function_path '$FISH_DIR/functions'; $1"
+}
+
+assert_eq() {
+  local got="$1" want="$2" desc="$3"
+  if [ "$got" = "$want" ]; then
+    pass=$((pass+1)); echo "  PASS  $desc"
+  else
+    fail=$((fail+1))
+    fail_msgs+=("FAIL  $desc"$'\n'"        got:  $got"$'\n'"        want: $want")
+    echo "  FAIL  $desc"
+  fi
+}
+
+assert_contains() {
+  local hay="$1" needle="$2" desc="$3"
+  if printf '%s' "$hay" | grep -qF -- "$needle"; then
+    pass=$((pass+1)); echo "  PASS  $desc"
+  else
+    fail=$((fail+1))
+    fail_msgs+=("FAIL  $desc"$'\n'"        wanted substring: $needle"$'\n'"        in: $hay")
+    echo "  FAIL  $desc"
+  fi
+}
+
+assert_not_contains() {
+  local hay="$1" needle="$2" desc="$3"
+  if printf '%s' "$hay" | grep -qF -- "$needle"; then
+    fail=$((fail+1))
+    fail_msgs+=("FAIL  $desc"$'\n'"        unwanted substring present: $needle"$'\n'"        in: $hay")
+    echo "  FAIL  $desc"
+  else
+    pass=$((pass+1)); echo "  PASS  $desc"
+  fi
+}
+
+echo "── name lists ──"
+theme_count="$(fishrun '__theme_set_names | count')"
+assert_eq "$theme_count" "10" "__theme_set_names emits 10 themes"
+assert_contains "$(fishrun '__theme_set_names')" "rose-pine-moon" "theme list includes rose-pine-moon"
+font_count="$(fishrun '__font_set_names | count')"
+assert_eq "$font_count" "17" "__font_set_names emits 17 fonts"
+assert_contains "$(fishrun '__font_set_names')" "jetbrains" "font list includes jetbrains"
+
+# ── (later tasks append sections above this summary block) ──
+
+echo
+if [ "$fail" -gt 0 ]; then
+  echo "❌ $fail failed, $pass passed"
+  printf '%s\n' "${fail_msgs[@]}"
+  exit 1
+fi
+echo "✅ all $pass checks passed"

--- a/scripts/test-theme-font-stats.sh
+++ b/scripts/test-theme-font-stats.sh
@@ -62,6 +62,15 @@ font_count="$(fishrun '__font_set_names | count')"
 assert_eq "$font_count" "17" "__font_set_names emits 17 fonts"
 assert_contains "$(fishrun '__font_set_names')" "jetbrains" "font list includes jetbrains"
 
+echo "── duration formatters ──"
+assert_eq "$(fishrun '__theme_font_dur 293040')" "3d 9h 24m" "dur multi-day drops seconds"
+assert_eq "$(fishrun '__theme_font_dur 3900')"   "1h 5m"     "dur hours"
+assert_eq "$(fishrun '__theme_font_dur 72')"     "1m 12s"    "dur minutes+seconds"
+assert_eq "$(fishrun '__theme_font_dur 42')"     "42s"       "dur seconds only"
+assert_eq "$(fishrun '__theme_font_ago 259200')" "3d ago"    "ago top unit days"
+assert_eq "$(fishrun '__theme_font_ago 18000')"  "5h ago"    "ago top unit hours"
+assert_eq "$(fishrun '__theme_font_ago 30')"     "just now"  "ago under a minute"
+
 # ── (later tasks append sections above this summary block) ──
 
 echo

--- a/scripts/test-theme-font-stats.sh
+++ b/scripts/test-theme-font-stats.sh
@@ -71,6 +71,25 @@ assert_eq "$(fishrun '__theme_font_ago 259200')" "3d ago"    "ago top unit days"
 assert_eq "$(fishrun '__theme_font_ago 18000')"  "5h ago"    "ago top unit hours"
 assert_eq "$(fishrun '__theme_font_ago 30')"     "just now"  "ago under a minute"
 
+echo "── history parser ──"
+fixture="$(mktemp)"
+cat >"$fixture" <<'EOF'
+- cmd: theme-set frappe
+  when: 1778000000
+- cmd: theme-set catpuccin
+  when: 1778000100
+- cmd: ls
+  when: 1778000200
+- cmd: theme-set solarized
+  when: 1778000300
+- cmd: theme-set rose-pine-moon
+  when: 1778000400
+EOF
+hist_out="$(FISH_HISTORY_FILE="$fixture" fishrun '__theme_font_history theme-set (__theme_set_names)')"
+want_hist="$(printf '1778000000\tfrappe\n1778000300\tsolarized\n1778000400\trose-pine-moon')"
+assert_eq "$hist_out" "$want_hist" "history parser: drops typos, keeps valid, sorted asc"
+rm -f "$fixture"
+
 # ── (later tasks append sections above this summary block) ──
 
 echo

--- a/scripts/test-theme-font-stats.sh
+++ b/scripts/test-theme-font-stats.sh
@@ -124,6 +124,27 @@ out_all="$(printf '%s' "$rows2" | THEME_FONT_STATS_NOW=1778194400 \
   fishrun '__theme_font_stats_report THEME rose-pine-moon 1 (__theme_set_names)')"
 assert_contains "$out_all" "gruvbox" "render --all: sub-minute gruvbox shown"
 
+echo "── theme-set dispatcher ──"
+tfix="$(mktemp)"
+cat >"$tfix" <<'EOF'
+- cmd: theme-set frappe
+  when: 1778000000
+- cmd: theme-set rose-pine-moon
+  when: 1778108000
+EOF
+# --stats: no name arg → should print a report, not the usage error.
+stats_out="$(FISH_HISTORY_FILE="$tfix" THEME_FONT_STATS_NOW=1778194400 \
+  fishrun 'theme-set --stats')"
+assert_contains "$stats_out" "frappe" "theme-set --stats prints report"
+assert_not_contains "$stats_out" "Usage:" "theme-set --stats is not the usage error"
+# --help still shows usage.
+help_out="$(fishrun 'theme-set --help')"
+assert_contains "$help_out" "Usage:" "theme-set --help shows usage"
+# Invalid name still errors (stderr captured).
+inv_out="$(fishrun 'theme-set bogus' 2>&1)"
+assert_contains "$inv_out" "Usage:" "theme-set <invalid> still errors"
+rm -f "$tfix"
+
 # ── (later tasks append sections above this summary block) ──
 
 echo

--- a/scripts/test-theme-font-stats.sh
+++ b/scripts/test-theme-font-stats.sh
@@ -105,6 +105,25 @@ assert_contains "$agg" $'rose-pine-moon\t86400\t1\t1778108000' "agg: rpm total 1
 first_line="$(printf '%s' "$agg" | head -1 | cut -f1)"
 assert_eq "$first_line" "rose-pine-moon" "agg: ties broken by most-recent last-set (rpm first)"
 
+echo "── report rendering ──"
+# Add a sub-minute taste of gruvbox between solarized and rpm.
+rows2="$(printf '1778000000\tfrappe\n1778086400\tsolarized\n1778107970\tgruvbox\n1778108000\trose-pine-moon')"
+# gruvbox active 1778107970→1778108000 = 30s (sub-minute → hidden by default).
+out_default="$(printf '%s' "$rows2" | THEME_FONT_STATS_NOW=1778194400 \
+  fishrun '__theme_font_stats_report THEME rose-pine-moon 0 (__theme_set_names)')"
+assert_contains "$out_default" "← current" "render: current row marked"
+assert_contains "$out_default" "rose-pine-moon" "render: current name present"
+assert_not_contains "$out_default" "gruvbox  " "render: sub-minute gruvbox hidden by default"
+assert_contains "$out_default" "short selections hidden" "render: hidden-count line shown"
+assert_contains "$out_default" "— never" "render: never-used names listed"
+assert_contains "$out_default" "tracked window" "render: footer present"
+# Piped output must be plain (no ANSI escape introducer).
+assert_not_contains "$out_default" $'\e[' "render: no ANSI escapes when piped"
+
+out_all="$(printf '%s' "$rows2" | THEME_FONT_STATS_NOW=1778194400 \
+  fishrun '__theme_font_stats_report THEME rose-pine-moon 1 (__theme_set_names)')"
+assert_contains "$out_all" "gruvbox" "render --all: sub-minute gruvbox shown"
+
 # ── (later tasks append sections above this summary block) ──
 
 echo

--- a/scripts/test-theme-font-stats.sh
+++ b/scripts/test-theme-font-stats.sh
@@ -90,6 +90,21 @@ want_hist="$(printf '1778000000\tfrappe\n1778000300\tsolarized\n1778000400\trose
 assert_eq "$hist_out" "$want_hist" "history parser: drops typos, keeps valid, sorted asc"
 rm -f "$fixture"
 
+echo "── report aggregation ──"
+# Three selections; now is 1d after the last switch.
+# frappe: 1778000000→1778086400 = 86400s (1d)
+# solarized: 1778086400→1778108000 = 21600s (6h)
+# rose-pine-moon: 1778108000→now(1778194400) = 86400s (1d), current
+rows="$(printf '1778000000\tfrappe\n1778086400\tsolarized\n1778108000\trose-pine-moon')"
+agg="$(printf '%s' "$rows" | THEME_FONT_STATS_NOW=1778194400 \
+      fishrun '__theme_font_stats_report --raw THEME rose-pine-moon 0 (__theme_set_names)')"
+# Expect rose-pine-moon and frappe tied at 86400 (rpm first by name? define: stable, ties broken by last-set desc → rpm before frappe), solarized last.
+assert_contains "$agg" $'frappe\t86400\t1\t1778000000' "agg: frappe total 1d, sw 1"
+assert_contains "$agg" $'solarized\t21600\t1\t1778086400' "agg: solarized total 6h"
+assert_contains "$agg" $'rose-pine-moon\t86400\t1\t1778108000' "agg: rpm total 1d, current"
+first_line="$(printf '%s' "$agg" | head -1 | cut -f1)"
+assert_eq "$first_line" "rose-pine-moon" "agg: ties broken by most-recent last-set (rpm first)"
+
 # ── (later tasks append sections above this summary block) ──
 
 echo

--- a/scripts/test-theme-font-stats.sh
+++ b/scripts/test-theme-font-stats.sh
@@ -145,6 +145,25 @@ inv_out="$(fishrun 'theme-set bogus' 2>&1)"
 assert_contains "$inv_out" "Usage:" "theme-set <invalid> still errors"
 rm -f "$tfix"
 
+echo "── font-set dispatcher ──"
+ffix="$(mktemp)"
+cat >"$ffix" <<'EOF'
+- cmd: font-set jetbrains
+  when: 1778000000
+- cmd: font-set monaspace Bold 14
+  when: 1778108000
+EOF
+fstats="$(FISH_HISTORY_FILE="$ffix" THEME_FONT_STATS_NOW=1778194400 \
+  fishrun 'font-set --stats')"
+assert_contains "$fstats" "monaspace" "font-set --stats prints report"
+assert_not_contains "$fstats" "Usage:" "font-set --stats is not the usage error"
+# weight/size-only re-run merges into family: jetbrains appears once, monaspace once.
+mono_rows="$(printf '%s' "$fstats" | grep -c 'monaspace')"
+assert_eq "$mono_rows" "1" "font-set --stats: monaspace merged to one row"
+fhelp="$(fishrun 'font-set --help' 2>&1)"
+assert_contains "$fhelp" "Usage:" "font-set --help shows usage"
+rm -f "$ffix"
+
 # ── (later tasks append sections above this summary block) ──
 
 echo

--- a/scripts/test-theme-font-stats.sh
+++ b/scripts/test-theme-font-stats.sh
@@ -164,6 +164,14 @@ fhelp="$(fishrun 'font-set --help' 2>&1)"
 assert_contains "$fhelp" "Usage:" "font-set --help shows usage"
 rm -f "$ffix"
 
+echo "── completions ──"
+tc="$(fish -c "set -p fish_complete_path '$FISH_DIR/completions'; set -p fish_function_path '$FISH_DIR/functions'; complete -C 'theme-set --'")"
+assert_contains "$tc" "--stats" "theme-set completes --stats"
+assert_contains "$tc" "--all" "theme-set completes --all"
+fc="$(fish -c "set -p fish_complete_path '$FISH_DIR/completions'; set -p fish_function_path '$FISH_DIR/functions'; complete -C 'font-set --'")"
+assert_contains "$fc" "--stats" "font-set completes --stats"
+assert_contains "$fc" "--all" "font-set completes --all"
+
 # ── (later tasks append sections above this summary block) ──
 
 echo

--- a/scripts/test-theme-font-stats.sh
+++ b/scripts/test-theme-font-stats.sh
@@ -172,6 +172,43 @@ fc="$(fish -c "set -p fish_complete_path '$FISH_DIR/completions'; set -p fish_fu
 assert_contains "$fc" "--stats" "font-set completes --stats"
 assert_contains "$fc" "--all" "font-set completes --all"
 
+echo "── bare readout ──"
+rofix="$(mktemp)"
+cat >"$rofix" <<'EOF'
+- cmd: theme-set frappe
+  when: 1778000000
+- cmd: theme-set rose-pine-moon
+  when: 1778108000
+EOF
+# Stub __theme_set_current / __font_set_current so the readout doesn't depend on
+# live symlinks. now is 1d (86400s) after the last switch.
+tro="$(FISH_HISTORY_FILE="$rofix" THEME_FONT_STATS_NOW=1778194400 \
+  fishrun 'function __theme_set_current; echo rose-pine-moon; end; theme-set' 2>&1)"
+assert_contains "$tro" "theme → rose-pine-moon" "theme readout: shows current theme"
+assert_contains "$tro" "1d ago" "theme readout: shows 'set ... (1d ago)'"
+assert_not_contains "$tro" "math: Error" "theme readout: no math errors"
+assert_not_contains "$tro" "1970-01-01" "theme readout: timestamp not epoch-zero"
+
+fro="$(FISH_HISTORY_FILE="$rofix" THEME_FONT_STATS_NOW=1778194400 \
+  fishrun 'function __font_set_current; echo monaspace; end; font-set' 2>&1)"
+# monaspace has no history rows here → 'before history', not a math error.
+assert_contains "$fro" "font → monaspace" "font readout: shows current font"
+assert_not_contains "$fro" "math: Error" "font readout: no math errors"
+
+# A font that IS in history extracts its timestamp cleanly.
+fro2fix="$(mktemp)"
+cat >"$fro2fix" <<'EOF'
+- cmd: font-set jetbrains
+  when: 1778000000
+- cmd: font-set monaspace Bold 14
+  when: 1778108000
+EOF
+fro2="$(FISH_HISTORY_FILE="$fro2fix" THEME_FONT_STATS_NOW=1778194400 \
+  fishrun 'function __font_set_current; echo monaspace; end; font-set' 2>&1)"
+assert_contains "$fro2" "1d ago" "font readout: extracts last-set timestamp"
+assert_not_contains "$fro2" "1970-01-01" "font readout: timestamp not epoch-zero"
+rm -f "$rofix" "$fro2fix"
+
 # ── (later tasks append sections above this summary block) ──
 
 echo


### PR DESCRIPTION
Closes #298

## ✨ What
- `theme-set --stats` / `font-set --stats [--all]` — per-name usage report (active time, %, switch count, last set) parsed from `fish_history`.
- Bare `theme-set` / `font-set` — current selection + when it was set (font shows family + weight + size).
- `--help` retained; completions for `--stats` / `--all` / `--help`.

## 🛠️ How
- Focused, independently-testable fish helpers (history parser, aggregator, table renderer, duration formatters, name-list + current-selection helpers) behind an early-return dispatcher. The existing apply path in `theme-set` / `font-set` is unchanged.

## ✅ Tests
- New `scripts/test-theme-font-stats.sh` (44 checks) — name lists, duration math, history parsing, aggregation, rendering, dispatchers, completions, bare readout.
- 🔁 Regression: `test-fish-loads.sh` clean, `test-theme-switch.sh` 66/66 (apply path untouched).
- 👀 Manual TTY eyeball: dimmed header, bold-cyan `← current` row, hidden-count + footer; color on TTY, plain when piped.

## ⚠️ Notes
- 🐟 fish 4.7.1: `string collect` no longer reads stdin — the smoke test pipes fixtures straight into the consumer.
- 🐛 Caught + fixed a readout regex bug: `string match -r "\t\$cur\$"` returned only the matched `<tab>name` portion, losing the epoch (timestamp fell back to 1970). Anchored to `^.+\t\$cur\$`.