### PR TITLE
🎨 btop: follow theme-set across all 10 themes

### DIFF
--- a/.config/btop/btop.conf.template
+++ b/.config/btop/btop.conf.template
@@ -2,7 +2,7 @@
 
 #* Name of a btop++/bpytop/bashtop formatted ".theme" file, "Default" and "TTY" for builtin themes.
 #* Themes should be placed in "../share/btop/themes" relative to binary or "$HOME/.config/btop/themes"
-color_theme = "solarized_dark"
+color_theme = "current"
 
 #* If the theme set background should be shown, set to False if you want terminal background transparency.
 theme_background = false

--- a/.config/btop/themes/catppuccin_frappe.theme
+++ b/.config/btop/themes/catppuccin_frappe.theme
@@ -1,0 +1,84 @@
+# Vendored from catppuccin/btop@f437574b600f1c6d932627050b15ff5153b58fa3 (MIT). Do not hand-edit; re-pull to update.
+# Main background, empty for terminal default, need to be empty if you want transparent background
+theme[main_bg]="#303446"
+
+# Main text color
+theme[main_fg]="#c6d0f5"
+
+# Title color for boxes
+theme[title]="#c6d0f5"
+
+# Highlight color for keyboard shortcuts
+theme[hi_fg]="#8caaee"
+
+# Background color of selected item in processes box
+theme[selected_bg]="#51576d"
+
+# Foreground color of selected item in processes box
+theme[selected_fg]="#8caaee"
+
+# Color of inactive/disabled text
+theme[inactive_fg]="#838ba7"
+
+# Color of text appearing on top of graphs, i.e uptime and current network graph scaling
+theme[graph_text]="#f2d5cf"
+
+# Background color of the percentage meters
+theme[meter_bg]="#51576d"
+
+# Misc colors for processes box including mini cpu graphs, details memory graph and details status text
+theme[proc_misc]="#f2d5cf"
+
+# CPU, Memory, Network, Proc box outline colors
+theme[cpu_box]="#ca9ee6" #Mauve
+theme[mem_box]="#a6d189" #Green
+theme[net_box]="#ea999c" #Maroon
+theme[proc_box]="#8caaee" #Blue
+
+# Box divider line and small boxes line color
+theme[div_line]="#737994"
+
+# Temperature graph color (Green -> Yellow -> Red)
+theme[temp_start]="#a6d189"
+theme[temp_mid]="#e5c890"
+theme[temp_end]="#e78284"
+
+# CPU graph colors (Teal -> Lavender)
+theme[cpu_start]="#81c8be"
+theme[cpu_mid]="#85c1dc"
+theme[cpu_end]="#babbf1"
+
+# Mem/Disk free meter (Mauve -> Lavender -> Blue)
+theme[free_start]="#ca9ee6"
+theme[free_mid]="#babbf1"
+theme[free_end]="#8caaee"
+
+# Mem/Disk cached meter (Sapphire -> Lavender)
+theme[cached_start]="#85c1dc"
+theme[cached_mid]="#8caaee"
+theme[cached_end]="#babbf1"
+
+# Mem/Disk available meter (Peach -> Red)
+theme[available_start]="#ef9f76"
+theme[available_mid]="#ea999c"
+theme[available_end]="#e78284"
+
+# Mem/Disk used meter (Green -> Sky)
+theme[used_start]="#a6d189"
+theme[used_mid]="#81c8be"
+theme[used_end]="#99d1db"
+
+# Download graph colors (Peach -> Red)
+theme[download_start]="#ef9f76"
+theme[download_mid]="#ea999c"
+theme[download_end]="#e78284"
+
+# Upload graph colors (Green -> Sky)
+theme[upload_start]="#a6d189"
+theme[upload_mid]="#81c8be"
+theme[upload_end]="#99d1db"
+
+# Process box color gradient for threads, mem and cpu usage (Sapphire -> Mauve)
+theme[process_start]="#85c1dc"
+theme[process_mid]="#babbf1"
+theme[process_end]="#ca9ee6"

--- a/.config/btop/themes/catppuccin_latte.theme
+++ b/.config/btop/themes/catppuccin_latte.theme
@@ -1,0 +1,84 @@
+# Vendored from catppuccin/btop@f437574b600f1c6d932627050b15ff5153b58fa3 (MIT). Do not hand-edit; re-pull to update.
+# Main background, empty for terminal default, need to be empty if you want transparent background
+theme[main_bg]="#eff1f5"
+
+# Main text color
+theme[main_fg]="#4c4f69"
+
+# Title color for boxes
+theme[title]="#4c4f69"
+
+# Highlight color for keyboard shortcuts
+theme[hi_fg]="#1e66f5"
+
+# Background color of selected item in processes box
+theme[selected_bg]="#bcc0cc"
+
+# Foreground color of selected item in processes box
+theme[selected_fg]="#1e66f5"
+
+# Color of inactive/disabled text
+theme[inactive_fg]="#8c8fa1"
+
+# Color of text appearing on top of graphs, i.e uptime and current network graph scaling
+theme[graph_text]="#dc8a78"
+
+# Background color of the percentage meters
+theme[meter_bg]="#bcc0cc"
+
+# Misc colors for processes box including mini cpu graphs, details memory graph and details status text
+theme[proc_misc]="#dc8a78"
+
+# CPU, Memory, Network, Proc box outline colors
+theme[cpu_box]="#8839ef" #Mauve
+theme[mem_box]="#40a02b" #Green
+theme[net_box]="#e64553" #Maroon
+theme[proc_box]="#1e66f5" #Blue
+
+# Box divider line and small boxes line color
+theme[div_line]="#9ca0b0"
+
+# Temperature graph color (Green -> Yellow -> Red)
+theme[temp_start]="#40a02b"
+theme[temp_mid]="#df8e1d"
+theme[temp_end]="#d20f39"
+
+# CPU graph colors (Teal -> Lavender)
+theme[cpu_start]="#179299"
+theme[cpu_mid]="#209fb5"
+theme[cpu_end]="#7287fd"
+
+# Mem/Disk free meter (Mauve -> Lavender -> Blue)
+theme[free_start]="#8839ef"
+theme[free_mid]="#7287fd"
+theme[free_end]="#1e66f5"
+
+# Mem/Disk cached meter (Sapphire -> Lavender)
+theme[cached_start]="#209fb5"
+theme[cached_mid]="#1e66f5"
+theme[cached_end]="#7287fd"
+
+# Mem/Disk available meter (Peach -> Red)
+theme[available_start]="#fe640b"
+theme[available_mid]="#e64553"
+theme[available_end]="#d20f39"
+
+# Mem/Disk used meter (Green -> Sky)
+theme[used_start]="#40a02b"
+theme[used_mid]="#179299"
+theme[used_end]="#04a5e5"
+
+# Download graph colors (Peach -> Red)
+theme[download_start]="#fe640b"
+theme[download_mid]="#e64553"
+theme[download_end]="#d20f39"
+
+# Upload graph colors (Green -> Sky)
+theme[upload_start]="#40a02b"
+theme[upload_mid]="#179299"
+theme[upload_end]="#04a5e5"
+
+# Process box color gradient for threads, mem and cpu usage (Sapphire -> Mauve)
+theme[process_start]="#209fb5"
+theme[process_mid]="#7287fd"
+theme[process_end]="#8839ef"

