### PR TITLE
🐹 mise: add Go 1.25.10 to the global toolchain

### DIFF
--- a/mise.global.toml
+++ b/mise.global.toml
@@ -5,6 +5,7 @@ ruby = "3.4.8"
 # puppeteer postinstall to fetch Chromium, so opt this one tool back in.
 "npm:@mermaid-js/mermaid-cli" = { version = "latest", npm_args = "--ignore-scripts=false" }
 "npm:ccstatusline" = "latest"
+go = "1.25.10"
 
 [settings]
 legacy_version_file = true


### PR DESCRIPTION
## 🎯 What

Adds `go = \"1.25.10\"` to `mise.global.toml`, so a managed Go interpreter is available across every checkout under `~/code` without each Go repo needing its own `.mise.toml`.

## 🧭 Why here

- 🐹 ccpulse (and any future Go sibling) currently has no managed runtime; this gives mise something to install when entering the dir.
- 🍺 Matches the file's existing convention — Ruby and Node sit here for the same reason. No Homebrew Go formula.
- 🔒 Pin (not `latest`) so machine setup is reproducible from the dotfiles checkout.

## 🧪 Test plan

- ✅ `mise install` from `~` picks up Go 1.25.10.
- ✅ `go version` reports `go1.25.10` after `mise install`.