### PR TITLE
🐳 sandbox: bring shared git aliases into the container (`git lo` parity)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,6 +10,7 @@
 !.config/themes
 !.config/glow
 !.config/lnav
+!.config/git
 !.config/starship-solarized.toml
 !.config/starship-mocha.toml
 !.config/starship-frappe.toml

--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -56,6 +56,9 @@ COPY --chown=${USER}:${USER} .config/themes /home/${USER}/.config/themes
 COPY --chown=${USER}:${USER} .config/glow /home/${USER}/.config/glow
 COPY --chown=${USER}:${USER} .config/lnav/configs/installed /home/${USER}/.config/lnav/configs/installed
 COPY --chown=${USER}:${USER} .config/starship-*.toml /home/${USER}/.config/
+# --- shared git aliases (theme-independent static file; the include is wired
+# into the generated ~/.gitconfig by stage_theme below).
+COPY --chown=${USER}:${USER} .config/git /home/${USER}/.config/git
 RUN bash /home/${USER}/.sandbox/install-linux.sh theme solarized
 
 # Persistent idle PID 1 so the container stays up for multiple `docker exec`

--- a/sandbox/install-linux.sh
+++ b/sandbox/install-linux.sh
@@ -148,10 +148,11 @@ stage_theme() {
   [ -f "$cfg/lnav/configs/installed/theme-$name.json" ] \
     && ln -sfn "theme-$name.json" "$cfg/lnav/configs/installed/theme.json"
 
-  # delta git wiring — write a minimal ~/.gitconfig only if absent (the sandbox
-  # ships the delta binary but never wires it as git's pager; mirrors README
-  # step 3). A missing include target is silently ignored by git, so the Latte
-  # floor (delta-solarized.gitconfig) is always present and safe.
+  # git wiring — write a minimal ~/.gitconfig only if absent (the sandbox ships
+  # the delta binary but never wires it as git's pager; mirrors README step 3).
+  # It includes both the theme-dependent delta config and the theme-independent
+  # shared aliases (git lo). A missing include target is silently ignored by git,
+  # so the Latte floor (delta-solarized.gitconfig) is always present and safe.
   if [ ! -f "$HOME/.gitconfig" ]; then
     cat > "$HOME/.gitconfig" <<'GITEOF'
 [core]
@@ -163,6 +164,7 @@ stage_theme() {
 	line-numbers = true
 [include]
 	path = ~/.config/themes/delta-current.gitconfig
+	path = ~/.config/git/aliases.gitconfig
 GITEOF
   fi
 

--- a/scripts/test-sandbox.sh
+++ b/scripts/test-sandbox.sh
@@ -48,6 +48,7 @@ theme_flip_test() {
   cp -R .config/glow "$tmp/.config/glow"
   cp -R .config/lnav/configs/installed "$tmp/.config/lnav/configs/installed"
   cp .config/starship-*.toml "$tmp/.config/"
+  cp -R .config/git "$tmp/.config/git"
 
   # Full-coverage theme: every tool overlays off the floor.
   HOME="$tmp" XDG_CONFIG_HOME="$tmp/.config" bash sandbox/install-linux.sh theme nord
@@ -80,6 +81,10 @@ theme_flip_test() {
     || { echo "❌ nord lnav"; rm -rf "$tmp"; exit 1; }
   grep -q 'pager = delta' "$tmp/.gitconfig" \
     || { echo "❌ nord gitconfig missing delta"; rm -rf "$tmp"; exit 1; }
+  grep -q 'path = ~/.config/git/aliases.gitconfig' "$tmp/.gitconfig" \
+    || { echo "❌ nord gitconfig missing shared aliases include"; rm -rf "$tmp"; exit 1; }
+  [ "$(HOME="$tmp" git -C "$tmp" config --get alias.lo)" = "log --oneline" ] \
+    || { echo "❌ nord git alias 'lo' not resolved via include"; rm -rf "$tmp"; exit 1; }
   # fish 4.x universals are written to ~/.config/fish/fish_variables; reading
   # via `fish -c` hits the running daemon instead, so grep the file directly.
   grep -q 'BAT_THEME:Nord' "$tmp/.config/fish/fish_variables" 2>/dev/null \

--- a/scripts/test-sandbox.sh
+++ b/scripts/test-sandbox.sh
@@ -154,6 +154,13 @@ out="$(docker run --rm sandbox:test bash -lc 'cat ~/.config/starship.toml')"
 [[ "$out" == *"symbol = \"$(printf '\357\205\274')\""* ]] || fail "theme floor missing penguin glyph (U+F17C)"
 pass "theme floor default (generated)"
 
+# git aliases: the shared aliases.gitconfig is baked (Dockerfile COPY + .dockerignore
+# allowlist) and included by the generated ~/.gitconfig, so `git lo` resolves. The only
+# tier that proves the COPY + allowlist worked (the no-docker check cannot).
+out="$(docker run --rm sandbox:test bash -lc 'git config --get alias.lo')"
+[[ "$out" == "log --oneline" ]] || fail "git lo alias not resolved in image: $out"
+pass "git lo alias (shared aliases.gitconfig baked + included)"
+
 out="$(docker run --rm sandbox:test bash -lc '
   bash ~/.sandbox/install-linux.sh theme nord >/dev/null 2>&1
   echo "palette=$(grep -m1 "^palette = " ~/.config/starship.toml)"


### PR DESCRIPTION
## 🎯 What
Make `git lo` resolve inside the sandbox container, matching the host. #303 added the shared, portable `.config/git/aliases.gitconfig` and wired it into the host `~/.gitconfig`; the sandbox never picked it up.

## 🔧 How
- 🧩 `install-linux.sh` — the generated `~/.gitconfig` now `[include]`s both the theme delta config and the theme-independent shared aliases.
- 🐳 `Dockerfile` — bake `.config/git` into the image (static, theme-independent).
- 📦 `.dockerignore` — allowlist `!.config/git` so the COPY isn't re-ignored by `.config/*`.

## 🧪 Test plan
- ✅ `bash scripts/test-sandbox.sh` passes both tiers (no-docker + docker), including a new `git lo` end-to-end assertion against the built image.
- ✅ Manual: `git lo` runs as a real command in a fresh container, emitting the oneline log.

## ⚠️ Notes
- Container-only; machine mode and theme behavior unchanged.
- 🔁 Existing sandbox volumes: the new file reaches only freshly-built images; an existing sandbox needs `rm`+recreate to pick it up (write-when-absent gitconfig).

Closes #304 · Parent: #303