### PR TITLE
🪝 claude: portable bin/claude-session-title for SessionStart hook

### DIFF
--- a/bin/claude-session-title
+++ b/bin/claude-session-title
@@ -1,0 +1,22 @@
+#!/opt/homebrew/bin/bash
+# claude-session-title — emit a SessionStart hookSpecificOutput JSON that
+# sets Claude Code's session title to "<repo>/<branch>" when invoked from
+# inside a git working tree. Silent (no output) when not in a repo, which
+# leaves Claude Code's default title untouched.
+#
+# Wired from ~/.claude/settings.json as a SessionStart hook command,
+# matched on startup|resume|clear|compact so the title survives /clear,
+# session resume, and auto-compaction.
+set -euo pipefail
+
+common=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)
+branch=$(git branch --show-current 2>/dev/null || true)
+
+[ -n "$common" ] && [ -n "$branch" ] || exit 0
+
+repo=$(basename "$(dirname "$common")")
+# Build JSON via jq so JSON-significant chars in $repo/$branch (legal in git
+# refs and macOS dir names) can't break out of sessionTitle and inject sibling
+# fields like additionalContext into Claude Code's hook payload.
+jq -cn --arg title "$repo/$branch" \
+  '{hookSpecificOutput:{hookEventName:"SessionStart",sessionTitle:$title}}'


### PR DESCRIPTION
## Summary

- ➕ Extracts the SessionStart session-title logic from `~/.claude/settings.json`'s inline one-liner into a `bin/claude-session-title` bash script (silent when not in a git tree).
- 🔗 Auto-symlinks to `~/.local/bin/` via `bootstrap.sh`'s existing `bin/*` loop — lands on every machine after bootstrap.
- 🪝 Pairs with broadening the hook matcher to `startup|resume|clear|compact` in `~/.claude/settings.json` (untracked) so the `<repo>/<branch>` title re-applies after `/clear`, session resume, and auto-compaction.

## Test plan

- [ ] 🧪 In a git tree: `claude-session-title` prints the expected `hookSpecificOutput` JSON.
- [ ] 🧪 Outside a git tree: prints nothing, exits 0.
- [ ] ✅ `/clear` in Claude Code re-applies the title to `<repo>/<branch>`.
- [ ] 🆕 Fresh bootstrap on another machine: `~/.local/bin/claude-session-title` symlink exists.