### PR TITLE
💎 nvim: route ruby_lsp and rubocop through mise shims in :LspOn

### DIFF
--- a/.config/nvim/lua/config/keymaps.lua
+++ b/.config/nvim/lua/config/keymaps.lua
@@ -7,8 +7,29 @@
 -- buffers included). For projects where you want it always on, drop
 -- a .nvim.lua at the repo root with vim.lsp.enable({...}); requires
 -- vim.o.exrc = true (not currently set).
+
+-- Per-server cmd overrides applied at opt-in time. ruby_lsp and rubocop must
+-- run via the mise shim, not lspconfig's defaults (`ruby-lsp`, `rubocop --lsp`)
+-- which resolve to Mason's binaries first, since mason.nvim prepends its bin to
+-- nvim's PATH. Mason's wrappers carry a frozen shebang to a removed rbenv ruby
+-- after the rbenv->mise migration, so they die with "bad interpreter". The
+-- shims re-resolve ruby per project and run inside the project bundle -- the
+-- same binary the per-project .nvim.lua files use.
+-- Note: don't :LspOn both -- ruby_lsp already runs RuboCop as an addon, so
+-- standalone rubocop on top doubles diagnostics. Use rubocop alone only when
+-- you want lint without full ruby-lsp.
+local lsp_cmd_overrides = {
+  ruby_lsp = { vim.fn.expand("~/.local/share/mise/shims/ruby-lsp") },
+  rubocop = { vim.fn.expand("~/.local/share/mise/shims/rubocop"), "--lsp" },
+}
+
 vim.api.nvim_create_user_command("LspOn", function(args)
-  vim.lsp.enable(args.args)
+  local name = args.args
+  local override = lsp_cmd_overrides[name]
+  if override then
+    vim.lsp.config(name, { cmd = override })
+  end
+  vim.lsp.enable(name)
 end, {
   nargs = 1,
   desc = "Enable an LSP server for this session",


### PR DESCRIPTION
## Summary

- Override `cmd` for `ruby_lsp` and `rubocop` in `:LspOn` to use mise shims (`~/.local/share/mise/shims/ruby-lsp`, `~/.local/share/mise/shims/rubocop`) instead of Mason's default binaries
- Mason's wrapper scripts carry a frozen shebang to the removed rbenv ruby after the rbenv→mise migration, causing "bad interpreter" errors
- Added a note that `ruby_lsp` already runs RuboCop as an addon, so enabling both doubles diagnostics

## Test plan

- [ ] `:LspOn ruby_lsp` in a Ruby project — server starts without "bad interpreter" error
- [ ] `:LspOn rubocop` in a Ruby project — server starts and produces diagnostics
- [ ] `:LspOn lua_ls` (no override) — still works as before
- [ ] `scripts/test-nvim.sh` passes