### PR TITLE
🦙 i: slug from title + description (and fix slm multiline stdin)

### DIFF
--- a/.config/fish/functions/slm.fish
+++ b/.config/fish/functions/slm.fish
@@ -49,13 +49,18 @@ Env:
     # Read stdin only when it is not a TTY (mirrors less.fish). NOTE: in a
     # non-TTY context (script/cron/background) an arg-only call still reads
     # stdin, so callers there must redirect (e.g. `slm foo </dev/null`).
-    # Capture via `(cat)` + `string join` — NOT `string collect` (fish 4.7.1
-    # no longer reads stdin from a bare `string collect`).
+    # Capture via `(cat)` + `string join … | string collect` — NOT a bare
+    # `(string collect)` (fish 4.7.1 no longer reads stdin from one). The
+    # `| string collect` is what keeps the joined output as a single argument
+    # — without it, command substitution re-splits on newlines, which both
+    # collapses the body into space-joined fragments and exposes any line
+    # starting with `-` to the next `string join` as a stray flag. `--` is
+    # belt-and-braces in case a fragment ever starts with `-` after collect.
     set -l instruction (string join ' ' -- $argv)
     set -l piped ""
     if not isatty stdin
         set -l lines (cat)
-        set piped (string join \n $lines)
+        set piped (string join -- \n $lines | string collect)
     end
 
     set -l parts
@@ -65,7 +70,7 @@ Env:
         echo $usage >&2
         return 2
     end
-    set -l content (string join \n\n $parts)
+    set -l content (string join -- \n\n $parts | string collect)
 
     # Build the request body with jq (safe escaping); omit the system message
     # when its content is empty (e.g. `-s ""`). Pipe straight to curl so the

--- a/bin/i
+++ b/bin/i
@@ -18,9 +18,13 @@
 # Requires: bd, wt, sesh, tmux, jq, gh, fish, `s` on PATH (claude for the seeded
 # session, `slm` for the slug).
 #
-# Branch slug: from the issue title via the local `slm` model (LM Studio),
-# word-boundary-trimmed to <=20 chars. Falls back to just the issue number if
-# fish/slm is unavailable or the model is unreachable. Override: `i <n> <slug>`.
+# Branch slug: from the issue title + description via the local `slm` model
+# (LM Studio), word-boundary-trimmed to <=20 chars. Description is capped at
+# 1500 chars to keep latency sane on the 1.2B model — empirically enough
+# context to disambiguate generic titles (#302 "generate" → "slug",
+# #336 "simplify" → "tui-render") without slowing the call by an order of
+# magnitude. Falls back to just the issue number if fish/slm is unavailable
+# or the model is unreachable. Override: `i <n> <slug>`.
 #
 # CONFIRM ON FIRST RUN (couldn't verify without GitHub creds + network):
 #   • `bd github pull "$n"` arg form — if a bare number isn't recognised as a
@@ -33,23 +37,29 @@ set -euo pipefail
 n="${1:?usage: i <issue-number> [slug]}"
 [[ "$n" =~ ^[0-9]+$ ]] || { echo "i: issue must be a number, got '$n'" >&2; exit 1; }
 
-# Branch slug from the issue title via the local `slm` model (LM Studio): 2-3
-# meaningful keywords, hyphen-separated, word-boundary-trimmed to <=20 chars,
-# sanitised to a safe branch ref. Prints nothing if fish/slm is unavailable or
-# the model is unreachable (caller then uses just the issue number).
-SLUG_SYS='Generate a git branch slug from the issue title. Rules: lowercase;
-2-3 meaningful keywords; hyphen-separated; pick whole words; drop filler like
-"add"/"the", file paths, and tool flags. Output ONLY the slug.'
+# Branch slug from the issue title + description via the local `slm` model
+# (LM Studio): 2-3 meaningful keywords, hyphen-separated, word-boundary-
+# trimmed to <=20 chars, sanitised to a safe branch ref. The description is
+# capped at 1500 chars before being passed in. Prints nothing if fish/slm is
+# unavailable or the model is unreachable (caller then uses just the issue
+# number).
+SLUG_SYS='Generate a git branch slug from the issue title and description.
+Rules: lowercase; 2-3 meaningful keywords; hyphen-separated; pick whole words;
+drop filler like "add"/"the", file paths, and tool flags. Use the description
+to disambiguate when the title is generic. Output ONLY the slug.'
 
