### PR TITLE
🎫 Add `i` — issue→worktree session launcher

### DIFF
--- a/.config/fish/completions/i.fish
+++ b/.config/fish/completions/i.fish
@@ -1,0 +1,26 @@
+# i — completion for the issue→worktree launcher (bin/i).
+#
+#   pos 1  -> open GitHub issues in cwd's repo (number + title), via `gh`.
+#   pos 2+ -> slug / free text, no completion.
+#
+# File completion is disabled. Network-backed (gh), so it's a deliberate tab —
+# bounded with --limit to keep it snappy.
+
+function __i_token_count
+    # Positional-arg index the user is about to type (mirrors __s_token_count).
+    set -l toks (commandline -opc)
+    math (count $toks) - 1
+end
+
+function __i_open_issues
+    # "<number>\t<title>" — fish shows the number as the candidate and the
+    # title as its description.
+    gh issue list --state open --limit 50 --json number,title 2>/dev/null \
+        | jq -r '.[] | "\(.number)\t\(.title)"' 2>/dev/null
+end
+
+# Disable file completion for `i`.
+complete -c i -f
+
+# pos 1: open issue numbers (titles as descriptions).
+complete -c i -n 'test (__i_token_count) -eq 0' -a '(__i_open_issues)'

--- a/bin/i
+++ b/bin/i
@@ -15,7 +15,11 @@
 #
 # One-time per repo:  bd config set github.repository <owner/repo>
 # (GITHUB_TOKEN is auto-sourced from `gh auth token` below — no manual token.)
-# Requires: bd, wt, sesh, tmux, jq, gh, and `s` on PATH.
+# Requires: bd, wt, sesh, tmux, jq, gh, `s` on PATH (claude optional, for slugs).
+#
+# Branch slug: a smart <=20-char slug via `claude -p` (Haiku) by default; set
+# I_SLUG_LLM=0 for the fast deterministic slug. Either way it falls back to the
+# deterministic slug if the model call fails or returns junk.
 #
 # CONFIRM ON FIRST RUN (couldn't verify without GitHub creds + network):
 #   • `bd github pull "$n"` arg form — if a bare number isn't recognised as a
@@ -42,6 +46,20 @@ slugify() {
     | cut -c1-32 | sed -E 's/-+$//'
 }
 
+# Smart slug via `claude -p` (Haiku): a <=20-char, 1-3 word slug capturing the
+# essence. Hard-sanitised and validated; prints nothing (caller falls back) on
+# failure or non-compliant output. NB: `claude -p` loads your Claude config, so
+# it's a couple of seconds, not instant.
+slugify_llm() {
+  command -v claude >/dev/null 2>&1 || return 1
+  local raw cand
+  raw=$(printf 'Generate a git branch slug for this issue title. Output ONLY the slug: lowercase, 1-3 words joined by single hyphens, max 20 characters, capturing the essence. No quotes, no explanation.\n\nTitle: %s\n' "$1" \
+        | claude -p --model haiku 2>/dev/null | head -n1) || return 1
+  cand=$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]' \
+        | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//' | cut -c1-20 | sed -E 's/-+$//')
+  [[ "$cand" =~ ^[a-z0-9]+(-[a-z0-9]+){0,3}$ ]] && printf '%s' "$cand"
+}
+
 # Main checkout path (works from inside a secondary worktree too — mirrors bin/s).
 common=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || {
   echo "i: not in a git repo" >&2; exit 1; }