--- a/.config/btop/themes/catppuccin_mocha.theme
+++ b/.config/btop/themes/catppuccin_mocha.theme
@@ -1,0 +1,84 @@
+# Vendored from catppuccin/btop@f437574b600f1c6d932627050b15ff5153b58fa3 (MIT). Do not hand-edit; re-pull to update.
+# Main background, empty for terminal default, need to be empty if you want transparent background
+theme[main_bg]="#1e1e2e"
+
+# Main text color
+theme[main_fg]="#cdd6f4"
+
+# Title color for boxes
+theme[title]="#cdd6f4"
+
+# Highlight color for keyboard shortcuts
+theme[hi_fg]="#89b4fa"
+
+# Background color of selected item in processes box
+theme[selected_bg]="#45475a"
+
+# Foreground color of selected item in processes box
+theme[selected_fg]="#89b4fa"
+
+# Color of inactive/disabled text
+theme[inactive_fg]="#7f849c"
+
+# Color of text appearing on top of graphs, i.e uptime and current network graph scaling
+theme[graph_text]="#f5e0dc"
+
+# Background color of the percentage meters
+theme[meter_bg]="#45475a"
+
+# Misc colors for processes box including mini cpu graphs, details memory graph and details status text
+theme[proc_misc]="#f5e0dc"
+
+# CPU, Memory, Network, Proc box outline colors
+theme[cpu_box]="#cba6f7" #Mauve
+theme[mem_box]="#a6e3a1" #Green
+theme[net_box]="#eba0ac" #Maroon
+theme[proc_box]="#89b4fa" #Blue
+
+# Box divider line and small boxes line color
+theme[div_line]="#6c7086"
+
+# Temperature graph color (Green -> Yellow -> Red)
+theme[temp_start]="#a6e3a1"
+theme[temp_mid]="#f9e2af"
+theme[temp_end]="#f38ba8"
+
+# CPU graph colors (Teal -> Lavender)
+theme[cpu_start]="#94e2d5"
+theme[cpu_mid]="#74c7ec"
+theme[cpu_end]="#b4befe"
+
+# Mem/Disk free meter (Mauve -> Lavender -> Blue)
+theme[free_start]="#cba6f7"
+theme[free_mid]="#b4befe"
+theme[free_end]="#89b4fa"
+
+# Mem/Disk cached meter (Sapphire -> Lavender)
+theme[cached_start]="#74c7ec"
+theme[cached_mid]="#89b4fa"
+theme[cached_end]="#b4befe"
+
+# Mem/Disk available meter (Peach -> Red)
+theme[available_start]="#fab387"
+theme[available_mid]="#eba0ac"
+theme[available_end]="#f38ba8"
+
+# Mem/Disk used meter (Green -> Sky)
+theme[used_start]="#a6e3a1"
+theme[used_mid]="#94e2d5"
+theme[used_end]="#89dceb"
+
+# Download graph colors (Peach -> Red)
+theme[download_start]="#fab387"
+theme[download_mid]="#eba0ac"
+theme[download_end]="#f38ba8"
+
+# Upload graph colors (Green -> Sky)
+theme[upload_start]="#a6e3a1"
+theme[upload_mid]="#94e2d5"
+theme[upload_end]="#89dceb"
+
+# Process box color gradient for threads, mem and cpu usage (Sapphire -> Mauve)
+theme[process_start]="#74c7ec"
+theme[process_mid]="#b4befe"
+theme[process_end]="#cba6f7"

