### PR TITLE
🩹 fish: clear TERMINFO inside tmux so termbox TUIs (ctop) stop panicking

### DIFF
--- a/.config/fish/conf.d/00-env.fish
+++ b/.config/fish/conf.d/00-env.fish
@@ -70,8 +70,20 @@ if test (uname) = Linux; and test -d /Users
     set -gx MISE_IGNORED_CONFIG_PATHS /Users
 end
 
-# Force Claude Code truecolor inside tmux. Single env line; the only tmux
-# integration that survives B-scope.
+# Tweaks that only apply inside tmux (no-ops elsewhere, incl. the sandbox where
+# $TMUX is unset).
 if test -n "$TMUX"
+    # Force Claude Code truecolor — the only tmux integration that survives
+    # B-scope.
     set -gx CLAUDE_CODE_TMUX_TRUECOLOR 1
+
+    # TERM is tmux-256color here, but Ghostty still exports TERMINFO pointing at
+    # its app bundle (which ships only ghostty/xterm-ghostty). nsf/termbox-go —
+    # ctop and other legacy TUIs — treats TERMINFO as exclusive ("no other
+    # directory should be searched"), so it can't find tmux-256color and panics
+    # with "termbox: unsupported terminal". Clearing it lets termbox fall back to
+    # /usr/share/terminfo, where tmux-256color lives. Safe: ncurses tools already
+    # fall back there, and Ghostty's own entries are mirrored in ~/.terminfo (and
+    # never used inside tmux anyway).
+    set -e TERMINFO
 end


### PR DESCRIPTION
## 🐛 Problem

`ctop` panics on launch **inside tmux**:

```
panic: termbox: error while reading terminfo data: termbox: unsupported terminal
```

It never reaches Docker — this is a terminal-setup failure.

## 🔍 Root cause

- Ghostty exports `TERMINFO=/Applications/Ghostty.app/Contents/Resources/terminfo` so its bundled `xterm-ghostty` resolves on any machine; tmux and every pane inherit it.
- Inside tmux `TERM` becomes `tmux-256color`, but that bundle ships only `ghostty` / `xterm-ghostty`.
- ctop's TUI lib (`nsf/termbox-go` via `gizak/termui`) treats `TERMINFO` as **exclusive** — `// if TERMINFO is set, no other directory should be searched` — so it never reaches the system db, can't find `tmux-256color`, and its tiny builtin fallback list (`xterm`/`rxvt`/`screen`/…) doesn't substring-match `tmux-256color` → panic.
- ncurses tools (vim/less/top/…) tolerate this only because they *fall back* to `~/.terminfo` + `/usr/share/terminfo`; termbox-go uniquely does not.

## 🩹 Fix

Clear `TERMINFO` for shells inside tmux (`00-env.fish`, folded into the existing `$TMUX` guard). termbox then falls back to `/usr/share/terminfo/74/tmux-256color`, which exists.

## ✅ Why it's safe

- `TERMINFO`-unset is the default state on essentially every machine; Ghostty *setting* it is the anomaly.
- ncurses still resolves `tmux-256color` with it unset (verified via `infocmp`).
- Ghostty's two entries (`ghostty`, `xterm-ghostty`) are also mirrored in `~/.terminfo`, and are never used inside tmux anyway (`TERM` is `tmux-256color` there).
- Scoped to `$TMUX`; outside tmux and in the sandbox (no `$TMUX`) nothing changes.

## 🧪 Verification

- ✅ `scripts/test-fish-loads.sh` passes.
- ✅ Sourcing `00-env.fish` inside tmux clears `TERMINFO`.
- ✅ termbox's terminfo lookup reproduced by hand against the real filesystem: missing in Ghostty's bundle, present at `/usr/share/terminfo/74/tmux-256color`.
- ✅ **Confirmed live:** `ctop` opens cleanly in a new tmux pane (no panic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
