### PR TITLE
🐳 ctop: add the top-like container-metrics TUI

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -59,6 +59,7 @@ brew "shfmt"                    # POSIX/bash/mksh formatter (`-d` for diff, `-w`
 
 # System monitoring & benchmarking
 brew "btop"                     # modern top replacement (themed Solarized)
+brew "ctop"                     # top-like TUI for container metrics (needs Docker daemon: OrbStack)
 brew "lazydocker"               # container-management TUI (needs OrbStack/daemon)
 brew "dua-cli"                  # interactive disk-usage analyzer (TUI: `dua i`)
 brew "duf"                      # modern df replacement (grouped, color-coded)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,6 +207,11 @@ bootstrap defaults. See "Switchable themes" / "Switchable Ghostty fonts" below.
   Live `btop.conf` is machine-local — seeded once from `btop.conf.template`
   (mixed-dir, seed-only), so runtime sort/UI toggles don't dirty the repo.
   Edit the template to change the baked default.
+- **`ctop` is the container-metrics TUI** (`bcicen/ctop`; raw, no `theme-set`,
+  no alias). Live per-container CPU/mem/net/IO; `enter` expands one container.
+  Needs a running Docker daemon — OrbStack on this machine; empty table
+  otherwise (not a bug). **Out of sandbox scope** (no Docker socket inside the
+  container). No config shipped; `S` saves one locally if wanted.
 - **`lnav` (raw).** `~/.config/lnav/` real dir; `formats/installed/` whole-dir
   symlinked, `configs/installed/` mixed-dir (tracked theme machinery symlinked,
   active `theme.json` machine-local). `lnav -i` writes to the real dir — `cp`

--- a/docs/terminal-cheatsheet.html
+++ b/docs/terminal-cheatsheet.html
@@ -69,6 +69,7 @@
       <tr><td class="key"><a href="https://github.com/bensadeh/tailspin"><code>tailspin</code></a></td><td class="desc">live-log highlighter (<code>tspin</code>); Solarized via <code>~/.config/tailspin/theme.toml</code></td></tr>
       <tr><td class="key"><a href="https://lnav.org/"><code>lnav</code></a></td><td class="desc">TUI log navigator; Solarized via built-in theme (see lnav section)</td></tr>
       <tr><td class="key"><a href="https://github.com/aristocratos/btop"><code>btop</code></a></td><td class="desc">modern <code>top</code> replacement; Solarized via <code>~/.config/btop/btop.conf</code></td></tr>
+      <tr><td class="key"><a href="https://github.com/bcicen/ctop"><code>ctop</code></a></td><td class="desc">top-like container-metrics TUI (CPU/mem/net/IO; <code>enter</code> expands one; needs Docker daemon; raw, no alias)</td></tr>
       <tr><td class="key"><a href="https://github.com/dlvhdr/gh-dash"><code>gh dash</code></a></td><td class="desc">GitHub TUI for PRs/issues/notifications (<code>ghd</code> abbr); Solarized via <code>~/.config/gh-dash/config.yml</code> — <code>?</code> help, <code>s</code>/<code>S</code> next/prev section, <code>j</code>/<code>k</code> rows, <code>enter</code> preview, <code>o</code> open in browser, <code>r</code> refresh, <code>/</code> filter, <code>q</code> quit</td></tr>
       <tr><td class="key"><a href="https://github.com/Byron/dua-cli"><code>dua</code></a></td><td class="desc">interactive disk-usage analyzer with TUI deleter (<code>dua i</code>; raw, no alias)</td></tr>
       <tr><td class="key"><a href="https://github.com/muesli/duf"><code>duf</code></a></td><td class="desc">modern <code>df</code> replacement (grouped, color-coded; raw, no alias)</td></tr>
@@ -834,7 +835,7 @@
 <span class="cmd">git log -p</span> | <span class="cmd">head</span>                 <span class="c"># should look styled</span></pre>
 
 <footer>
-  Built from <code>~/.config/fish/</code>, <code>Brewfile</code>, and project CLAUDE.md on 2026-05-25.
+  Built from <code>~/.config/fish/</code>, <code>Brewfile</code>, and project CLAUDE.md on 2026-05-29.
   Refresh after meaningful color-tooling changes.
 </footer>
 


### PR DESCRIPTION
## 🐳 What

Adds [`ctop`](https://github.com/bcicen/ctop) (`bcicen/ctop`, brew 0.7.7) — a top-like TUI for live per-container Docker metrics — installed **raw** alongside `btop`, matching the `dua`/`duf` posture (no `theme-set` wiring, no alias, no `~/.config/ctop/` symlink).

Closes #323.

## ✨ Changes

- 🍺 **`Brewfile`** — `brew "ctop"` inserted between `btop` and `dua-cli` so the host→container monitoring tools stay adjacent (matched `btop`'s comment column).
- 📝 **`CLAUDE.md`** — new convention bullet after the `top → btop` entry: raw / no-theme / no-alias, OrbStack-daemon prerequisite (empty table otherwise, not a bug), out-of-sandbox-scope, no config shipped.
- 📄 **`docs/terminal-cheatsheet.html`** — table row after `btop` (mirrors the dua/duf structure) + footer date bump to 2026-05-29.

## ✅ Test plan

- ✅ `brew install ctop` → installs 0.7.7; on PATH.
- ✅ `brew bundle check --file=Brewfile --verbose` → *"The Brewfile's dependencies are satisfied."*
- ✅ Smoke: `ctop` launches under a pty, initializes, enters its TUI main loop against the running Docker daemon, and quits cleanly (exit 0) — no panic, no connector error.
- 🔸 Interactive checks (metrics populating, `enter` to expand a container, daemon-down empty table) are manual — `ctop` is a pure termbox TUI with no headless mode.

## ⚠️ Notes

- 🧩 `scripts/test-helpers.sh` currently exits non-zero on this machine, but **only on pre-existing, unrelated assertions**: tmux git-status colour checks hardcode Solarized while the live active theme is Rose Pine Moon, plus a separate glow `glamour.json` resolution issue. This branch touches none of that code (only the three files above).