--- a/.config/btop/themes/rose-pine-moon.theme
+++ b/.config/btop/themes/rose-pine-moon.theme
@@ -1,0 +1,90 @@
+# Vendored from rose-pine/btop@c27e5d48e44e8bd115a2838ecf8cf1f3ea39475e (MIT). Do not hand-edit; re-pull to update.
+# Main background, empty for terminal default, need to be empty if you want transparent background
+theme[main_bg]="#232136"
+
+# Main text color
+theme[main_fg]="#e0def4"
+
+# Title color for boxes
+theme[title]="#908caa"
+
+# Highlight color for keyboard shortcuts
+theme[hi_fg]="#e0def4"
+
+# Background color of selected item in processes box
+theme[selected_bg]="#56526e"
+
+# Foreground color of selected item in processes box
+theme[selected_fg]="#f6c177"
+
+# Color of inactive/disabled text
+theme[inactive_fg]="#44415a"
+
+# Color of text appearing on top of graphs, i.e uptime and current network graph scaling
+theme[graph_text]="#9ccfd8"
+
+# Background color of the percentage meters
+theme[meter_bg]="#9ccfd8"
+
+# Misc colors for processes box including mini cpu graphs, details memory graph and details status text
+theme[proc_misc]="#c4a7e7"
+
+# Cpu box outline color
+theme[cpu_box]="#ea9a97"
+
+# Memory/disks box outline color
+theme[mem_box]="#3e8fb0"
+
+# Net up/down box outline color
+theme[net_box]="#c4a7e7"
+
+# Processes box outline color
+theme[proc_box]="#eb6f92"
+
+# Box divider line and small boxes line color
+theme[div_line]="#6e6a86"
+
+# Temperature graph colors
+theme[temp_start]="#ea9a97"
+theme[temp_mid]="#f6c177"
+theme[temp_end]="#eb6f92"
+
+# CPU graph colors
+theme[cpu_start]="#f6c177"
+theme[cpu_mid]="#ea9a97"
+theme[cpu_end]="#eb6f92"
+
+# Mem/Disk free meter
+theme[free_start]="#eb6f92"
+theme[free_mid]="#eb6f92"
+theme[free_end]="#eb6f92"
+
+# Mem/Disk cached meter
+theme[cached_start]="#c4a7e7"
+theme[cached_mid]="#c4a7e7"
+theme[cached_end]="#c4a7e7"
+
+# Mem/Disk available meter
+theme[available_start]="#3e8fb0"
+theme[available_mid]="#3e8fb0"
+theme[available_end]="#3e8fb0"
+
+# Mem/Disk used meter
+theme[used_start]="#ea9a97"
+theme[used_mid]="#ea9a97"
+theme[used_end]="#ea9a97"
+
+# Download graph colors
+theme[download_start]="#3e8fb0"
+theme[download_mid]="#9ccfd8"
+theme[download_end]="#9ccfd8"
+
+# Upload graph colors
+theme[upload_start]="#ea9a97"
+theme[upload_mid]="#eb6f92"
+theme[upload_end]="#eb6f92"
+
+# Process box color gradient for threads, mem and cpu usage
+theme[process_start]="#3e8fb0"
+theme[process_mid]="#9ccfd8"
+theme[process_end]="#9ccfd8"

--- a/.config/btop/themes/rose-pine.theme
+++ b/.config/btop/themes/rose-pine.theme
@@ -1,0 +1,120 @@
+# Vendored from rose-pine/btop@c27e5d48e44e8bd115a2838ecf8cf1f3ea39475e (MIT). Do not hand-edit; re-pull to update.
+# Main background, empty for terminal default, need to be empty if you want transparent background
+theme[main_bg]="#191724"
+# Base
+
+# Main text color
+theme[main_fg]="#e0def4"
+# Text
+
+# Title color for boxes
+theme[title]="#908caa"
+# Subtle
+
+# Highlight color for keyboard shortcuts
+theme[hi_fg]="#e0def4"
+# Text
+
+# Background color of selected item in processes box
+theme[selected_bg]="#524f67"
+# HL High
+
+# Foreground color of selected item in processes box
+theme[selected_fg]="#f6c177"
+# Gold
+
+# Color of inactive/disabled text
+theme[inactive_fg]="#403d52"
+# HL Med
+
+# Color of text appearing on top of graphs, i.e uptime and current network graph scaling
+theme[graph_text]="#9ccfd8"
+# Foam
+
+# Background color of the percentage meters
+theme[meter_bg]="#9ccfd8"
+# Foam
+
+# Misc colors for processes box including mini cpu graphs, details memory graph and details status text
+theme[proc_misc]="#c4a7e7"
+# Iris
+
+# Cpu box outline color
+theme[cpu_box]="#ebbcba"
+# Rose
+
+# Memory/disks box outline color
+theme[mem_box]="#31748f"
+# Pine
+
+# Net up/down box outline color
+theme[net_box]="#c4a7e7"
+# Iris
+
+# Processes box outline color
+theme[proc_box]="#eb6f92"
+# Love
+
+# Box divider line and small boxes line color
+theme[div_line]="#6e6a86"
+# Muted
+
+# Temperature graph colors
+theme[temp_start]="#ebbcba"
+# Rose
+theme[temp_mid]="#f6c177"
+# Gold
+theme[temp_end]="#eb6f92"
+# Love
+
+# CPU graph colors
+theme[cpu_start]="#f6c177"
+# Gold
+theme[cpu_mid]="#ebbcba"
+# Rose
+theme[cpu_end]="#eb6f92"
+# Love
+
+# Mem/Disk free meter
+# all love
+theme[free_start]="#eb6f92"
+theme[free_mid]="#eb6f92"
+theme[free_end]="#eb6f92"
+
+# Mem/Disk cached meter
+# all iris
+theme[cached_start]="#c4a7e7"
+theme[cached_mid]="#c4a7e7"
+theme[cached_end]="#c4a7e7"
+
+# Mem/Disk available meter
+# all pine
+theme[available_start]="#31748f"
+theme[available_mid]="#31748f"
+theme[available_end]="#31748f"
+
+# Mem/Disk used meter
+# all rose
+theme[used_start]="#ebbcba"
+theme[used_mid]="#ebbcba"
+theme[used_end]="#ebbcba"
+
+# Download graph colors
+# Pine for start, foam for the rest
+theme[download_start]="#31748f"
+theme[download_mid]="#9ccfd8"
+theme[download_end]="#9ccfd8"
+
+# Upload graph colors
+theme[upload_start]="#ebbcba"
+# Rose for start
+theme[upload_mid]="#eb6f92"
+# Love for mid and end
+theme[upload_end]="#eb6f92"
+
+# Process box color gradient for threads, mem and cpu usage
+theme[process_start]="#31748f"
+# Pine
+theme[process_mid]="#9ccfd8"
+# Foam for mid and end
+theme[process_end]="#9ccfd8"

