### PR TITLE
🤖 slm: pipe any prompt to the local LM Studio model (lfm2.5)

### DIFF
--- a/.config/fish/functions/slm.fish
+++ b/.config/fish/functions/slm.fish
@@ -1,0 +1,101 @@
+function slm --description 'One-off prompt to the local LM Studio model (lfm2.5)'
+    set -l usage "slm — one-off prompt to the local LM Studio model
+
+Usage:
+  slm [-m <id>] [-s <prompt>] <prompt words...>
+  cat file | slm [-m <id>] [-s <prompt>] [prompt words...]
+
+Flags:
+  -m, --model <id>    model id (default: \$SLM_MODEL or lfm2.5-1.2b-instruct)
+  -s, --system <txt>  system prompt (default: \$SLM_SYSTEM or a terse built-in)
+  -h, --help          show this help
+
+Env:
+  SLM_URL     base URL (default http://localhost:1234/v1)
+  SLM_MODEL   default model id
+  SLM_SYSTEM  default system prompt"
+
+    argparse m/model= s/system= h/help -- $argv
+    or return 2
+
+    if set -q _flag_help
+        echo $usage
+        return 0
+    end
+
+    # Config: flag > env > built-in default.
+    set -l url $SLM_URL
+    test -n "$url"; or set url http://localhost:1234/v1
+
+    set -l model
+    if set -q _flag_model
+        set model $_flag_model
+    else if set -q SLM_MODEL; and test -n "$SLM_MODEL"
+        set model $SLM_MODEL
+    else
+        set model lfm2.5-1.2b-instruct
+    end
+
+    set -l system
+    if set -q _flag_system
+        set system $_flag_system
+    else if set -q SLM_SYSTEM
+        set system $SLM_SYSTEM
+    else
+        set system "You are a terse assistant. Reply with only the answer, no preamble."
+    end
+
+    # User message = args and/or piped stdin (instruction first, then the blob).
+    # Read stdin only when it is not a TTY (mirrors less.fish). NOTE: in a
+    # non-TTY context (script/cron/background) an arg-only call still reads
+    # stdin, so callers there must redirect (e.g. `slm foo </dev/null`).
+    # Capture via `(cat)` + `string join` — NOT `string collect` (fish 4.7.1
+    # no longer reads stdin from a bare `string collect`).
+    set -l instruction (string join ' ' -- $argv)
+    set -l piped ""
+    if not isatty stdin
+        set -l lines (cat)
+        set piped (string join \n $lines)
+    end
+
+    set -l parts
+    test -n "$instruction"; and set -a parts $instruction
+    test -n "$piped"; and set -a parts $piped
+    if test (count $parts) -eq 0
+        echo $usage >&2
+        return 2
+    end
+    set -l content (string join \n\n $parts)
+
+    # Build the request body with jq (safe escaping); omit the system message
+    # when its content is empty (e.g. `-s ""`). Pipe straight to curl so the
+    # JSON never round-trips through a fish variable. `curl -s` (not -sS) so
+    # curl's own connection error doesn't double up with our friendly message.
+    set -l resp (jq -n --arg m "$model" --arg s "$system" --arg u "$content" \
+        '{model:$m, messages:((if $s=="" then [] else [{role:"system",content:$s}] end)+[{role:"user",content:$u}]), temperature:0.3, stream:false}' \
+        | curl -s --connect-timeout 5 --max-time 120 \
+            "$url/chat/completions" -H 'Content-Type: application/json' --data @-)
+    set -l rc $status
+
+    if test $rc -eq 7
+        echo "slm: LM Studio not reachable at $url — run 'lms server start'" >&2
+        return 1
+    else if test $rc -ne 0
+        echo "slm: request failed (curl exit $rc)" >&2
+        return 1
+    end
+
+    # Extract the completion; fall back to the API error, then a generic message.
+    set -l out (printf '%s\n' $resp | jq -r '.choices[0].message.content // empty')
+    if test -z "$out"
+        set -l errmsg (printf '%s\n' $resp | jq -r '.error.message // empty')
+        if test -n "$errmsg"
+            echo "slm: $errmsg" >&2
+        else
+            echo "slm: no response from $model" >&2
+        end
+        return 1
+    end
+
+    printf '%s\n' $out
+end

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,6 +219,17 @@ bootstrap defaults. See "Switchable themes" / "Switchable Ghostty fonts" below.
   Escape `command diff`. Don't pin flags.
 - **`xh` is the HTTP client** (`xh`/`xhs`; `--style=solarized` in
   `.config/xh/config.json`). Don't alias `curl`. No `http`/`https` alias.
+- **`slm` pipes any prompt to the local LM Studio model** (fish function
+  `.config/fish/functions/slm.fish`; LM-Studio-only, Mac-only). One-shot,
+  buffered: args and/or stdin → one `curl` POST to `$SLM_URL/chat/completions`
+  (default `:1234/v1`) with `$SLM_MODEL` (default `lfm2.5-1.2b-instruct`) →
+  prints `.choices[0].message.content`. Uses **`curl`, not `xh`** — raw JSON
+  body via `jq`, the documented exception. Flags `-m`/`-s`/`-h`; env
+  `SLM_URL`/`SLM_MODEL`/`SLM_SYSTEM` (precedence flag > env > built-in). Server
+  not always-on → friendly `lms server start` error on connection refusal, no
+  auto-start. 1.2B model: quick/cheap, not authoritative. **Out of sandbox
+  scope** (LM Studio is a Mac desktop app; in-container `localhost` isn't the
+  host). Smoke: `scripts/test-slm.sh`.
 - **`hyperfine`** for benchmarks (warmups / A-B), additive to `time`. Raw.
 - **`duf`/`dust`/`dua` are modern `df`/`du`/`du`-aggregate companions** (raw, no
   alias; `du`/`df` stay for scripts). `dua i` opens a TUI deleter.
@@ -292,6 +303,7 @@ derivatives, re-run after swapping a source.
 - Theme/font stats: `scripts/test-theme-font-stats.sh`
 - Sandbox smoke: `scripts/test-sandbox.sh`
 - nvimpager smoke: `scripts/test-nvimpager.sh`
+- slm smoke: `scripts/test-slm.sh`
 
 ## First-time setup on a new machine
 

--- a/docs/terminal-cheatsheet.html
+++ b/docs/terminal-cheatsheet.html
@@ -22,7 +22,7 @@
   <div class="hero-inner">
     <h1>Terminal <span class="accent">— Getting Started &amp; Cheatsheet</span></h1>
     <div class="sub">
-      Solarized Dark default (switchable) &middot; eza · bat · git-delta · difftastic · glow · vivid · procs · lnav · xh · fzf · nvimpager · sandbox · vhs
+      Solarized Dark default (switchable) &middot; eza · bat · git-delta · difftastic · glow · vivid · procs · lnav · xh · slm · fzf · nvimpager · sandbox · vhs
     </div>
   </div>
   <a class="hero-cta" href="images/example_terminal.png">view full screenshot</a>
@@ -41,6 +41,7 @@
   <a href="#glow">glow / md</a>
   <a href="#tspin">tspin</a>
   <a href="#xh">xh</a>
+  <a href="#slm">slm</a>
   <a href="#vivid">vivid / LS_COLORS</a>
   <a href="#fzf">fzf</a>
   <a href="#themes">themes / fonts</a>
@@ -484,6 +485,33 @@
       <code>curl</code> verbatim. <code>xh</code>/<code>xhs</code> are the interactive surface only.
     </p>
     <p class="note">Don't alias <code>curl</code> to <code>xh</code>, and don't introduce an <code>http</code>/<code>https</code> alias either — the binary's own name is the only entry point.</p>
+  </div>
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════════════════ -->
+<h2 id="slm">slm <span class="tool-tag">local LLM prompt</span></h2>
+
+<div class="grid">
+  <div class="card">
+    <h3>Usage</h3>
+    <table>
+      <tr><td class="key"><code>slm &lt;prompt words&gt;</code></td><td class="desc">one-off completion from args</td></tr>
+      <tr><td class="key"><code>cat file | slm</code></td><td class="desc">prompt from stdin</td></tr>
+      <tr><td class="key"><code>cat err.log | slm explain this</code></td><td class="desc">args = instruction, stdin = material (joined)</td></tr>
+      <tr><td class="key"><code>slm -m &lt;id&gt; …</code></td><td class="desc">override model for this call</td></tr>
+      <tr><td class="key"><code>slm -s "translate to French" …</code></td><td class="desc">set the system prompt</td></tr>
+      <tr><td class="key"><code>slm -h</code></td><td class="desc">help</td></tr>
+    </table>
+  </div>
+
+  <div class="card">
+    <h3>Env &amp; notes</h3>
+    <table>
+      <tr><td class="key"><code>SLM_URL</code></td><td class="desc">base URL (default <code>http://localhost:1234/v1</code>)</td></tr>
+      <tr><td class="key"><code>SLM_MODEL</code></td><td class="desc">default model (<code>lfm2.5-1.2b-instruct</code>); persist via <code>set -Ux</code></td></tr>
+      <tr><td class="key"><code>SLM_SYSTEM</code></td><td class="desc">default system prompt (terse built-in otherwise)</td></tr>
+    </table>
+    <p class="note">Talks to LM Studio's OpenAI-compatible endpoint via <code>curl</code>. Server isn't always-on — start it with <code>lms server start</code>. It's a 1.2B model: quick &amp; free, not authoritative.</p>
   </div>
 </div>
 

--- a/scripts/test-slm.sh
+++ b/scripts/test-slm.sh
@@ -1,0 +1,91 @@
+#!/opt/homebrew/bin/bash
+# Smoke test for the `slm` fish function (.config/fish/functions/slm.fish).
+# Covers the deterministic no-server paths; the live happy-path is gated on
+# LM Studio being reachable so CI (no LM Studio) still passes.
+set -uo pipefail
+
+DOTFILES="$(cd "$(dirname "$0")/.." && pwd)"
+SLM_FN="$DOTFILES/.config/fish/functions/slm.fish"
+
+for tool in fish jq curl; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "⏭️  $tool not installed — skipping slm smoke"
+    exit 0
+  fi
+done
+
+if [ ! -f "$SLM_FN" ]; then
+  echo "❌ $SLM_FN not present"
+  exit 1
+fi
+
+pass=0
+fail=0
+fail_msgs=()
+
+assert_eq() {
+  local got="$1" want="$2" desc="$3"
+  if [ "$got" = "$want" ]; then
+    pass=$((pass+1)); echo "  PASS  $desc"
+  else
+    fail=$((fail+1))
+    fail_msgs+=("FAIL  $desc"$'\n'"        got:  '$got'"$'\n'"        want: '$want'")
+    echo "  FAIL  $desc"
+  fi
+}
+
+assert_contains() {
+  local got="$1" needle="$2" desc="$3"
+  if printf '%s' "$got" | grep -q -F -- "$needle"; then
+    pass=$((pass+1)); echo "  PASS  $desc"
+  else
+    fail=$((fail+1))
+    fail_msgs+=("FAIL  $desc"$'\n'"        got:  '$got'"$'\n'"        needle: '$needle'")
+    echo "  FAIL  $desc"
+  fi
+}
+
+echo
+echo "slm"
+echo "───"
+
+# 1. -h prints usage to stdout, exit 0.
+out=$(fish --no-config -c "source '$SLM_FN'; slm -h" </dev/null 2>/dev/null); rc=$?
+assert_eq "$rc" "0" "-h exits 0"
+assert_contains "$out" "Usage:" "-h prints usage"
+
+# 2. No prompt (empty args + empty stdin) -> usage on stderr, exit 2.
+err=$(fish --no-config -c "source '$SLM_FN'; slm" </dev/null 2>&1 >/dev/null); rc=$?
+assert_eq "$rc" "2" "no prompt exits 2"
+assert_contains "$err" "Usage:" "no prompt prints usage to stderr"
+
+# 3. Server down -> friendly message, exit 1. (</dev/null so the arg-only
+#    call's stdin read gets EOF instead of blocking on an open pipe.)
+err=$(SLM_URL=http://localhost:1/v1 fish --no-config -c "source '$SLM_FN'; slm hi" </dev/null 2>&1 >/dev/null); rc=$?
+assert_eq "$rc" "1" "server-down exits 1"
+assert_contains "$err" "lms server start" "server-down suggests 'lms server start'"
+
+# 4. Live happy-path — only if LM Studio is reachable.
+SLM_URL_DEFAULT="${SLM_URL:-http://localhost:1234/v1}"
+if curl -sf -o /dev/null --max-time 2 "$SLM_URL_DEFAULT/models" 2>/dev/null; then
+  out=$(fish --no-config -c "source '$SLM_FN'; slm reply with only the word OK" </dev/null 2>/dev/null); rc=$?
+  assert_eq "$rc" "0" "live: exits 0"
+  if [ -n "$out" ]; then
+    pass=$((pass+1)); echo "  PASS  live: non-empty completion"
+  else
+    fail=$((fail+1)); fail_msgs+=("FAIL  live: empty completion"); echo "  FAIL  live: non-empty completion"
+  fi
+else
+  echo "  SKIP — LM Studio not reachable at $SLM_URL_DEFAULT, skipping live happy-path"
+fi
+
+echo
+echo "─────────────────"
+echo "passed: $pass"
+echo "failed: $fail"
+if [ "$fail" -gt 0 ]; then
+  echo
+  printf '%s\n' "${fail_msgs[@]}"
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## 🎯 What

Adds `slm` — a fish function that pipes any prompt (args and/or stdin) through the local LM Studio model (`lfm2.5-1.2b-instruct`) via its OpenAI-compatible endpoint and prints the buffered completion. One-shot, buffered, LM-Studio-only.

Closes #305.

## 🛠️ How

- 📦 `​.config/fish/functions/slm.fish` — autoloaded function. Builds the chat-completion body with `jq` (safe escaping), POSTs it with `curl` to `$SLM_URL/chat/completions`, extracts `.choices[0].message.content` with `jq`.
- 🔀 Args = instruction, stdin = material; merged when both are present. Stdin read only when not a TTY (mirrors `less.fish`); uses `(cat)` + `string join`, not the broken bare `string collect` on fish 4.7.1.
- ⚙️ Flags `-m`/`-s`/`-h`; env `SLM_URL`/`SLM_MODEL`/`SLM_SYSTEM` with precedence **flag > env > built-in**. System message omitted when empty (`-s ""`).
- 🌐 Uses `curl`, not `xh` — raw JSON body, the documented exception. Connection refusal → friendly `lms server start` hint (exit 1); no prompt → usage on stderr (exit 2).

## ✅ Test plan

- 🧪 `scripts/test-slm.sh` — 8/8 PASS: `-h` (exit 0), no-prompt (exit 2), server-down (exit 1), and the LM-Studio-gated live happy-path. Live path is skipped when no server is reachable, so CI stays green.
- 🐟 `scripts/test-fish-loads.sh` — `✅ fish config loads clean` (now parses `slm.fish`).
- 🔬 Live feature smoke against the running model: args-only → `4`; stdin pipe → `Paris`; args+stdin merge → `4`; `-s` override → `HELLO!`.

## 📝 Docs

- 🗒️ CLAUDE.md — conventions bullet (after `xh`) + a Verify-changes line.
- 🌐 `docs/terminal-cheatsheet.html` — subtitle entry, TOC link, dedicated `#slm` section.

## ⚠️ Notes

- 🏝️ Out of sandbox scope: LM Studio is a Mac desktop app; in-container `localhost` isn't the host.
- 🤏 1.2B model — quick and free, not authoritative.