### PR TITLE
🔧 git: make shared aliases portable via tracked include fragment

### DIFF
--- a/.config/git/aliases.gitconfig
+++ b/.config/git/aliases.gitconfig
@@ -1,0 +1,6 @@
+# Shared git aliases — tracked, portable across machines.
+# Pulled in via an `include.path` line in each machine's ~/.gitconfig
+# (see README → Setup), mirroring how the delta theme config is wired.
+# Machine identity (user/email) stays in ~/.gitconfig and overrides on collision.
+[alias]
+	lo = log --oneline

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,7 +253,8 @@ bootstrap defaults. See "Switchable themes" / "Switchable Ghostty fonts" below.
 
 - Sources in `$PROJECTS_HOME/dotfiles/`: `.config/` (whole-dir: btop,
   ccstatusline, procs, tailspin, tmux, xh; mixed-dir: fish, gh-dash, ghostty,
-  glow, nvim, worktrunk; `themes/` palettes; `starship-*.toml`; partial links
+  git (aliases.gitconfig; `include.path` in ~/.gitconfig), glow, nvim,
+  worktrunk; `themes/` palettes; `starship-*.toml`; partial links
   for sesh + lnav), `.vimrc`, `.vim/colors`, `.gitignore_global`,
   `.claude/CLAUDE.md`. `bin/` files symlink to `~/.local/bin/`.
 - The repo's `.claude/CLAUDE.md` IS the user-global Claude config (symlinked to

--- a/README.md
+++ b/README.md
@@ -59,9 +59,11 @@ hot-swap an existing pane).
 on first run. Edit it to add machine-local project sessions; the shared
 `sesh.toml` is the wrong place for them.
 
-**3. Wire delta into git** (one-time, global). The include line picks up
-delta's theme + chip tweaks from the active theme (see "Switching themes"
-below — `theme-set` flips the included file).
+**3. Wire delta + shared aliases into git** (one-time, global). The delta
+include picks up theme + chip tweaks from the active theme (see "Switching
+themes" below — `theme-set` flips the included file). The aliases include
+pulls in the tracked, portable `[alias]` block (e.g. `git lo`); `bootstrap.sh`
+symlinks the file into `~/.config/git/`, and this line wires it into git.
 
 ```sh
 git config --global core.pager delta
@@ -69,6 +71,7 @@ git config --global interactive.diffFilter "delta --color-only"
 git config --global delta.navigate true
 git config --global delta.line-numbers true
 git config --global include.path "~/.config/themes/delta-current.gitconfig"
+git config --global --add include.path "~/.config/git/aliases.gitconfig"
 ```
 
 **4. `atuin import fish`** — one-time backfill of existing fish history

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -139,6 +139,13 @@ rescue_in_repo "$DOTFILES/.config/worktrunk/approvals.toml" \
                "$HOME/.config/worktrunk/approvals.toml"
 link_tracked_entries ".config/worktrunk" "$HOME/.config/worktrunk"
 
+# --- git
+# ~/.config/git/ is a real dir (often holds a machine-local `ignore`); the
+# tracked aliases.gitconfig is individually symlinked. Pulled into git via an
+# include.path line in ~/.gitconfig (see README → Setup), mirroring delta.
+prepare_real_dir "$HOME/.config/git"
+link_tracked_entries ".config/git" "$HOME/.config/git"
+
 # --- glow
 # ~/.config/glow/ is a real dir; tracked entries (glamour-{solarized,mocha}.json)
 # are individually symlinked. Active glamour.json is a machine-local symlink.


### PR DESCRIPTION
## 🎯 What

Make the `git lo` (= `log --oneline`) alias **portable across machines** by moving it out of the machine-local `~/.gitconfig` into a tracked fragment, wired via `include.path` — exactly mirroring how `delta-current.gitconfig` is already pulled in.

## 🔧 Changes

- **`.config/git/aliases.gitconfig`** (new, tracked) — holds the shared `[alias]` block; future shared aliases go here.
- **`bootstrap.sh`** — new `# --- git` block: `prepare_real_dir` + `link_tracked_entries` per-file-symlinks `aliases.gitconfig` into `~/.config/git/`, leaving the machine-local `ignore` untouched (mixed-dir pattern, same as fish/themes/worktrunk).
- **`README.md`** — Setup step 3 now documents the second `include.path` line next to the delta one.
- **`CLAUDE.md`** — "where things live" lists `git` as a mixed-dir tool.

## 🤔 Why this shape

`~/.gitconfig` is intentionally **not** tracked (it carries machine identity), so aliases can't live there portably. A tracked fragment + `include.path` reuses the established delta mechanism; `~/.gitconfig` still wins on key collisions, so identity is unaffected.

## ✅ Verification

- 🔗 Symlinked the fragment as bootstrap's `link()` would; `git config --show-origin --get alias.lo` now resolves to `~/.config/git/aliases.gitconfig`.
- 🧪 `git lo` works via the include; machine-local `~/.config/git/ignore` left real (not clobbered).
- ✅ `bash -n bootstrap.sh` passes.

## ⚠️ Follow-up — sandbox parity (not in this PR)

`git lo` won't reach the **sandbox** container: its `install-linux.sh` generates a minimal `~/.gitconfig` with only the delta include, and the Dockerfile doesn't COPY `.config/git`. Parity would need a `COPY .config/git` (+ `.dockerignore` allowlist) and a second `include.path` line in the generated gitconfig. Happy to do it here or file a follow-up issue — flagged per the sandbox-parity convention.