--- a/.config/fish/functions/theme-set.fish
+++ b/.config/fish/functions/theme-set.fish
@@ -34,44 +34,55 @@ function theme-set --description 'Switch colour scheme; bare = show current, --s
 
     set -l bat_theme
     set -l vivid_theme
+    set -l btop_theme
     switch $name
         case mocha
             set bat_theme "Catppuccin Mocha"
             set vivid_theme "catppuccin-mocha"
+            set btop_theme "catppuccin_mocha"
         case frappe
             set bat_theme "Catppuccin Frappé"
             set vivid_theme "catppuccin-frappe"
+            set btop_theme "catppuccin_frappe"
         case dracula
             set bat_theme "Dracula"
             set vivid_theme "dracula"
+            set btop_theme "dracula"
         case gruvbox
             set bat_theme "gruvbox-dark"
             set vivid_theme "gruvbox-dark"
+            set btop_theme "gruvbox_dark"
         case tokyo-night
             # bat 0.26 has no tokyonight syntax theme; fall back to
             # Catppuccin Mocha (closest pastel-on-dark in bat's catalogue).
             set bat_theme "Catppuccin Mocha"
             set vivid_theme "tokyonight-storm"
+            set btop_theme "tokyo-storm"
         case nord
             # bat 0.26+ ships `Nord` built-in (capitalized, no hyphen).
             set bat_theme "Nord"
             set vivid_theme "nord"
+            set btop_theme "nord"
         case latte
             set bat_theme "Catppuccin Latte"
             set vivid_theme "catppuccin-latte"
+            set btop_theme "catppuccin_latte"
         case rose-pine
             # bat 0.26 has no rose-pine syntax theme; fall back to
             # Catppuccin Mocha (closest pastel-on-dark; Tokyo Night
             # precedent).
             set bat_theme "Catppuccin Mocha"
             set vivid_theme "rose-pine"
+            set btop_theme "rose-pine"
         case rose-pine-moon
             # Same bat fallback as Main; vivid ships moon natively.
             set bat_theme "Catppuccin Mocha"
             set vivid_theme "rose-pine-moon"
+            set btop_theme "rose-pine-moon"
         case '*'
             set bat_theme "Solarized (dark)"
             set vivid_theme "solarized-dark"
+            set btop_theme "solarized_dark"
     end
 
     # Flip symlinks. -sfn replaces the link atomically. Each flip is
@@ -94,6 +105,8 @@ function theme-set --description 'Switch colour scheme; bare = show current, --s
         ; and ln -sfn glamour-$name.json ~/.config/glow/glamour.json
     test -f ~/.config/lnav/configs/installed/theme-$name.json \
         ; and ln -sfn theme-$name.json ~/.config/lnav/configs/installed/theme.json
+    test -f ~/.config/btop/themes/$btop_theme.theme \
+        ; and ln -sfn $btop_theme.theme ~/.config/btop/themes/current.theme
 
     # gh-dash live config is a generated real file, not a symlink.
     # base.yml has no `theme:` key; theme-colors-$name.yml has only `theme:` —
@@ -127,7 +140,7 @@ function theme-set --description 'Switch colour scheme; bare = show current, --s
 
     echo "theme → $name"
     echo "  live:    tmux + helpers, starship (next prompt), glow, delta"
