### PR TITLE
🐳 sandbox: allow multiple `-p` flags to publish more than one port

### DIFF
--- a/.config/fish/completions/sandbox.fish
+++ b/.config/fish/completions/sandbox.fish
@@ -31,7 +31,7 @@ complete -c sandbox -n '__fish_seen_subcommand_from machine' -f -a 'create ssh r
 
 # Flags (available after a name is given).
 complete -c sandbox -l rm -d 'Ephemeral throwaway'
-complete -c sandbox -s p -d 'Publish PORT to 127.0.0.1' -x
+complete -c sandbox -s p -d 'Publish PORT[:CONTAINER_PORT] to 127.0.0.1 (repeatable)' -x
 complete -c sandbox -l mount -d 'Bind-mount ONE dir' -r
 complete -c sandbox -l env-file -d 'Pass an env file' -r
 complete -c sandbox -s e -d 'Pass KEY=VAL' -x

--- a/bin/sandbox
+++ b/bin/sandbox
@@ -20,9 +20,10 @@ DOTFILES="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # Defaults (overridable by flags).
 MEMORY="2g"; CPUS="2"; PIDS="512"
-PORT=""; MOUNT_DIR=""; ENV_FILE=""; EPHEMERAL=0; ALLOW_CREATE=0
+MOUNT_DIR=""; ENV_FILE=""; EPHEMERAL=0; ALLOW_CREATE=0
 declare -a EXTRA_ENV=()
 declare -a FLAGS_PASSED=()   # creation-time flags as typed, for the "use reup" hint
+declare -a PORTS=()
 
 die() { echo "sandbox: $*" >&2; exit 1; }
 
@@ -42,7 +43,7 @@ Usage:
 
 Flags (for `sandbox <name>` and `sandbox reup <name>`):
   --rm                 ephemeral throwaway (no named volume)
-  -p PORT              publish PORT to 127.0.0.1 only (LAN off)
+  -p PORT[:CONTAINER_PORT]  publish to 127.0.0.1 only (LAN off; repeatable)
   --mount DIR          bind-mount ONE dir at /home/dev/mnt
   --env-file FILE      pass an env file (e.g. ~/sandbox/<name>/.env) into the container
   -e KEY=VAL           pass a single env var (repeatable)
@@ -112,7 +113,13 @@ assemble_run_args() {
     --security-opt no-new-privileges
     --memory "$MEMORY" --cpus "$CPUS" --pids-limit "$PIDS"
   )
-  [ -n "$PORT" ] && RUN_ARGS+=(-p "127.0.0.1:${PORT}:${PORT}")
+  local p
+  for p in "${PORTS[@]}"; do
+    case "$p" in
+      *:*) RUN_ARGS+=(-p "127.0.0.1:${p}") ;;
+      *)   RUN_ARGS+=(-p "127.0.0.1:${p}:${p}") ;;
+    esac
+  done
   if [ -n "$MOUNT_DIR" ]; then
     mkdir -p "$MOUNT_DIR"
     RUN_ARGS+=(-v "${MOUNT_DIR}:/home/dev/mnt")
@@ -334,7 +341,7 @@ declare -a REST=()
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --rm) EPHEMERAL=1; shift ;;
-    -p) PORT="${2:?-p needs a PORT}"; FLAGS_PASSED+=(-p "$2"); shift 2 ;;
+    -p) PORTS+=("${2:?-p needs a PORT}"); FLAGS_PASSED+=(-p "$2"); shift 2 ;;
     --mount) MOUNT_DIR="${2:?--mount needs a DIR}"; FLAGS_PASSED+=(--mount "$2"); shift 2 ;;
     --env-file) ENV_FILE="${2:?--env-file needs a FILE}"; FLAGS_PASSED+=(--env-file "$2"); shift 2 ;;
     -e) EXTRA_ENV+=("${2:?-e needs KEY=VAL}"); FLAGS_PASSED+=(-e "$2"); shift 2 ;;

