### PR TITLE
📊 mise: keep mermaid-cli's Chromium after the npm `--ignore-scripts` default

### DIFF
--- a/mise.global.toml
+++ b/mise.global.toml
@@ -1,7 +1,9 @@
 [tools]
 node = "lts"
 ruby = "3.4.8"
-"npm:@mermaid-js/mermaid-cli" = "latest"
+# mise 2026.5.13 defaults npm installs to --ignore-scripts; mermaid-cli needs its
+# puppeteer postinstall to fetch Chromium, so opt this one tool back in.
+"npm:@mermaid-js/mermaid-cli" = { version = "latest", npm_args = "--ignore-scripts=false" }
 "npm:ccstatusline" = "latest"
 
 [settings]


### PR DESCRIPTION
## 🎯 What

Pin `npm_args = "--ignore-scripts=false"` on the `npm:@mermaid-js/mermaid-cli` entry in `mise.global.toml`. Every other npm tool keeps the new locked-down default.

## 🤔 Why

mise **2026.5.13** changed the npm backend to install with `--ignore-scripts=true` by default (a supply-chain hardening — it also dropped Bun's auto `--trust`). `mermaid-cli` (`mmdc`) depends on **puppeteer, whose postinstall script downloads Chromium**. With scripts suppressed, the next time the pinned `latest` version bumps and reinstalls, mmdc would come up **browserless** and `scripts/build-diagrams.sh` would fail at render time.

The currently installed mmdc (11.14.0) already has its Chromium, so this is a **pre-emptive fix** for the next reinstall/upgrade, not a fix for a present breakage.

## ✅ Verification

- 🧩 `mise config get tools` parses the new inline table — `version = "latest"`, `npm_args = "--ignore-scripts=false"`.
- 🔌 `mise ls` still resolves `npm:@mermaid-js/mermaid-cli 11.14.0` (no reinstall triggered).
- 🔒 `npm:ccstatusline` (pure JS, no native postinstall) deliberately left on the locked-down default.

## ⚠️ Notes

- Scoped to this one tool — the security benefit of `--ignore-scripts` is preserved everywhere else.
- `mise.global.toml` is symlinked to `~/.config/mise/config.toml`, so the change is live on this machine immediately.