@@ -65,7 +83,14 @@ id=$(bd -C "$main" list --json 2>/dev/null \
 
 # 2. Branch name + shape the bead for /mc:* — in MAIN, before the worktree snapshot.
 title=$(bd -C "$main" show "$id" --json 2>/dev/null | jq -r '.[0].title // ""')
-slug="${2:-$(slugify "$title")}"; [[ -n "$slug" ]] || slug="work"
+if [[ -n "${2:-}" ]]; then
+  slug="$2"                                                      # explicit slug wins
+else
+  slug=""
+  [[ "${I_SLUG_LLM:-1}" = 1 ]] && slug=$(slugify_llm "$title")   # smart, <=20 chars
+  [[ -n "$slug" ]] || slug=$(slugify "$title")                   # deterministic fallback
+fi
+[[ -n "$slug" ]] || slug="work"
 branch="$n-$slug"
 
 bd -C "$main" update "$id" --type feature >/dev/null

--- a/bin/i
+++ b/bin/i
@@ -15,11 +15,10 @@
 #
 # One-time per repo:  bd config set github.repository <owner/repo>
 # (GITHUB_TOKEN is auto-sourced from `gh auth token` below — no manual token.)
-# Requires: bd, wt, sesh, tmux, jq, gh, `s` on PATH (claude optional, for slugs).
+# Requires: bd, wt, sesh, tmux, jq, gh, `s` on PATH (claude for the slug).
 #
-# Branch slug: a smart <=20-char slug via `claude -p` (Haiku) by default; set
-# I_SLUG_LLM=0 for the fast deterministic slug. Either way it falls back to the
-# deterministic slug if the model call fails or returns junk.
+# Branch slug: from the issue title via `claude -p` (Haiku), <=20 chars. Falls
+# back to just the issue number if claude is unavailable. Override: `i <n> <slug>`.
 #
 # CONFIRM ON FIRST RUN (couldn't verify without GitHub creds + network):
 #   • `bd github pull "$n"` arg form — if a bare number isn't recognised as a
@@ -32,32 +31,15 @@ set -euo pipefail
 n="${1:?usage: i <issue-number> [slug]}"
 [[ "$n" =~ ^[0-9]+$ ]] || { echo "i: issue must be a number, got '$n'" >&2; exit 1; }
 
-# Short branch slug: lowercase, drop noise words, keep the first few meaningful
-# words. The issue number already makes the branch unique, so this is just a
-# hint. Tune length with I_SLUG_WORDS (default 3); 32-char backstop.
-slugify() {
-  printf '%s\n' "$1" \
+# Branch slug from the issue title via `claude -p` (Haiku): lowercase, 1-3
+# words, <=20 chars. Sanitised to a safe branch ref; prints nothing if claude
+# is missing or returns blank (caller then uses just the issue number).
+claude_slug() {
+  command -v claude >/dev/null 2>&1 || return 0
+  printf 'Make a git branch slug for this issue title: lowercase, 1-3 words, hyphen-separated, max 20 chars, capturing the essence. Output ONLY the slug.\n\nTitle: %s\n' "$1" \
+    | claude -p --model haiku 2>/dev/null | head -n1 \
     | tr '[:upper:]' '[:lower:]' \
-    | tr -c 'a-z0-9' '\n' \
-    | grep -vxE 'a|an|the|to|of|for|in|on|at|by|and|or|but|with|from|into|is|are|be|as|that|this' \
-    | grep -v '^$' \
-    | head -n "${I_SLUG_WORDS:-3}" \
-    | paste -sd- - \
-    | cut -c1-32 | sed -E 's/-+$//'
-}
-
-# Smart slug via `claude -p` (Haiku): a <=20-char, 1-3 word slug capturing the
-# essence. Hard-sanitised and validated; prints nothing (caller falls back) on
-# failure or non-compliant output. NB: `claude -p` loads your Claude config, so
-# it's a couple of seconds, not instant.
-slugify_llm() {
-  command -v claude >/dev/null 2>&1 || return 1
-  local raw cand
-  raw=$(printf 'Generate a git branch slug for this issue title. Output ONLY the slug: lowercase, 1-3 words joined by single hyphens, max 20 characters, capturing the essence. No quotes, no explanation.\n\nTitle: %s\n' "$1" \
-        | claude -p --model haiku 2>/dev/null | head -n1) || return 1
-  cand=$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]' \
-        | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//' | cut -c1-20 | sed -E 's/-+$//')
-  [[ "$cand" =~ ^[a-z0-9]+(-[a-z0-9]+){0,3}$ ]] && printf '%s' "$cand"
+    | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//' | cut -c1-20 | sed -E 's/-+$//'
 }
 
 # Main checkout path (works from inside a secondary worktree too — mirrors bin/s).