--- a/scripts/test-sandbox.sh
+++ b/scripts/test-sandbox.sh
@@ -205,6 +205,17 @@ binds="$(docker inspect "$rcont" --format '{{json .HostConfig.PortBindings}}' 2>
 [[ "$binds" == *127.0.0.1* && "$binds" == *"$rport"* ]] || fail "reup did not publish port: $binds"
 pass "reup applies new -p flag"
 
+# 7b. reup with two -p flags (one bare, one remap) publishes BOTH on 127.0.0.1.
+rport2_bare=58081; rport2_host=58082; rport2_ctn=82
+SANDBOX_IMAGE=sandbox:test bin/sandbox reup "$rname" -p "$rport2_bare" -p "${rport2_host}:${rport2_ctn}" true >/dev/null 2>&1 || true
+binds="$(docker inspect "$rcont" --format '{{json .HostConfig.PortBindings}}' 2>/dev/null || true)"
+[[ "$binds" == *"\"${rport2_bare}/tcp\""* && "$binds" == *"\"HostPort\":\"${rport2_bare}\""* ]] \
+  || fail "reup multi-port: bare ${rport2_bare} not published: $binds"
+[[ "$binds" == *"\"${rport2_ctn}/tcp\""* && "$binds" == *"\"HostPort\":\"${rport2_host}\""* ]] \
+  || fail "reup multi-port: remap ${rport2_host}:${rport2_ctn} not published: $binds"
+[[ "$binds" == *"\"HostIp\":\"127.0.0.1\""* ]] || fail "reup multi-port: not 127.0.0.1-bound: $binds"
+pass "reup applies multiple -p flags (bare + remap)"
+
 # 8. reup on a nonexistent sandbox errors clearly with a non-zero exit.
 rc=0; out="$(bin/sandbox reup "nope-$$" 2>&1)" || rc=$?
 [[ "$rc" -ne 0 && "$out" == *"no such sandbox"* ]] || fail "reup nonexistent: rc=$rc out=$out"


### PR DESCRIPTION
## 📋 Summary

- Lift `-p` from a scalar to a repeatable flag — each occurrence accepts either a bare `PORT` (same-port mapping) or a `HOST:CONTAINER` pair (remap).
- `sandbox create web -p 3000 -p 8080:80` now publishes both `mac:3000 → ctn:3000` and `mac:8080 → ctn:80` instead of silently keeping only the last value.
- Also fixes the prior `sandbox reup foo -p 15173:5173` crash, where the scalar path concatenated `H:C` into a malformed `127.0.0.1:15173:5173:15173:5173` docker arg.

## 🔒 Invariants

- 🛡️ 127.0.0.1-only binding stays — no LAN exposure.
- 🪧 Only the two existing docker `-p` shapes (bare + `H:C`); no third form.
- 🚦 No artificial cap on count — `--pids-limit` / `--memory` are the real bounds.
- 🩹 Pass-through value validation (matches `--memory` / `--cpus`).

## 🔧 Shape

Three byte-exact hunks in `bin/sandbox`:

- 🧱 State: `PORT=""` → `declare -a PORTS=()`
- 🛠️ `assemble_run_args`: loop over `${PORTS[@]}`, `case "$p" in *:*) ... ;; *) ... ;; esac`
- 🎛️ `-p)` arg-parse branch: `PORTS+=("$2")` (append instead of overwrite)

Plus a one-line touch each to `.config/fish/completions/sandbox.fish` and `bin/sandbox`'s `usage()` block.

## 🧪 Test Plan

- [x] `scripts/test-sandbox.sh` — full smoke suite green (19 checks, incl. new `reup applies multiple -p flags (bare + remap)`).
- [x] `shellcheck bin/sandbox scripts/test-sandbox.sh` clean.
- [x] `fish -n .config/fish/completions/sandbox.fish` parses.
- [ ] Manual: `sandbox create web -p 3000 -p 8080:80` → `docker inspect` shows both `PortBindings`, both on `127.0.0.1`.
- [ ] Manual: `sandbox reup foo -p 15173:5173` no longer crashes with the malformed-arg docker error.

Closes #311