-    echo "  restart: bat + ls colors (new shells for \$BAT_THEME / \$VIVID_THEME), nvim, gh-dash, lnav"
+    echo "  restart: bat + ls colors (new shells for \$BAT_THEME / \$VIVID_THEME), nvim, gh-dash, lnav, btop"
     # Ghostty 1.3 limitation: reload_config does NOT repaint existing surfaces
     # when `theme` changes — only NEW windows/tabs/splits opened after reload
     # pick up the new palette. Existing windows keep their old theme until a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,7 +141,11 @@ bootstrap defaults. See "Switchable themes" / "Switchable Ghostty fonts" below.
   in (existence-guarded `test -f` in `theme-set.fish` auto-engages — partial
   coverage is fine; Latte is the only light theme and ships ghostty/tmux/
   starship only, #215) **and** add the `starship-<theme>.toml` `link` line in
-  `bootstrap.sh` (the one tool not covered by `link_tracked_entries`).
+  `bootstrap.sh` (the one tool not covered by `link_tracked_entries`) **and**
+  add a `case` in `theme-set.fish`'s `switch $name` block setting `btop_theme`
+  (btop names differ: e.g. `tokyo-night`→`tokyo-storm`, `gruvbox`→`gruvbox_dark`;
+  brew-bundled themes also need a loop entry in `bootstrap.sh`, vendored ones
+  auto-link via `link_tracked_entries`).
   Fallbacks: bat lacks Tokyo Night + Rose Pine → both fall back to Catppuccin
   Mocha; lnav themes for gruvbox/tokyo-night/nord/rose-pine are vendored in
   `configs/installed/` (lnav 0.14 doesn't ship them). nvim picks its colorscheme
@@ -198,15 +202,16 @@ bootstrap defaults. See "Switchable themes" / "Switchable Ghostty fonts" below.
   animation). `man` (`MANPAGER=bat`) and `git` (delta) unaffected. Smoke:
   `scripts/test-nvimpager.sh`.
 - **`top` → `btop`** (`vim_keys`; follows `theme-set` across all 10 themes).
-  `command top` for macOS. `btop.conf` sets `color_theme = "current"`; the
-  active `~/.config/btop/themes/current.theme` symlink is machine-local,
+  `command top` for macOS. `btop.conf` sets `color_theme = "current"` (existing
+  machines converged by a guarded `bootstrap.sh` migration that rewrites that
+  line); `~/.config/btop/themes/current.theme` is a machine-local symlink
   flipped by `theme-set` (restart tier — btop has no live reload). Themes dir
   holds 10 per-file symlinks: 5 vendored (Catppuccin ×3, Rosé Pine ×2,
   pinned-SHA MIT ports) + 5 shimmed from brew's
-  `/opt/homebrew/share/btop/themes/`. Live `btop.conf` is machine-local —
-  seeded once from `btop.conf.template` (mixed-dir, seed-only), so runtime
-  sort/UI toggles don't dirty the repo. Edit the template to change the baked
-  default; `current.theme` defaults to `solarized_dark.theme`.
+  `/opt/homebrew/share/btop/themes/`. `btop.conf` is seeded once from
+  `btop.conf.template` (mixed-dir, seed-only), so runtime sort/UI toggles
+  don't dirty the repo. Edit the template to change the baked default;
+  `current.theme` defaults to `solarized_dark.theme`.
 - **`lnav` (raw).** `~/.config/lnav/` real dir; `formats/installed/` whole-dir
   symlinked, `configs/installed/` mixed-dir (tracked theme machinery symlinked,
   active `theme.json` machine-local). `lnav -i` writes to the real dir — `cp`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,7 +178,7 @@ bootstrap defaults. See "Switchable themes" / "Switchable Ghostty fonts" below.
 - **Bells silenced at every layer** (Ghostty `bell-features=`, vim `belloff=all`,
   tmux bell/visual/monitor off). Don't re-enable.
 - **Terminal tools default Solarized Dark; some follow `theme-set`.** Follow:
-  `bat`, `git-delta`, `glow`/`md`, `vivid`/`LS_COLORS`, fzf, atuin. Stay
+  `bat`, `git-delta`, `glow`/`md`, `vivid`/`LS_COLORS`, fzf, atuin, `btop`. Stay
   Solarized-only: `procs`, `tailspin` (`tspin`), `xh`. `bat --theme="Solarized
   (dark)"` is the unset fallback. No `tail` alias. Don't introduce alternatives
   (`exa`/`lsd`/`diff-so-fancy`/`mdcat`). Delta git config: README → Setup.
@@ -197,10 +197,16 @@ bootstrap defaults. See "Switchable themes" / "Switchable Ghostty fonts" below.
   `snacks.nvim` for scroll (existence-guarded — fresh machine works without
   animation). `man` (`MANPAGER=bat`) and `git` (delta) unaffected. Smoke:
   `scripts/test-nvimpager.sh`.
-- **`top` → `btop`** (`solarized_dark`, `vim_keys`). `command top` for macOS.
-  Live `btop.conf` is machine-local — seeded once from `btop.conf.template`
-  (mixed-dir, seed-only), so runtime sort/UI toggles don't dirty the repo.
-  Edit the template to change the baked default.
+- **`top` → `btop`** (`vim_keys`; follows `theme-set` across all 10 themes).
+  `command top` for macOS. `btop.conf` sets `color_theme = "current"`; the
+  active `~/.config/btop/themes/current.theme` symlink is machine-local,
+  flipped by `theme-set` (restart tier — btop has no live reload). Themes dir
+  holds 10 per-file symlinks: 5 vendored (Catppuccin ×3, Rosé Pine ×2,
+  pinned-SHA MIT ports) + 5 shimmed from brew's
+  `/opt/homebrew/share/btop/themes/`. Live `btop.conf` is machine-local —
+  seeded once from `btop.conf.template` (mixed-dir, seed-only), so runtime
+  sort/UI toggles don't dirty the repo. Edit the template to change the baked
+  default; `current.theme` defaults to `solarized_dark.theme`.
 - **`lnav` (raw).** `~/.config/lnav/` real dir; `formats/installed/` whole-dir
   symlinked, `configs/installed/` mixed-dir (tracked theme machinery symlinked,
   active `theme.json` machine-local). `lnav -i` writes to the real dir — `cp`

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -164,6 +164,19 @@ link ".config/tailspin" "$HOME/.config/tailspin"
 prepare_real_dir "$HOME/.config/btop"
 seed_local ".config/btop/btop.conf.template" "$HOME/.config/btop/btop.conf"
 
+# btop themes follow theme-set. ~/.config/btop/themes/ is a real dir holding
+# 10 per-file symlinks: 5 vendored (→ repo) + 5 bundled (→ brew share). The
+# active current.theme symlink is machine-local — created only if missing so
+# a prior theme-set pick survives re-running bootstrap.
+prepare_real_dir "$HOME/.config/btop/themes"
+link_tracked_entries ".config/btop/themes" "$HOME/.config/btop/themes"
+for t in solarized_dark dracula gruvbox_dark nord tokyo-storm; do
+    src="/opt/homebrew/share/btop/themes/$t.theme"
+    [ -f "$src" ] && ln -sfn "$src" "$HOME/.config/btop/themes/$t.theme"
+done
+[ -L "$HOME/.config/btop/themes/current.theme" ] \
+    || ln -sfn solarized_dark.theme "$HOME/.config/btop/themes/current.theme"
+
 # --- procs (modern ps; Solarized config + procs-heavy.toml for `psh`)
 link ".config/procs"   "$HOME/.config/procs"
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -164,6 +164,19 @@ link ".config/tailspin" "$HOME/.config/tailspin"
 prepare_real_dir "$HOME/.config/btop"
 seed_local ".config/btop/btop.conf.template" "$HOME/.config/btop/btop.conf"
 
+# Migration (#316): the live btop.conf is seeded once and never re-seeded, so a
+# machine that seeded before the color_theme="current" indirection keeps its old
+# baked theme name and silently ignores theme-set. Force the single color_theme
+# line to the indirection value; btop preserves it across save_config_on_exit.
+# Idempotent (grep-guarded) and portable (no in-place sed flag).
+btop_conf="$HOME/.config/btop/btop.conf"
+if [ -f "$btop_conf" ] && ! grep -q '^color_theme = "current"' "$btop_conf"; then
+    btop_tmp="$(mktemp)"
+    sed 's/^color_theme = .*/color_theme = "current"/' "$btop_conf" > "$btop_tmp" \
+        && mv "$btop_tmp" "$btop_conf"
+    echo "🎨  $btop_conf (color_theme → current; #316 migration)"
+fi
+
 # btop themes follow theme-set. ~/.config/btop/themes/ is a real dir holding
 # 10 per-file symlinks: 5 vendored (→ repo) + 5 bundled (→ brew share). The
 # active current.theme symlink is machine-local — created only if missing so

--- a/docs/terminal-cheatsheet.html
+++ b/docs/terminal-cheatsheet.html
@@ -68,7 +68,7 @@
       <tr><td class="key"><a href="https://github.com/dalance/procs"><code>procs</code></a></td><td class="desc">modern ps replacement (Rust)</td></tr>
       <tr><td class="key"><a href="https://github.com/bensadeh/tailspin"><code>tailspin</code></a></td><td class="desc">live-log highlighter (<code>tspin</code>); Solarized via <code>~/.config/tailspin/theme.toml</code></td></tr>
       <tr><td class="key"><a href="https://lnav.org/"><code>lnav</code></a></td><td class="desc">TUI log navigator; Solarized via built-in theme (see lnav section)</td></tr>
-      <tr><td class="key"><a href="https://github.com/aristocratos/btop"><code>btop</code></a></td><td class="desc">modern <code>top</code> replacement; Solarized via <code>~/.config/btop/btop.conf</code></td></tr>
+      <tr><td class="key"><a href="https://github.com/aristocratos/btop"><code>btop</code></a></td><td class="desc">modern <code>top</code> replacement; follows <code>theme-set</code> (10 themes, restart tier)</td></tr>
       <tr><td class="key"><a href="https://github.com/dlvhdr/gh-dash"><code>gh dash</code></a></td><td class="desc">GitHub TUI for PRs/issues/notifications (<code>ghd</code> abbr); Solarized via <code>~/.config/gh-dash/config.yml</code> — <code>?</code> help, <code>s</code>/<code>S</code> next/prev section, <code>j</code>/<code>k</code> rows, <code>enter</code> preview, <code>o</code> open in browser, <code>r</code> refresh, <code>/</code> filter, <code>q</code> quit</td></tr>
       <tr><td class="key"><a href="https://github.com/Byron/dua-cli"><code>dua</code></a></td><td class="desc">interactive disk-usage analyzer with TUI deleter (<code>dua i</code>; raw, no alias)</td></tr>
       <tr><td class="key"><a href="https://github.com/muesli/duf"><code>duf</code></a></td><td class="desc">modern <code>df</code> replacement (grouped, color-coded; raw, no alias)</td></tr>
@@ -101,7 +101,7 @@
       <tr><td class="key"><code>vi</code></td><td class="desc">→ <code>command vim</code> (legacy minimal vim, suppresses recursive alias)</td></tr>
       <tr><td class="key"><code>ps</code></td><td class="desc">→ <code>procs</code> (Solarized; PID asc; ps-like columns)</td></tr>
       <tr><td class="key"><code>psh</code></td><td class="desc">→ <code>procs --load-config ~/.config/procs/procs-heavy.toml</code> (CPU desc, trimmed)</td></tr>
-      <tr><td class="key"><code>top</code></td><td class="desc">→ <code>btop</code> (modern colorful TUI, Solarized; <code>command top</code> for BSD top)</td></tr>
+      <tr><td class="key"><code>top</code></td><td class="desc">→ <code>btop</code> (modern colorful TUI, follows <code>theme-set</code>; <code>command top</code> for BSD top)</td></tr>
     </table>
     <p class="note">BSD <code>\ls</code> still works (escape skips alias) and uses OMZ's default LSCOLORS. Use <code>command less</code> to reach real <code>less</code> for <code>less +F</code>, <code>-R</code>, etc. <code>command ps</code> / <code>\ps</code> / <code>/bin/ps</code> reach legacy <code>ps</code>.</p>
   </div>
@@ -702,8 +702,8 @@
 
   <div class="card">
     <h3>What follows the theme</h3>
-    <p><strong>Follow <code>theme-set</code>:</strong> bat, git-delta, difftastic, glow/<code>md</code>, vivid/<code>LS_COLORS</code>, fzf, atuin, Ghostty, starship, lnav, gh-dash, tmux, nvim.</p>
-    <p><strong>Stay Solarized Dark:</strong> procs, tailspin (<code>tspin</code>), xh, btop.</p>
+    <p><strong>Follow <code>theme-set</code>:</strong> bat, git-delta, difftastic, glow/<code>md</code>, vivid/<code>LS_COLORS</code>, fzf, atuin, Ghostty, starship, lnav, gh-dash, tmux, nvim, btop.</p>
+    <p><strong>Stay Solarized Dark:</strong> procs, tailspin (<code>tspin</code>), xh.</p>
     <p class="note">fzf + atuin + difftastic auto-adapt via ANSI palette refs (no per-theme file). tmux sources the active palette; nvim reads it at startup. See CLAUDE.md → "Switchable themes".</p>
   </div>
 </div>
@@ -834,7 +834,7 @@
 <span class="cmd">git log -p</span> | <span class="cmd">head</span>                 <span class="c"># should look styled</span></pre>
 
 <footer>
-  Built from <code>~/.config/fish/</code>, <code>Brewfile</code>, and project CLAUDE.md on 2026-05-25.
+  Built from <code>~/.config/fish/</code>, <code>Brewfile</code>, and project CLAUDE.md on 2026-05-29.
   Refresh after meaningful color-tooling changes.
 </footer>
 

--- a/scripts/test-theme-switch.sh
+++ b/scripts/test-theme-switch.sh
@@ -89,6 +89,7 @@ assert_link "$HOME/.config/starship.toml"                     "starship-mocha.to
 assert_link "$HOME/.config/glow/glamour.json"                 "glamour-mocha.json"       "glow glamour.json → glamour-mocha.json"
 assert_gh_dash_config "#cdd6f4" "gh-dash config.yml ← base + theme-colors-mocha"
 assert_link "$HOME/.config/lnav/configs/installed/theme.json" "theme-mocha.json"         "lnav theme.json → theme-mocha.json"
+assert_link "$HOME/.config/btop/themes/current.theme" "catppuccin_mocha.theme" "btop current.theme → catppuccin_mocha.theme"
 
 # Forward: mocha → frappe
 run_theme_set frappe
@@ -99,6 +100,7 @@ assert_link "$HOME/.config/starship.toml"                     "starship-frappe.t
 assert_link "$HOME/.config/glow/glamour.json"                 "glamour-frappe.json"        "glow glamour.json → glamour-frappe.json"
 assert_gh_dash_config "#c6d0f5" "gh-dash config.yml ← base + theme-colors-frappe"
 assert_link "$HOME/.config/lnav/configs/installed/theme.json" "theme-frappe.json"          "lnav theme.json → theme-frappe.json"
+assert_link "$HOME/.config/btop/themes/current.theme" "catppuccin_frappe.theme" "btop current.theme → catppuccin_frappe.theme"
 
 # Forward: frappe → dracula
 run_theme_set dracula
@@ -109,6 +111,7 @@ assert_link "$HOME/.config/starship.toml"                     "starship-dracula.
 assert_link "$HOME/.config/glow/glamour.json"                 "glamour-dracula.json"       "glow glamour.json → glamour-dracula.json"
 assert_gh_dash_config "#f8f8f2" "gh-dash config.yml ← base + theme-colors-dracula"
 assert_link "$HOME/.config/lnav/configs/installed/theme.json" "theme-dracula.json"         "lnav theme.json → theme-dracula.json"
+assert_link "$HOME/.config/btop/themes/current.theme" "dracula.theme" "btop current.theme → dracula.theme"
 
 # Forward: dracula → gruvbox
 run_theme_set gruvbox
@@ -119,6 +122,7 @@ assert_link "$HOME/.config/starship.toml"                     "starship-gruvbox.
 assert_link "$HOME/.config/glow/glamour.json"                 "glamour-gruvbox.json"       "glow glamour.json → glamour-gruvbox.json"
 assert_gh_dash_config "#ebdbb2" "gh-dash config.yml ← base + theme-colors-gruvbox"
 assert_link "$HOME/.config/lnav/configs/installed/theme.json" "theme-gruvbox.json"         "lnav theme.json → theme-gruvbox.json"
+assert_link "$HOME/.config/btop/themes/current.theme" "gruvbox_dark.theme" "btop current.theme → gruvbox_dark.theme"
 
 # Forward: gruvbox → tokyo-night
 run_theme_set tokyo-night
@@ -129,6 +133,7 @@ assert_link "$HOME/.config/starship.toml"                     "starship-tokyo-ni
 assert_link "$HOME/.config/glow/glamour.json"                 "glamour-tokyo-night.json"       "glow glamour.json → glamour-tokyo-night.json"
 assert_gh_dash_config "#c0caf5" "gh-dash config.yml ← base + theme-colors-tokyo-night"
 assert_link "$HOME/.config/lnav/configs/installed/theme.json" "theme-tokyo-night.json"         "lnav theme.json → theme-tokyo-night.json"
+assert_link "$HOME/.config/btop/themes/current.theme" "tokyo-storm.theme" "btop current.theme → tokyo-storm.theme"
 
 # Forward: tokyo-night → nord
 run_theme_set nord
@@ -139,6 +144,7 @@ assert_link "$HOME/.config/starship.toml"                     "starship-nord.tom
 assert_link "$HOME/.config/glow/glamour.json"                 "glamour-nord.json"       "glow glamour.json → glamour-nord.json"
 assert_gh_dash_config "#d8dee9" "gh-dash config.yml ← base + theme-colors-nord"
 assert_link "$HOME/.config/lnav/configs/installed/theme.json" "theme-nord.json"         "lnav theme.json → theme-nord.json"
+assert_link "$HOME/.config/btop/themes/current.theme" "nord.theme" "btop current.theme → nord.theme"
 
 # Forward: nord → rose-pine
 run_theme_set rose-pine
@@ -149,6 +155,7 @@ assert_link "$HOME/.config/starship.toml"                     "starship-rose-pin
 assert_link "$HOME/.config/glow/glamour.json"                 "glamour-rose-pine.json"       "glow glamour.json → glamour-rose-pine.json"
 assert_gh_dash_config "#e0def4" "gh-dash config.yml ← base + theme-colors-rose-pine"
 assert_link "$HOME/.config/lnav/configs/installed/theme.json" "theme-rose-pine.json"         "lnav theme.json → theme-rose-pine.json"
+assert_link "$HOME/.config/btop/themes/current.theme" "rose-pine.theme" "btop current.theme → rose-pine.theme"
 
 # Forward: rose-pine → rose-pine-moon
 run_theme_set rose-pine-moon
@@ -159,6 +166,7 @@ assert_link "$HOME/.config/starship.toml"                     "starship-rose-pin
 assert_link "$HOME/.config/glow/glamour.json"                 "glamour-rose-pine-moon.json"       "glow glamour.json → glamour-rose-pine-moon.json"
 assert_gh_dash_config "#e0def4" "gh-dash config.yml ← base + theme-colors-rose-pine-moon"
 assert_link "$HOME/.config/lnav/configs/installed/theme.json" "theme-rose-pine-moon.json"         "lnav theme.json → theme-rose-pine-moon.json"
+assert_link "$HOME/.config/btop/themes/current.theme" "rose-pine-moon.theme" "btop current.theme → rose-pine-moon.theme"
 
 # Forward: rose-pine-moon → latte (partial-coverage theme — only ghostty/tmux/starship
 # flip; delta/glow/lnav/gh-dash stay on nord by design, see spec).
@@ -167,6 +175,7 @@ run_theme_set latte
 assert_link "$HOME/.config/themes/current.tmux"               "latte.tmux"               "current.tmux → latte.tmux"
 assert_link "$HOME/.config/ghostty/theme.ghostty"             "theme-latte.ghostty"      "ghostty theme.ghostty → theme-latte.ghostty"
 assert_link "$HOME/.config/starship.toml"                     "starship-latte.toml"      "starship.toml → starship-latte.toml"
+assert_link "$HOME/.config/btop/themes/current.theme" "catppuccin_latte.theme" "btop current.theme → catppuccin_latte.theme (full coverage incl. Latte)"
 # Negative contract — what does NOT flip (partial coverage stays on previous theme = rose-pine-moon):
 assert_link "$HOME/.config/themes/delta-current.gitconfig"    "delta-rose-pine-moon.gitconfig"    "delta stays on rose-pine-moon (no delta-latte.gitconfig)"
 assert_link "$HOME/.config/glow/glamour.json"                 "glamour-rose-pine-moon.json"       "glow stays on rose-pine-moon (no glamour-latte.json)"
@@ -178,6 +187,7 @@ run_theme_set solarized
 assert_link "$HOME/.config/themes/current.tmux"               "solarized.tmux"             "current.tmux → solarized.tmux (reverse)"
 assert_link "$HOME/.config/ghostty/theme.ghostty"             "theme-solarized.ghostty"    "ghostty theme.ghostty → theme-solarized.ghostty (reverse)"
 assert_link "$HOME/.config/starship.toml"                     "starship-solarized.toml"    "starship.toml → starship-solarized.toml (reverse)"
+assert_link "$HOME/.config/btop/themes/current.theme" "solarized_dark.theme" "btop current.theme → solarized_dark.theme (reverse)"
 
 # Restore starting state.
 run_theme_set "$start_theme"


### PR DESCRIPTION
Closes #316.

## 🎯 What

Wires `btop` into the `theme-set <name>` switcher so it follows the active scheme across all 10 themes, instead of being pinned to `solarized_dark`.

Mechanism: `btop.conf` reads a stable `color_theme = "current"`; `theme-set` flips `~/.config/btop/themes/current.theme` to one of 10 sibling `.theme` files (existence-guarded, same idiom as every other theme-set follower). btop has no live reload, so it sits in the **restart tier**.

## 🧩 Changes

- 🎨 **Vendored 5 upstream themes** not shipped by brew — Catppuccin Mocha/Frappé/Latte (`catppuccin/btop`) + Rosé Pine / Rosé Pine Moon (`rose-pine/btop`), pinned-SHA MIT ports with attribution headers.
- 🔧 **`btop.conf.template`** → `color_theme = "current"` (the indirection).
- 🔧 **`bootstrap.sh`** → `~/.config/btop/themes/` is now a mixed-dir: 5 vendored per-file symlinks + 5 brew shims (`/opt/homebrew/share/btop/themes/`) + a machine-local `current.theme` guard (defaults to `solarized_dark.theme`, survives re-runs).
- 🐟 **`theme-set.fish`** → adds `btop_theme` per case + an existence-guarded `current.theme` flip + btop in the restart-tier echo.
- 🧪 **`test-theme-switch.sh`** → one btop assertion per theme block (Latte in the positive contract; reverse covered).
- 📄 **`CLAUDE.md`** → btop bullet rewritten + added to the `theme-set` Follow: list.

## 🛠️ Extra fix found while smoke-testing

The live `btop.conf` is machine-local and only ever **seeded** (idempotent — written when absent). A machine that seeded *before* this change keeps its old `color_theme = "solarized_dark"` and silently ignores the new symlink, so the feature would do nothing on existing machines (including mine).

Added a guarded, idempotent migration in `bootstrap.sh` that forces the single `color_theme` line to `"current"`; btop preserves it across `save_config_on_exit`. Fresh machines were already covered by the new template.

## ✅ Test plan

- 🧪 `scripts/test-theme-switch.sh` → **76 passed, 0 failed** (10 new btop assertions across all themes + reverse).
- 🐟 `scripts/test-fish-loads.sh` → fish config loads clean.
- 📊 `scripts/test-theme-font-stats.sh` → 44/44 (theme-set var addition didn't regress `--stats`).
- 🔁 `./bootstrap.sh` runs clean and is idempotent (migration fires once, no-ops on re-run).
- 👁️ End-to-end: `theme-set {solarized,gruvbox,rose-pine-moon}` flips `current.theme` while `btop.conf color_theme` stays `"current"` throughout.

## ⚠️ Notes / risks

- 🔗 In a worktree, `bootstrap.sh` sources tracked files from the **primary** checkout, so the 5 vendored symlinks only materialize there after merge; verification here used worktree-pointed scaffolding symlinks (re-pointed automatically by the next bootstrap on `main`). Brew shims and the migration are unaffected.
- 🖥️ btop has no live reload — relaunch to see a theme change (documented restart-tier behavior).