### PR TITLE
🦙 i: generate the branch slug with local slm instead of claude -p

### DIFF
--- a/bin/i
+++ b/bin/i
@@ -15,10 +15,12 @@
 #
 # One-time per repo:  bd config set github.repository <owner/repo>
 # (GITHUB_TOKEN is auto-sourced from `gh auth token` below — no manual token.)
-# Requires: bd, wt, sesh, tmux, jq, gh, `s` on PATH (claude for the slug).
+# Requires: bd, wt, sesh, tmux, jq, gh, fish, `s` on PATH (claude for the seeded
+# session, `slm` for the slug).
 #
-# Branch slug: from the issue title via `claude -p` (Haiku), <=20 chars. Falls
-# back to just the issue number if claude is unavailable. Override: `i <n> <slug>`.
+# Branch slug: from the issue title via the local `slm` model (LM Studio),
+# word-boundary-trimmed to <=20 chars. Falls back to just the issue number if
+# fish/slm is unavailable or the model is unreachable. Override: `i <n> <slug>`.
 #
 # CONFIRM ON FIRST RUN (couldn't verify without GitHub creds + network):
 #   • `bd github pull "$n"` arg form — if a bare number isn't recognised as a
@@ -31,15 +33,29 @@ set -euo pipefail
 n="${1:?usage: i <issue-number> [slug]}"
 [[ "$n" =~ ^[0-9]+$ ]] || { echo "i: issue must be a number, got '$n'" >&2; exit 1; }
 
-# Branch slug from the issue title via `claude -p` (Haiku): lowercase, 1-3
-# words, <=20 chars. Sanitised to a safe branch ref; prints nothing if claude
-# is missing or returns blank (caller then uses just the issue number).
-claude_slug() {
-  command -v claude >/dev/null 2>&1 || return 0
-  printf 'Make a git branch slug for this issue title: lowercase, 1-3 words, hyphen-separated, max 20 chars, capturing the essence. Output ONLY the slug.\n\nTitle: %s\n' "$1" \
-    | claude -p --model haiku 2>/dev/null | head -n1 \
+# Branch slug from the issue title via the local `slm` model (LM Studio): 2-3
+# meaningful keywords, hyphen-separated, word-boundary-trimmed to <=20 chars,
+# sanitised to a safe branch ref. Prints nothing if fish/slm is unavailable or
+# the model is unreachable (caller then uses just the issue number).
+SLUG_SYS='Generate a git branch slug from the issue title. Rules: lowercase;
+2-3 meaningful keywords; hyphen-separated; pick whole words; drop filler like
+"add"/"the", file paths, and tool flags. Output ONLY the slug.'
+
+local_slug() {                       # $1 = issue title
+  command -v fish >/dev/null 2>&1 || return 0
+  local slm_fn="${XDG_CONFIG_HOME:-$HOME/.config}/fish/functions/slm.fish"
+  [[ -f "$slm_fn" ]] || return 0
+  # `|| true`: under `set -euo pipefail` a non-zero anywhere in this pipeline —
+  # slm failing (LM Studio down) or `head -n1` closing the pipe early on a
+  # multi-line reply — would otherwise abort `i`. Swallow it so empty output
+  # falls through to the bare issue number.
+  printf '%s' "$1" \
+    | SLM_SYSTEM="$SLUG_SYS" fish --no-config -c "source '$slm_fn'; slm" 2>/dev/null \
+    | head -n1 \
     | tr '[:upper:]' '[:lower:]' \
-    | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//' | cut -c1-20 | sed -E 's/-+$//'
+    | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//' \
+    | awk -F- -v max=20 '{acc="";for(i=1;i<=NF;i++){c=(acc==""?$i:acc"-"$i);if(length(c)<=max)acc=c;else break}print acc}' \
+    || true
 }
 
 # Main checkout path (works from inside a secondary worktree too — mirrors bin/s).
@@ -65,7 +81,7 @@ id=$(bd -C "$main" list --json 2>/dev/null \
 
 # 2. Branch name + shape the bead for /mc:* — in MAIN, before the worktree snapshot.
 title=$(bd -C "$main" show "$id" --json 2>/dev/null | jq -r '.[0].title // ""')
-slug="${2:-$(claude_slug "$title")}"   # explicit arg wins; else claude
+slug="${2:-$(local_slug "$title")}"   # explicit arg wins; else local slm model
 branch="$n${slug:+-$slug}"             # <n>-<slug>, or just <n> if no slug
 
 bd -C "$main" update "$id" --type feature >/dev/null


### PR DESCRIPTION
## 🦙 What & why

`bin/i` derived its branch slug by shelling out to `claude -p --model haiku` on every invocation — spinning up a full Claude session just to name a branch. This swaps that for the local `slm` model (LM Studio, lfm2.5), which is faster, free, and offline-capable.

## 🔧 Changes (`bin/i` only, +28/−12)

- 🔁 `claude_slug` → `local_slug`: title on stdin → hermetic `fish --no-config -c "source …/slm.fish; slm"` (no mise/starship/atuin/plugin init in the subshell), slug rules passed via `SLM_SYSTEM`.
- ✂️ Word-boundary trim via `awk` (≤20 chars, whole words) replaces `cut -c1-20`.
- 🛟 Trailing `|| true` keeps a down LM Studio from aborting `i` under `set -euo pipefail` — empty output falls through to the bare issue number.
- 🪜 Fallback chain is now explicit `i <n> <slug>` → `slm` → bare issue number. `claude` stays only for launching the seeded `/mc:brainstorm` session.
- 📝 Header comments + `Requires:` line updated (`fish` now required; `claude` only for the seeded session).

## 🧪 Test plan

- ✅ `bash -n bin/i` exit 0; `shellcheck bin/i` clean (no warnings).
- ✅ Deterministic post-proc: `generate-the-branch`, `weird-punctuation-in`, and empty for a single >20-char leading word (→ bare-number fallback).
- ✅ `set -euo pipefail` survives a simulated LM-Studio-down failure (`SURVIVED slug=[]`); confirmed the `|| true` guard is load-bearing.
- ✅ Live end-to-end through the real `local_slug`: this issue's title → `bin-i-generate` (14 chars); a sample title → `fix-authentication` (18 chars). Script held under pipefail.

No automated test added (deliberate — slug generation is non-deterministic and depends on a Mac-desktop LM Studio; verification is manual).

Closes #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)