### PR TITLE
🐳 lazydocker: add the container-management TUI (install-only)

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -59,6 +59,7 @@ brew "shfmt"                    # POSIX/bash/mksh formatter (`-d` for diff, `-w`
 
 # System monitoring & benchmarking
 brew "btop"                     # modern top replacement (themed Solarized)
+brew "lazydocker"               # container-management TUI (needs OrbStack/daemon)
 brew "dua-cli"                  # interactive disk-usage analyzer (TUI: `dua i`)
 brew "duf"                      # modern df replacement (grouped, color-coded)
 brew "dust"                     # tree-style du replacement (largest-first, bar graphs)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -236,6 +236,13 @@ bootstrap defaults. See "Switchable themes" / "Switchable Ghostty fonts" below.
 - **`hyperfine`** for benchmarks (warmups / A-B), additive to `time`. Raw.
 - **`duf`/`dust`/`dua` are modern `df`/`du`/`du`-aggregate companions** (raw, no
   alias; `du`/`df` stay for scripts). `dua i` opens a TUI deleter.
+- **`lazydocker` (raw).** Container-management TUI (lazygit's Docker sibling).
+  Needs a running Docker daemon — **OrbStack** here; inert without one (not
+  broken on a fresh machine). No alias; launch by name. Config untracked (runs
+  built-in defaults from `~/Library/Application Support/jesseduffield/lazydocker/`);
+  `theme-set` theming deferred to the #317 lazygit pattern — redirect to an XDG
+  path via the `CONFIG_DIR` env var when it lands. **Out of sandbox scope** (the
+  sandbox is itself a container — no Docker socket).
 - **`mmdc` renders Mermaid** (mise global npm tool). `.mmd` + `.svg` co-located,
   both committed. Build: `scripts/build-diagrams.sh`. Don't install via
   brew/`npm -g`.


### PR DESCRIPTION
## 🐳 What

Adds [`lazydocker`](https://github.com/jesseduffield/lazydocker) — lazygit's
Docker sibling, a TUI for managing containers, images, volumes, networks, and
logs — to the dotfiles as an **install-only** tool. Mirrors how `lazygit` is
handled today: one Brewfile formula plus one terse `CLAUDE.md` conventions
bullet. No config file, no symlink, no alias, no sandbox parity.

Closes #322.

## 📦 Changes

- 🍺 **`Brewfile`** — `brew "lazydocker"` in the System-monitoring section,
  right after `btop`, so the two live-monitoring TUIs sit together.
- 📝 **`CLAUDE.md`** — a conventions bullet capturing the OrbStack
  prerequisite, the no-alias / no-config decisions, the future-theming lever
  (deferred to the #317 lazygit `CONFIG_DIR` pattern), and the sandbox
  exclusion (the sandbox is itself a container — no Docker socket).

## 🧭 Why install-only

Theming and config-tracking are intentionally deferred to the #317 lazygit
pattern — when that lands, `lazydocker` redirects its config to an XDG path via
the `CONFIG_DIR` env var. Until then it runs built-in defaults from
`~/Library/Application Support/jesseduffield/lazydocker/`.

## ✅ Test plan

- 🔧 `brew bundle --file=Brewfile` → installs `lazydocker` 0.25.2, exit 0.
- 🔎 `command -v lazydocker` → `/opt/homebrew/bin/lazydocker`.
- 📋 `brew bundle check --file=Brewfile` → "dependencies are satisfied", exit 0.
- 🖥️ **Live-daemon smoke** (OrbStack running): launched `lazydocker` in a pty —
  it connected to the daemon, rendered all panels (containers / images /
  volumes / networks / logs / menu), emitted no errors, and quit cleanly
  (exit 0).

## ⚠️ Risk / notes

- Inert without a running Docker daemon — **not broken** on a fresh machine,
  just nothing to show. OrbStack is the daemon here.
- No alias, no `.config/lazydocker/` dir, no `bootstrap.sh` handling, no
  `sandbox/` change — all explicitly out of scope.