@@ -83,15 +65,8 @@ id=$(bd -C "$main" list --json 2>/dev/null \
 
 # 2. Branch name + shape the bead for /mc:* — in MAIN, before the worktree snapshot.
 title=$(bd -C "$main" show "$id" --json 2>/dev/null | jq -r '.[0].title // ""')
-if [[ -n "${2:-}" ]]; then
-  slug="$2"                                                      # explicit slug wins
-else
-  slug=""
-  [[ "${I_SLUG_LLM:-1}" = 1 ]] && slug=$(slugify_llm "$title")   # smart, <=20 chars
-  [[ -n "$slug" ]] || slug=$(slugify "$title")                   # deterministic fallback
-fi
-[[ -n "$slug" ]] || slug="work"
-branch="$n-$slug"
+slug="${2:-$(claude_slug "$title")}"   # explicit arg wins; else claude
+branch="$n${slug:+-$slug}"             # <n>-<slug>, or just <n> if no slug
 
 bd -C "$main" update "$id" --type feature >/dev/null
 bd -C "$main" label add "$id" "branch:$branch" >/dev/null

--- a/bin/i
+++ b/bin/i
@@ -1,0 +1,71 @@
+#!/opt/homebrew/bin/bash
+# i — issue-driven worktree session (an `s` wrapper).
+#
+#   i <issue> [slug]
+#
+# From inside a project repo:
+#   1. pulls GitHub issue <issue> into beads — PULL-ONLY, never `bd github sync`
+#      (a bare sync would push your local/stealth beads to GitHub).
+#   2. shapes the bead for the /mc:* workflow: type=feature + a `branch:<name>`
+#      label, set in the MAIN .beads/ *before* the worktree is made so
+#      worktrunk's post-start copy-ignored carries the labelled bead in.
+#   3. hands off to `s`, which makes the worktree + tmux session and launches
+#      claude seeded with `/mc:brainstorm` (no issue number — it loads the
+#      issue from the branch's feature bead).
+#
+# One-time per repo:  bd config set github.repository <owner/repo>  + GITHUB_TOKEN
+# Requires: bd, wt, sesh, tmux, jq, and `s` on PATH.
+#
+# CONFIRM ON FIRST RUN (couldn't verify without GitHub creds + network):
+#   • `bd github pull "$n"` arg form — if a bare number isn't recognised as a
+#     GitHub ref, try `github:$n` or the issue URL (the github tracker matches
+#     /issues/<n> and a github:<n> shorthand).
+#   • `claude "/mc:brainstorm"` — confirm this starts an INTERACTIVE session
+#     seeded with that command (vs `-p`, which is headless).
+set -euo pipefail
+
+n="${1:?usage: i <issue-number> [slug]}"
+[[ "$n" =~ ^[0-9]+$ ]] || { echo "i: issue must be a number, got '$n'" >&2; exit 1; }
+
+# Compact slugify: lowercase, non-alnum -> hyphen, trim, cap 40 chars.
+slugify() {
+  printf '%s' "$1" \
+    | tr '[:upper:]' '[:lower:]' \
+    | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//' \
+    | cut -c1-40 | sed -E 's/-+$//'
+}
+
+# Main checkout path (works from inside a secondary worktree too — mirrors bin/s).
+common=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || {
+  echo "i: not in a git repo" >&2; exit 1; }
+main=$(cd "$(dirname "$common")" && pwd -P)
+
+bd -C "$main" status >/dev/null 2>&1 || {
+  echo "i: beads not initialised in $main (run 'bd init' + set github.repository once)" >&2; exit 1; }
+
+# 1. PULL-ONLY ingest.
+echo "i: pulling issue #$n into beads…" >&2
+bd -C "$main" github pull "$n" >/dev/null
+
+# Resolve the pulled bead by its GitHub external_ref (issue URL, or github:<n>
+# shorthand fallback). bd --json output is an array.
+id=$(bd -C "$main" list --json 2>/dev/null \
+  | jq -r --arg n "$n" '[.[] | select((.external_ref // "") | test("(/issues/|github:)" + $n + "$"))][0].id // empty')
+[[ -n "$id" ]] || { echo "i: couldn't find the pulled bead for issue #$n (check github config / pull arg form)" >&2; exit 1; }
+
+# 2. Branch name + shape the bead for /mc:* — in MAIN, before the worktree snapshot.
+title=$(bd -C "$main" show "$id" --json 2>/dev/null | jq -r '.[0].title // ""')
+slug="${2:-$(slugify "$title")}"; [[ -n "$slug" ]] || slug="work"
+branch="$n-$slug"
+
+bd -C "$main" update "$id" --type feature >/dev/null
+bd -C "$main" label add "$id" "branch:$branch" >/dev/null
+
+# 3. Hand off to `s` (worktree + tmux + seeded claude). `s` runs
+#    ${S_CLAUDE_CMD:-claude} in window 1; we seed Phase 1 (Opus, max effort).
+project=$(sesh list -c -j 2>/dev/null | jq -r --arg p "$main" '.[] | select(.Path == $p) | .Name' | head -n1)
+[[ -n "$project" ]] || { echo "i: $main is not in your sesh config" >&2; exit 1; }
+
+echo "i: issue #$n → bead $id → branch $branch" >&2
+S_CLAUDE_CMD='CLAUDE_CODE_EFFORT_LEVEL=max claude --model opus "/mc:brainstorm"' \
+  exec s "$project" "$branch"

--- a/bin/i
+++ b/bin/i
@@ -13,8 +13,9 @@
 #      claude seeded with `/mc:brainstorm` (no issue number — it loads the
 #      issue from the branch's feature bead).
 #
-# One-time per repo:  bd config set github.repository <owner/repo>  + GITHUB_TOKEN
-# Requires: bd, wt, sesh, tmux, jq, and `s` on PATH.
+# One-time per repo:  bd config set github.repository <owner/repo>
+# (GITHUB_TOKEN is auto-sourced from `gh auth token` below — no manual token.)
+# Requires: bd, wt, sesh, tmux, jq, gh, and `s` on PATH.
 #
 # CONFIRM ON FIRST RUN (couldn't verify without GitHub creds + network):
 #   • `bd github pull "$n"` arg form — if a bare number isn't recognised as a
@@ -42,6 +43,9 @@ main=$(cd "$(dirname "$common")" && pwd -P)
 
 bd -C "$main" status >/dev/null 2>&1 || {
   echo "i: beads not initialised in $main (run 'bd init' + set github.repository once)" >&2; exit 1; }
+
+# GitHub token for the bd github bridge — sourced fresh from gh, never stored.
+export GITHUB_TOKEN="${GITHUB_TOKEN:-$(gh auth token 2>/dev/null)}"
 
 # 1. PULL-ONLY ingest.
 echo "i: pulling issue #$n into beads…" >&2

--- a/bin/i
+++ b/bin/i
@@ -28,12 +28,18 @@ set -euo pipefail
 n="${1:?usage: i <issue-number> [slug]}"
 [[ "$n" =~ ^[0-9]+$ ]] || { echo "i: issue must be a number, got '$n'" >&2; exit 1; }
 
-# Compact slugify: lowercase, non-alnum -> hyphen, trim, cap 40 chars.
+# Short branch slug: lowercase, drop noise words, keep the first few meaningful
+# words. The issue number already makes the branch unique, so this is just a
+# hint. Tune length with I_SLUG_WORDS (default 3); 32-char backstop.
 slugify() {
-  printf '%s' "$1" \
+  printf '%s\n' "$1" \
     | tr '[:upper:]' '[:lower:]' \
-    | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//' \
-    | cut -c1-40 | sed -E 's/-+$//'
+    | tr -c 'a-z0-9' '\n' \
+    | grep -vxE 'a|an|the|to|of|for|in|on|at|by|and|or|but|with|from|into|is|are|be|as|that|this' \
+    | grep -v '^$' \
+    | head -n "${I_SLUG_WORDS:-3}" \
+    | paste -sd- - \
+    | cut -c1-32 | sed -E 's/-+$//'
 }
 
 # Main checkout path (works from inside a secondary worktree too — mirrors bin/s).

--- a/bin/s
+++ b/bin/s
@@ -64,12 +64,13 @@ resolve_project_name() {
     | head -n1
 }
 
-# Lay out a brand-new worktree session: window 1 runs claude, window 2
-# is a blank shell. -d on new-window keeps the active window unchanged,
-# so the user sees no flicker when the session attaches.
+# Lay out a brand-new worktree session: window 1 runs the launch command
+# (${S_CLAUDE_CMD:-claude} — `i` overrides it to seed `/mc:brainstorm`),
+# window 2 is a blank shell. -d on new-window keeps the active window
+# unchanged, so the user sees no flicker when the session attaches.
 bootstrap_worktree_windows() {
   local session="$1" target_path="$2"
-  tmux send-keys -t "$session" 'claude' Enter
+  tmux send-keys -t "$session" "${S_CLAUDE_CMD:-claude}" Enter
   tmux new-window -d -t "$session" -c "$target_path"
 }
 


### PR DESCRIPTION
## 🎫 Summary

`i <issue> [slug]` turns a GitHub issue number into a ready-to-work worktree session in one command — composing tools already on the box (`bd`, `wt`, `sesh`, `tmux`, `s`), no orchestration platform.

It does:
1. 📥 **pull** the issue into beads — `bd github pull` (pull-only; never a bare `sync`, which would push local/stealth beads)
2. 🏷️ **shape** the bead for `/mc:*` — `type=feature` + `branch:<n>-<slug>` label, set in the **main** checkout before the worktree snapshot (so worktrunk's `copy-ignored` carries the labelled bead into the worktree)
3. 🚀 **hand off to `s`** — which makes the worktree + tmux session and launches an Opus session seeded with `/mc:brainstorm` (no issue number — it loads the issue from the bead)

## 🔧 Changes

- **`bin/i`** (new, `+x`) — the launcher: inline slugify, fail-loud guards, resolves the pulled bead by its `external_ref`.
- **`bin/s`** — window 1 now runs `${S_CLAUDE_CMD:-claude}` (default unchanged → plain `s` is identical); `i` overrides it to seed brainstorm, reusing all of s's worktree/tmux logic.

## 🧪 Test plan

- [x] `bash -n bin/i` / `bash -n bin/s` clean; `bin/i` is executable
- [ ] One-time: `bd config set github.repository <owner/repo>` + `GITHUB_TOKEN`
- [ ] `i <issue>` end-to-end: pull → worktree → seeded brainstorm session

## ⚠️ Confirm on first run (couldn't verify without GitHub creds + network)

- `bd github pull "$n"` arg form — if a bare number isn't recognised, use `github:$n` or the issue URL (the resolver already matches both).
- `claude "/mc:brainstorm"` starts an **interactive** session seeded with that command (vs `-p`, which is headless).

Pairs with martinciu/gruppo: `/mc:brainstorm` resolving the issue from the feature bead.