-local_slug() {                       # $1 = issue title
+local_slug() {                       # $1 = title, $2 = description (optional)
   command -v fish >/dev/null 2>&1 || return 0
   local slm_fn="${XDG_CONFIG_HOME:-$HOME/.config}/fish/functions/slm.fish"
   [[ -f "$slm_fn" ]] || return 0
+  # Cap description to keep latency sane on the 1.2B model.
+  local desc="${2:-}"
+  desc="${desc:0:1500}"
   # `|| true`: under `set -euo pipefail` a non-zero anywhere in this pipeline —
   # slm failing (LM Studio down) or `head -n1` closing the pipe early on a
   # multi-line reply — would otherwise abort `i`. Swallow it so empty output
   # falls through to the bare issue number.
-  printf '%s' "$1" \
+  printf 'Title: %s\n\nDescription: %s' "$1" "$desc" \
     | SLM_SYSTEM="$SLUG_SYS" fish --no-config -c "source '$slm_fn'; slm" 2>/dev/null \
     | head -n1 \
     | tr '[:upper:]' '[:lower:]' \
@@ -80,8 +90,10 @@ id=$(bd -C "$main" list --json 2>/dev/null \
 [[ -n "$id" ]] || { echo "i: couldn't find the pulled bead for issue #$n (check github config / pull arg form)" >&2; exit 1; }
 
 # 2. Branch name + shape the bead for /mc:* — in MAIN, before the worktree snapshot.
-title=$(bd -C "$main" show "$id" --json 2>/dev/null | jq -r '.[0].title // ""')
-slug="${2:-$(local_slug "$title")}"   # explicit arg wins; else local slm model
+bead_json=$(bd -C "$main" show "$id" --json 2>/dev/null)
+title=$(jq -r '.[0].title // ""'       <<<"$bead_json")
+desc=$( jq -r '.[0].description // ""' <<<"$bead_json")
+slug="${2:-$(local_slug "$title" "$desc")}"   # explicit arg wins; else local slm model
 branch="$n${slug:+-$slug}"             # <n>-<slug>, or just <n> if no slug
 
 bd -C "$main" update "$id" --type feature >/dev/null

--- a/scripts/test-slm.sh
+++ b/scripts/test-slm.sh
@@ -65,6 +65,28 @@ err=$(SLM_URL=http://localhost:1/v1 fish --no-config -c "source '$SLM_FN'; slm h
 assert_eq "$rc" "1" "server-down exits 1"
 assert_contains "$err" "lms server start" "server-down suggests 'lms server start'"
 
+# 4. Multi-line stdin where lines begin with `-` must not be misread as flags
+#    to the internal `string join` calls. Regression for a bug where
+#    `(string join \n $lines)` re-split on newlines through command
+#    substitution, leaking `- bullet` fragments to the next join as flags.
+#    Server-down is fine — we only assert the friendly-error path is reached
+#    (not a `string join: -…: unknown option` fish crash).
+err=$(SLM_URL=http://localhost:1/v1 fish --no-config -c "source '$SLM_FN'; slm" <<'EOF' 2>&1 >/dev/null
+Title: foo
+
+Description:
+- bullet one
+- bullet two
+EOF
+); rc=$?
+assert_eq "$rc" "1" "leading-dash stdin doesn't crash slm"
+assert_contains "$err" "lms server start" "leading-dash stdin still reaches friendly server-down error"
+if printf '%s' "$err" | grep -q "string join:.*unknown option"; then
+  fail=$((fail+1)); fail_msgs+=("FAIL  leading-dash stdin leaked to string join as a flag"); echo "  FAIL  leading-dash stdin no string-join flag leak"
+else
+  pass=$((pass+1)); echo "  PASS  leading-dash stdin no string-join flag leak"
+fi
+
 # 4. Live happy-path — only if LM Studio is reachable.
 SLM_URL_DEFAULT="${SLM_URL:-http://localhost:1234/v1}"
 if curl -sf -o /dev/null --max-time 2 "$SLM_URL_DEFAULT/models" 2>/dev/null; then


### PR DESCRIPTION
## 🎯 What

Two coupled changes, in order:

1. **🤖 `slm.fish` — multiline stdin survives intact.** `(string join \n $lines)` and `(string join \n\n $parts)` were sitting inside command substitution, so the joined output got re-split on newlines on the way back out — silently collapsing multi-line input to space-joined fragments, and crashing the call (`string join: - bullet: unknown option`) the moment a fragment started with `-`. Fixed with `| string collect` (keeps the join as a single argument) and `--` (belt-and-braces against future leading-`-` fragments).
2. **🦙 `bin/i` — slug from title + description.** Now feeds `Title: <t>\n\nDescription: <d>` (description capped at 1500 chars) through `slm`, and updates the system prompt to say "Use the description to disambiguate when the title is generic." Needs the fix above — bulleted issue bodies would have crashed `slm` otherwise.

## 🐛 Why this pairing

Started as "test title-vs-title+description for slug generation." First run with title+body produced **empty output for every issue** — turned out to be the `string join` flag-leak above, not anything wrong with the prompt. So the bug had to go first, then the upgrade landed on top.

## 📊 Bake-off — 20 closed issues across dotfiles + ccpulse

|                        | title-only | title+body |
|------------------------|-----------:|-----------:|
| Clearly better         |          4 |          8 |
| Identical              |        n/a |          8 |

Examples where description carried the work:

| Title                                              | title-only        | title+body          |
|----------------------------------------------------|-------------------|---------------------|
| bin/i: generate the branch slug with `slm`           | `bin-i-generate`    | `bin-i-slug`          |
| refactor(tui): tame the model.go monolith            | `refactor-tui-model`| `refactor-tui-tame`* |
| nvimpager: follow theme-set …                        | `nvimpager-follow-th` | `nvimpager-theme-set` |
| sandbox: bring shared git aliases …                  | `sandbox-share`     | `sandbox-shared-git`  |
| lint: adopt golangci-lint …                          | `lint-slug-golangci` | `golangci-lint-adopt` |

\* title-only happened to match the merged branch here, but only because the human picked an equally generic name.

Title+body's worst case (peripheral noun from the body — `starship`, `ccpulse`) showed up less than title-only's worst case (truncated words, generic stems, occasional literal `slug` leak from the system prompt).

## 🧪 Test plan

- ✅ `scripts/test-slm.sh` — **11/11 pass**, including 3 new assertions: stdin with `- bullet` lines no longer crashes, reaches the friendly server-down path, leaves no `string join: -…: unknown option` in stderr.
- ✅ End-to-end dry-run of the new `local_slug` against 10 closed dotfiles issues (gh-pulled title+body, same input shape `bd github pull` would land in the bead): all 10 produce clean slugs ≤ 20 chars, no `slug` leak, all valid branch refs.

## 🚫 Out of scope

- No post-filter for residual `slug` tokens — title+body didn't exhibit the leak in any of the 20 issues. Easy follow-up if it shows up in the wild.
- No `bin/i` smoke test — meaningful coverage would need either a live LM Studio or mocking the whole `bd github pull` + `slm` stack. The `slm` smoke covers the actual fragile bit (multiline stdin); `bin/i` itself is straight glue.