### PR TITLE
🎨 lazygit: follow theme-set across all 10 themes

### DIFF
--- a/.config/fish/functions/theme-set.fish
+++ b/.config/fish/functions/theme-set.fish
@@ -107,6 +107,17 @@ function theme-set --description 'Switch colour scheme; bare = show current, --s
             > ~/.config/gh-dash/config.yml
     end
 
+    # lazygit live config is a generated real file, same contract as gh-dash:
+    # config-base.yml has no `gui:` key; theme-colors-$name.yml has only the
+    # `gui.theme` block — plain concatenation is valid YAML. lazygit reads its
+    # theme at launch (restart tier), so this repaints on the next launch.
+    if test -f ~/.config/lazygit/theme-colors-$name.yml
+        cat \
+            ~/.config/lazygit/config-base.yml \
+            ~/.config/lazygit/theme-colors-$name.yml \
+            > ~/.config/lazygit/config.yml
+    end
+
     # Persisted env vars; survive shell restarts. Open shells need new
     # session to pick up the values. BAT_THEME is read by bat at startup;
     # VIVID_THEME is read by .config/fish/conf.d/10-colors.fish at fish
@@ -127,7 +138,7 @@ function theme-set --description 'Switch colour scheme; bare = show current, --s
 
     echo "theme → $name"
     echo "  live:    tmux + helpers, starship (next prompt), glow, delta"
-    echo "  restart: bat + ls colors (new shells for \$BAT_THEME / \$VIVID_THEME), nvim, gh-dash, lnav"
+    echo "  restart: bat + ls colors (new shells for \$BAT_THEME / \$VIVID_THEME), nvim, gh-dash, lnav, lazygit"
     # Ghostty 1.3 limitation: reload_config does NOT repaint existing surfaces
     # when `theme` changes — only NEW windows/tabs/splits opened after reload
     # pick up the new palette. Existing windows keep their old theme until a

--- a/.config/lazygit/config-base.yml
+++ b/.config/lazygit/config-base.yml
@@ -1,0 +1,9 @@
+# lazygit config — managed by theme-set.
+# Edit THIS file (config-base.yml), never the generated config.yml.
+# theme-set writes config.yml = config-base.yml + theme-colors-<name>.yml.
+# Keep this file free of any `gui:` key — the theme block is appended from
+# theme-colors-<name>.yml, and a second top-level `gui:` would be invalid YAML.
+git:
+  paging:
+    colorArg: always
+    pager: delta --paging=never

--- a/.config/lazygit/theme-colors-dracula.yml
+++ b/.config/lazygit/theme-colors-dracula.yml
@@ -1,0 +1,32 @@
+# Derived from .config/themes/dracula.* palette
+# activeBorderColor uses Dracula purple, not @color_accent_blue (which the
+# palette intentionally aliases to the comment grey #6272a4 = muted_fg, so it
+# would collide with inactiveBorderColor).
+gui:
+  theme:
+    activeBorderColor:
+      - "#bd93f9"
+      - bold
+    inactiveBorderColor:
+      - "#6272a4"
+    searchingActiveBorderColor:
+      - "#f1fa8c"
+      - bold
+    optionsTextColor:
+      - "#8be9fd"
+    selectedLineBgColor:
+      - "#282a36"
+    inactiveViewSelectedLineBgColor:
+      - "#21222c"
+    cherryPickedCommitFgColor:
+      - "#21222c"
+    cherryPickedCommitBgColor:
+      - "#ff79c6"
+    markedBaseCommitFgColor:
+      - "#21222c"
+    markedBaseCommitBgColor:
+      - "#f1fa8c"
+    unstagedChangesColor:
+      - "#ff5555"
+    defaultFgColor:
+      - "#f8f8f2"

--- a/.config/lazygit/theme-colors-frappe.yml
+++ b/.config/lazygit/theme-colors-frappe.yml
@@ -1,0 +1,28 @@
+# Source: catppuccin/lazygit (themes-mergable/frappe/blue.yml)  MIT
+gui:
+  theme:
+    activeBorderColor:
+      - '#8caaee'
+      - bold
+    inactiveBorderColor:
+      - '#a5adce'
+    searchingActiveBorderColor:
+      - '#e5c890'
+    optionsTextColor:
+      - '#8caaee'
+    selectedLineBgColor:
+      - '#414559'
+    inactiveViewSelectedLineBgColor:
+      - '#737994'
+    cherryPickedCommitFgColor:
+      - '#8caaee'
+    cherryPickedCommitBgColor:
+      - '#51576d'
+    markedBaseCommitFgColor:
+      - '#8caaee'
+    markedBaseCommitBgColor:
+      - '#e5c890'
+    unstagedChangesColor:
+      - '#e78284'
+    defaultFgColor:
+      - '#c6d0f5'

--- a/.config/lazygit/theme-colors-gruvbox.yml
+++ b/.config/lazygit/theme-colors-gruvbox.yml
@@ -1,0 +1,29 @@
+# Derived from .config/themes/gruvbox.* palette
+gui:
+  theme:
+    activeBorderColor:
+      - "#458588"
+      - bold
+    inactiveBorderColor:
+      - "#928374"
+    searchingActiveBorderColor:
+      - "#d79921"
+      - bold
+    optionsTextColor:
+      - "#689d6a"
+    selectedLineBgColor:
+      - "#3c3836"
+    inactiveViewSelectedLineBgColor:
+      - "#282828"
+    cherryPickedCommitFgColor:
+      - "#282828"
+    cherryPickedCommitBgColor:
+      - "#b16286"
+    markedBaseCommitFgColor:
+      - "#282828"
+    markedBaseCommitBgColor:
+      - "#d79921"
+    unstagedChangesColor:
+      - "#cc241d"
+    defaultFgColor:
+      - "#ebdbb2"

--- a/.config/lazygit/theme-colors-latte.yml
+++ b/.config/lazygit/theme-colors-latte.yml
@@ -1,0 +1,28 @@
+# Source: catppuccin/lazygit (themes-mergable/latte/blue.yml)  MIT
+gui:
+  theme:
+    activeBorderColor:
+      - '#1e66f5'
+      - bold
+    inactiveBorderColor:
+      - '#6c6f85'
+    searchingActiveBorderColor:
+      - '#df8e1d'
+    optionsTextColor:
+      - '#1e66f5'
+    selectedLineBgColor:
+      - '#ccd0da'
+    inactiveViewSelectedLineBgColor:
+      - '#9ca0b0'
+    cherryPickedCommitFgColor:
+      - '#1e66f5'
+    cherryPickedCommitBgColor:
+      - '#bcc0cc'
+    markedBaseCommitFgColor:
+      - '#1e66f5'
+    markedBaseCommitBgColor:
+      - '#df8e1d'
+    unstagedChangesColor:
+      - '#d20f39'
+    defaultFgColor:
+      - '#4c4f69'

--- a/.config/lazygit/theme-colors-mocha.yml
+++ b/.config/lazygit/theme-colors-mocha.yml
@@ -1,0 +1,28 @@
+# Source: catppuccin/lazygit (themes-mergable/mocha/blue.yml)  MIT
+gui:
+  theme:
+    activeBorderColor:
+      - '#89b4fa'
+      - bold
+    inactiveBorderColor:
+      - '#a6adc8'
+    searchingActiveBorderColor:
+      - '#f9e2af'
+    optionsTextColor:
+      - '#89b4fa'
+    selectedLineBgColor:
+      - '#313244'
+    inactiveViewSelectedLineBgColor:
+      - '#6c7086'
+    cherryPickedCommitFgColor:
+      - '#89b4fa'
+    cherryPickedCommitBgColor:
+      - '#45475a'
+    markedBaseCommitFgColor:
+      - '#89b4fa'
+    markedBaseCommitBgColor:
+      - '#f9e2af'
+    unstagedChangesColor:
+      - '#f38ba8'
+    defaultFgColor:
+      - '#cdd6f4'

--- a/.config/lazygit/theme-colors-nord.yml
+++ b/.config/lazygit/theme-colors-nord.yml
@@ -1,0 +1,32 @@
+# Derived from .config/themes/nord.* palette
+# Selection bgs intentionally swapped vs the other derived themes: nord0
+# (#2e3440 = bar_bg) ≈ main bg and reads invisible as a selection, so nord1
+# (#3b4252 = deep_bg) is used for the active selection instead.
+gui:
+  theme:
+    activeBorderColor:
+      - "#5e81ac"
+      - bold
+    inactiveBorderColor:
+      - "#4c566a"
+    searchingActiveBorderColor:
+      - "#ebcb8b"
+      - bold
+    optionsTextColor:
+      - "#88c0d0"
+    selectedLineBgColor:
+      - "#3b4252"
+    inactiveViewSelectedLineBgColor:
+      - "#2e3440"
+    cherryPickedCommitFgColor:
+      - "#2e3440"
+    cherryPickedCommitBgColor:
+      - "#b48ead"
+    markedBaseCommitFgColor:
+      - "#2e3440"
+    markedBaseCommitBgColor:
+      - "#ebcb8b"
+    unstagedChangesColor:
+      - "#bf616a"
+    defaultFgColor:
+      - "#d8dee9"

--- a/.config/lazygit/theme-colors-rose-pine-moon.yml
+++ b/.config/lazygit/theme-colors-rose-pine-moon.yml
@@ -1,0 +1,30 @@
+# Source: rose-pine/lazygit (themes/rose-pine-moon.yml)  MIT
+gui:
+  theme:
+    activeBorderColor:
+      - "#3e8fb0"
+      - bold
+    inactiveBorderColor:
+      - "#6e6a86"
+    searchingActiveBorderColor:
+      - "#ea9a97"
+      - bold
+    optionsTextColor:
+      - "#9ccfd8"
+    selectedLineBgColor:
+      - "#3e8fb0"
+    inactiveViewSelectedLineBgColor:
+      - "#393552"
+      - bold
+    cherryPickedCommitFgColor:
+      - "#2a273f"
+    cherryPickedCommitBgColor:
+      - "#ea9a97"
+    markedBaseCommitFgColor:
+      - "#9ccfd8"
+    markedBaseCommitBgColor:
+      - "#f6c177"
+    unstagedChangesColor:
+      - "#eb6f92"
+    defaultFgColor:
+      - "#e0def4"

--- a/.config/lazygit/theme-colors-rose-pine.yml
+++ b/.config/lazygit/theme-colors-rose-pine.yml
@@ -1,0 +1,30 @@
+# Source: rose-pine/lazygit (themes/rose-pine.yml)  MIT
+gui:
+  theme:
+    activeBorderColor:
+      - "#31748f"
+      - bold
+    inactiveBorderColor:
+      - "#6e6a86"
+    searchingActiveBorderColor:
+      - "#ebbcba"
+      - bold
+    optionsTextColor:
+      - "#9ccfd8"
+    selectedLineBgColor:
+      - "#31748f"
+    inactiveViewSelectedLineBgColor:
+      - "#26233a"
+      - bold
+    cherryPickedCommitFgColor:
+      - "#1f1d2e"
+    cherryPickedCommitBgColor:
+      - "#ebbcba"
+    markedBaseCommitFgColor:
+      - "#9ccfd8"
+    markedBaseCommitBgColor:
+      - "#f6c177"
+    unstagedChangesColor:
+      - "#eb6f92"
+    defaultFgColor:
+      - "#e0def4"

--- a/.config/lazygit/theme-colors-solarized.yml
+++ b/.config/lazygit/theme-colors-solarized.yml
@@ -1,0 +1,29 @@
+# Derived from .config/themes/solarized.* palette
+gui:
+  theme:
+    activeBorderColor:
+      - "#268bd2"
+      - bold
+    inactiveBorderColor:
+      - "#586e75"
+    searchingActiveBorderColor:
+      - "#b58900"
+      - bold
+    optionsTextColor:
+      - "#2aa198"
+    selectedLineBgColor:
+      - "#073642"
+    inactiveViewSelectedLineBgColor:
+      - "#002b36"
+    cherryPickedCommitFgColor:
+      - "#002b36"
+    cherryPickedCommitBgColor:
+      - "#d33682"
+    markedBaseCommitFgColor:
+      - "#002b36"
+    markedBaseCommitBgColor:
+      - "#b58900"
+    unstagedChangesColor:
+      - "#dc322f"
+    defaultFgColor:
+      - "#839496"

--- a/.config/lazygit/theme-colors-tokyo-night.yml
+++ b/.config/lazygit/theme-colors-tokyo-night.yml
@@ -1,0 +1,29 @@
+# Derived from .config/themes/tokyo-night.* palette (Storm)
+gui:
+  theme:
+    activeBorderColor:
+      - "#7aa2f7"
+      - bold
+    inactiveBorderColor:
+      - "#565f89"
+    searchingActiveBorderColor:
+      - "#e0af68"
+      - bold
+    optionsTextColor:
+      - "#7dcfff"
+    selectedLineBgColor:
+      - "#24283b"
+    inactiveViewSelectedLineBgColor:
+      - "#1a1b26"
+    cherryPickedCommitFgColor:
+      - "#1a1b26"
+    cherryPickedCommitBgColor:
+      - "#bb9af7"
+    markedBaseCommitFgColor:
+      - "#1a1b26"
+    markedBaseCommitBgColor:
+      - "#e0af68"
+    unstagedChangesColor:
+      - "#f7768e"
+    defaultFgColor:
+      - "#c0caf5"

--- a/.dockerignore
+++ b/.dockerignore
@@ -11,6 +11,7 @@
 !.config/glow
 !.config/lnav
 !.config/git
+!.config/lazygit
 !.config/starship-solarized.toml
 !.config/starship-mocha.toml
 !.config/starship-frappe.toml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,7 +178,7 @@ bootstrap defaults. See "Switchable themes" / "Switchable Ghostty fonts" below.
 - **Bells silenced at every layer** (Ghostty `bell-features=`, vim `belloff=all`,
   tmux bell/visual/monitor off). Don't re-enable.
 - **Terminal tools default Solarized Dark; some follow `theme-set`.** Follow:
-  `bat`, `git-delta`, `glow`/`md`, `vivid`/`LS_COLORS`, fzf, atuin. Stay
+  `bat`, `git-delta`, `glow`/`md`, `vivid`/`LS_COLORS`, fzf, atuin, `lazygit`. Stay
   Solarized-only: `procs`, `tailspin` (`tspin`), `xh`. `bat --theme="Solarized
   (dark)"` is the unset fallback. No `tail` alias. Don't introduce alternatives
   (`exa`/`lsd`/`diff-so-fancy`/`mdcat`). Delta git config: README → Setup.
@@ -211,6 +211,17 @@ bootstrap defaults. See "Switchable themes" / "Switchable Ghostty fonts" below.
   `cat` — **don't add `yq`** or a top-level `theme:` to the base (smoke test
   asserts one `^theme:` line). Bootstrap auto-installs the extension. Don't
   re-fragment sections.
+- **`lazygit` (git TUI; `<leader>gg` + standalone).** Mixed-dir
+  `.config/lazygit/`: `config-base.yml` (delta paging, **no `gui:` key**) +
+  `theme-colors-<name>.yml` (only the `gui.theme` block). Live `config.yml`
+  is **generated** by `theme-set` via plain `cat base + theme-colors-<name>`
+  (gh-dash pattern) — machine-local, never a symlink, never add a `gui:` to
+  the base (smoke asserts exactly one `^gui:`). **Restart tier** — lazygit
+  reads the theme at launch; relaunch to repaint. **Full 10-theme coverage
+  incl. Latte** (catppuccin ships a Latte block), so unlike most followers
+  Latte flips rather than degrades. rose-pine/catppuccin vendored upstream
+  (MIT); solarized/dracula/gruvbox/tokyo-night/nord derived from
+  `.config/themes/<name>.*`. Bootstrap seeds solarized (don't-clobber).
 - **`bd` is beads (raw), stealth mode** (`bd init --stealth`): `.beads/` +
   `.claude/settings.local.json` in `.git/info/exclude`, `no-git-ops: true`.
   Re-init only via `--stealth`. **Don't use bd's memory layer** — memory is
@@ -253,11 +264,14 @@ bootstrap defaults. See "Switchable themes" / "Switchable Ghostty fonts" below.
   keeping the volume. Secrets injected at runtime (never baked). Build needs
   `GITHUB_TOKEN`. Active Mac theme is baked + re-applied on entry; in-container
   theme *switcher*, tmux, sesh, gh, bd, font-set, vhs out of scope. The sandbox
-  starship prompt is the one theme tool whose config is **generated** (not
-  symlinked): `stage_theme` injects a container-gated penguin glyph + native
-  git branch/status into a copy of the active `starship-<theme>.toml`, so the
-  in-sandbox prompt shows container + git context while the Mac's shared tomls
-  stay git-less (#280). **nvimpager** is the sole non-mise sandbox tool —
+  starship prompt is the one theme tool whose config is **transformed** when
+  generated (not symlinked): `stage_theme` injects a container-gated penguin
+  glyph + native git branch/status into a copy of the active
+  `starship-<theme>.toml`, so the in-sandbox prompt shows container + git
+  context while the Mac's shared tomls stay git-less (#280). `lazygit` also
+  follows in-sandbox — `stage_theme` regenerates its `config.yml` by plain
+  `cat` (host-identical, no transform). **nvimpager** is the sole non-mise
+  sandbox tool —
   `stage_nvimpager` clones it + `make install-no-man` (no prebuilt release
   assets), config copied like nvim's (#283). Smoke: `scripts/test-sandbox.sh`
   (also run in CI: `.github/workflows/sandbox.yml`, arm64, on sandbox-path PRs +

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -217,6 +217,28 @@ if ! gh extension list 2>/dev/null | grep -q '^gh dash'; then
     echo "⚠️  gh extension install failed (network?) — re-run bootstrap when online"
 fi
 
+# --- lazygit (git TUI; <leader>gg in LazyVim + standalone; switchable theme)
+# ~/.config/lazygit/ is a real dir. Shared schema lives in config-base.yml
+# (delta paging, no gui.theme); per-theme gui.theme blocks live in
+# theme-colors-<name>.yml. The live config.yml is generated (cat base +
+# theme-colors-<name>) — never a symlink — so it stays machine-local and
+# theme-set can rewrite it. Mirrors the gh-dash pattern above.
+prepare_real_dir "$HOME/.config/lazygit"
+# Drop a legacy whole-dir/config.yml symlink if a prior setup left one.
+if [ -L "$HOME/.config/lazygit/config.yml" ]; then
+    rm "$HOME/.config/lazygit/config.yml"
+    echo "🗑️  $HOME/.config/lazygit/config.yml (legacy symlink)"
+fi
+link_tracked_entries ".config/lazygit" "$HOME/.config/lazygit"
+# Seed the generated config.yml once (solarized default). "Don't clobber":
+# never overwrite an existing pick, so a prior theme-set survives bootstrap.
+if [ ! -f "$HOME/.config/lazygit/config.yml" ]; then
+    cat "$HOME/.config/lazygit/config-base.yml" \
+        "$HOME/.config/lazygit/theme-colors-solarized.yml" \
+        > "$HOME/.config/lazygit/config.yml"
+    echo "✨  $HOME/.config/lazygit/config.yml (seeded from base + solarized)"
+fi
+
 # --- lnav (TUI log navigator)
 # ~/.config/lnav/ is a real dir. formats/installed/ is whole-dir-symlinked to
 # the repo. configs/installed/ is mixed-dir: tracked theme variants

--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -55,6 +55,7 @@ RUN bash /home/${USER}/.sandbox/install-linux.sh config
 COPY --chown=${USER}:${USER} .config/themes /home/${USER}/.config/themes
 COPY --chown=${USER}:${USER} .config/glow /home/${USER}/.config/glow
 COPY --chown=${USER}:${USER} .config/lnav/configs/installed /home/${USER}/.config/lnav/configs/installed
+COPY --chown=${USER}:${USER} .config/lazygit /home/${USER}/.config/lazygit
 COPY --chown=${USER}:${USER} .config/starship-*.toml /home/${USER}/.config/
 # --- shared git aliases (theme-independent static file; the include is wired
 # into the generated ~/.gitconfig by stage_theme below).

--- a/sandbox/install-linux.sh
+++ b/sandbox/install-linux.sh
@@ -148,6 +148,20 @@ stage_theme() {
   [ -f "$cfg/lnav/configs/installed/theme-$name.json" ] \
     && ln -sfn "theme-$name.json" "$cfg/lnav/configs/installed/theme.json"
 
+  # lazygit: generated real config.yml (cat base + theme-colors), same contract
+  # as gh-dash on the host. lazygit is in the sandbox toolset (mise.toml), so it
+  # follows the active theme inside the container. Existence-guarded; the floor
+  # (solarized) always ships a theme-colors file so config.yml is never empty.
+  if [ -f "$cfg/lazygit/theme-colors-$name.yml" ]; then
+    cat "$cfg/lazygit/config-base.yml" \
+        "$cfg/lazygit/theme-colors-$name.yml" \
+        > "$cfg/lazygit/config.yml"
+  elif [ -f "$cfg/lazygit/theme-colors-solarized.yml" ]; then
+    cat "$cfg/lazygit/config-base.yml" \
+        "$cfg/lazygit/theme-colors-solarized.yml" \
+        > "$cfg/lazygit/config.yml"
+  fi
+
   # git wiring — write a minimal ~/.gitconfig only if absent (the sandbox ships
   # the delta binary but never wires it as git's pager; mirrors README step 3).
   # It includes both the theme-dependent delta config and the theme-independent

--- a/scripts/test-theme-switch.sh
+++ b/scripts/test-theme-switch.sh
@@ -58,6 +58,44 @@ assert_gh_dash_config() {
     fi
 }
 
+# lazygit's live config.yml is a generated real file (cat base + theme-colors)
+# like gh-dash, but the theme lives under `gui: -> theme:` (indented), not a
+# top-level `theme:`. Assert: (1) not a symlink, (2) exists, (3) exactly one
+# top-level `gui:` key (catches a stray gui:/theme block leaking into
+# config-base.yml), (4) contains the theme's signature hex (quote-agnostic —
+# vendored blocks use ' or ", derived blocks may differ).
+assert_lazygit_config() {
+    local want_hex="$1" desc="$2"
+    local path="$HOME/.config/lazygit/config.yml"
+    if [ -L "$path" ]; then
+        fail=$((fail+1))
+        fail_msgs+=("FAIL  $desc"$'\n'"        path: $path"$'\n'"        is a symlink; expected a generated real file")
+        echo "  FAIL  $desc"
+        return
+    fi
+    if [ ! -f "$path" ]; then
+        fail=$((fail+1))
+        fail_msgs+=("FAIL  $desc"$'\n'"        path: $path missing")
+        echo "  FAIL  $desc"
+        return
+    fi
+    local gui_keys; gui_keys=$(grep -c "^gui:" "$path")
+    if [ "$gui_keys" -ne 1 ]; then
+        fail=$((fail+1))
+        fail_msgs+=("FAIL  $desc"$'\n'"        path: $path"$'\n'"        expected 1 top-level gui: key, got $gui_keys")
+        echo "  FAIL  $desc"
+        return
+    fi
+    if grep -q "$want_hex" "$path"; then
+        pass=$((pass+1))
+        echo "  PASS  $desc"
+    else
+        fail=$((fail+1))
+        fail_msgs+=("FAIL  $desc"$'\n'"        path: $path"$'\n'"        did not contain $want_hex")
+        echo "  FAIL  $desc"
+    fi
+}
+
 REPO="${REPO:-$PROJECTS_HOME/dotfiles}"
 THEME_SET_FN="$REPO/.config/fish/functions/theme-set.fish"
 
@@ -88,6 +126,7 @@ assert_link "$HOME/.config/ghostty/theme.ghostty"             "theme-mocha.ghost
 assert_link "$HOME/.config/starship.toml"                     "starship-mocha.toml"      "starship.toml → starship-mocha.toml"
 assert_link "$HOME/.config/glow/glamour.json"                 "glamour-mocha.json"       "glow glamour.json → glamour-mocha.json"
 assert_gh_dash_config "#cdd6f4" "gh-dash config.yml ← base + theme-colors-mocha"
+assert_lazygit_config "#89b4fa" "lazygit config.yml ← base + theme-colors-mocha"
 assert_link "$HOME/.config/lnav/configs/installed/theme.json" "theme-mocha.json"         "lnav theme.json → theme-mocha.json"
 
 # Forward: mocha → frappe
@@ -98,6 +137,7 @@ assert_link "$HOME/.config/ghostty/theme.ghostty"             "theme-frappe.ghos
 assert_link "$HOME/.config/starship.toml"                     "starship-frappe.toml"       "starship.toml → starship-frappe.toml"
 assert_link "$HOME/.config/glow/glamour.json"                 "glamour-frappe.json"        "glow glamour.json → glamour-frappe.json"
 assert_gh_dash_config "#c6d0f5" "gh-dash config.yml ← base + theme-colors-frappe"
+assert_lazygit_config "#8caaee" "lazygit config.yml ← base + theme-colors-frappe"
 assert_link "$HOME/.config/lnav/configs/installed/theme.json" "theme-frappe.json"          "lnav theme.json → theme-frappe.json"
 
 # Forward: frappe → dracula
@@ -108,6 +148,7 @@ assert_link "$HOME/.config/ghostty/theme.ghostty"             "theme-dracula.gho
 assert_link "$HOME/.config/starship.toml"                     "starship-dracula.toml"      "starship.toml → starship-dracula.toml"
 assert_link "$HOME/.config/glow/glamour.json"                 "glamour-dracula.json"       "glow glamour.json → glamour-dracula.json"
 assert_gh_dash_config "#f8f8f2" "gh-dash config.yml ← base + theme-colors-dracula"
+assert_lazygit_config "#bd93f9" "lazygit config.yml ← base + theme-colors-dracula"
 assert_link "$HOME/.config/lnav/configs/installed/theme.json" "theme-dracula.json"         "lnav theme.json → theme-dracula.json"
 
 # Forward: dracula → gruvbox
@@ -118,6 +159,7 @@ assert_link "$HOME/.config/ghostty/theme.ghostty"             "theme-gruvbox.gho
 assert_link "$HOME/.config/starship.toml"                     "starship-gruvbox.toml"      "starship.toml → starship-gruvbox.toml"
 assert_link "$HOME/.config/glow/glamour.json"                 "glamour-gruvbox.json"       "glow glamour.json → glamour-gruvbox.json"
 assert_gh_dash_config "#ebdbb2" "gh-dash config.yml ← base + theme-colors-gruvbox"
+assert_lazygit_config "#458588" "lazygit config.yml ← base + theme-colors-gruvbox"
 assert_link "$HOME/.config/lnav/configs/installed/theme.json" "theme-gruvbox.json"         "lnav theme.json → theme-gruvbox.json"
 
 # Forward: gruvbox → tokyo-night
@@ -128,6 +170,7 @@ assert_link "$HOME/.config/ghostty/theme.ghostty"             "theme-tokyo-night
 assert_link "$HOME/.config/starship.toml"                     "starship-tokyo-night.toml"      "starship.toml → starship-tokyo-night.toml"
 assert_link "$HOME/.config/glow/glamour.json"                 "glamour-tokyo-night.json"       "glow glamour.json → glamour-tokyo-night.json"
 assert_gh_dash_config "#c0caf5" "gh-dash config.yml ← base + theme-colors-tokyo-night"
+assert_lazygit_config "#7aa2f7" "lazygit config.yml ← base + theme-colors-tokyo-night"
 assert_link "$HOME/.config/lnav/configs/installed/theme.json" "theme-tokyo-night.json"         "lnav theme.json → theme-tokyo-night.json"
 
 # Forward: tokyo-night → nord
@@ -138,6 +181,7 @@ assert_link "$HOME/.config/ghostty/theme.ghostty"             "theme-nord.ghostt
 assert_link "$HOME/.config/starship.toml"                     "starship-nord.toml"      "starship.toml → starship-nord.toml"
 assert_link "$HOME/.config/glow/glamour.json"                 "glamour-nord.json"       "glow glamour.json → glamour-nord.json"
 assert_gh_dash_config "#d8dee9" "gh-dash config.yml ← base + theme-colors-nord"
+assert_lazygit_config "#5e81ac" "lazygit config.yml ← base + theme-colors-nord"
 assert_link "$HOME/.config/lnav/configs/installed/theme.json" "theme-nord.json"         "lnav theme.json → theme-nord.json"
 
 # Forward: nord → rose-pine
@@ -148,6 +192,7 @@ assert_link "$HOME/.config/ghostty/theme.ghostty"             "theme-rose-pine.g
 assert_link "$HOME/.config/starship.toml"                     "starship-rose-pine.toml"      "starship.toml → starship-rose-pine.toml"
 assert_link "$HOME/.config/glow/glamour.json"                 "glamour-rose-pine.json"       "glow glamour.json → glamour-rose-pine.json"
 assert_gh_dash_config "#e0def4" "gh-dash config.yml ← base + theme-colors-rose-pine"
+assert_lazygit_config "#31748f" "lazygit config.yml ← base + theme-colors-rose-pine"
 assert_link "$HOME/.config/lnav/configs/installed/theme.json" "theme-rose-pine.json"         "lnav theme.json → theme-rose-pine.json"
 
 # Forward: rose-pine → rose-pine-moon
@@ -158,6 +203,7 @@ assert_link "$HOME/.config/ghostty/theme.ghostty"             "theme-rose-pine-m
 assert_link "$HOME/.config/starship.toml"                     "starship-rose-pine-moon.toml"      "starship.toml → starship-rose-pine-moon.toml"
 assert_link "$HOME/.config/glow/glamour.json"                 "glamour-rose-pine-moon.json"       "glow glamour.json → glamour-rose-pine-moon.json"
 assert_gh_dash_config "#e0def4" "gh-dash config.yml ← base + theme-colors-rose-pine-moon"
+assert_lazygit_config "#3e8fb0" "lazygit config.yml ← base + theme-colors-rose-pine-moon"
 assert_link "$HOME/.config/lnav/configs/installed/theme.json" "theme-rose-pine-moon.json"         "lnav theme.json → theme-rose-pine-moon.json"
 
 # Forward: rose-pine-moon → latte (partial-coverage theme — only ghostty/tmux/starship
@@ -167,6 +213,7 @@ run_theme_set latte
 assert_link "$HOME/.config/themes/current.tmux"               "latte.tmux"               "current.tmux → latte.tmux"
 assert_link "$HOME/.config/ghostty/theme.ghostty"             "theme-latte.ghostty"      "ghostty theme.ghostty → theme-latte.ghostty"
 assert_link "$HOME/.config/starship.toml"                     "starship-latte.toml"      "starship.toml → starship-latte.toml"
+assert_lazygit_config "#1e66f5" "lazygit config.yml ← base + theme-colors-latte (flips; has a Latte variant)"
 # Negative contract — what does NOT flip (partial coverage stays on previous theme = rose-pine-moon):
 assert_link "$HOME/.config/themes/delta-current.gitconfig"    "delta-rose-pine-moon.gitconfig"    "delta stays on rose-pine-moon (no delta-latte.gitconfig)"
 assert_link "$HOME/.config/glow/glamour.json"                 "glamour-rose-pine-moon.json"       "glow stays on rose-pine-moon (no glamour-latte.json)"


### PR DESCRIPTION
## 🎨 What

Makes `lazygit` repaint with `theme-set <name>` across all 10 schemes, joining the existing theme-set followers. Previously lazygit used its built-in default theme regardless of the active scheme.

Closes #317.

## 🛠️ How

New mixed-dir `.config/lazygit/` follows the gh-dash generated-config pattern:

- 📄 `config-base.yml` — shared schema (delta paging), **no `gui:` key**.
- 🎨 `theme-colors-<name>.yml` — only the `gui.theme` block, one per scheme.
- 🔀 The live `~/.config/lazygit/config.yml` is **generated** (`cat base + theme-colors-<name>`) by `theme-set` and seeded by `bootstrap.sh` — machine-local, never a symlink. Plain concatenation yields valid YAML (exactly one `gui:` + one `git:`).
- ⏱️ **Restart tier** — lazygit reads its theme at launch, so it repaints on next launch (noted in the `theme-set` output).
- 🟦 **Full 10-theme coverage incl. Latte** (catppuccin ships a Latte block), so unlike most followers Latte *flips* rather than degrades.

Palette provenance: rose-pine + catppuccin (mocha/frappe/latte) vendored upstream (MIT); solarized/dracula/gruvbox/tokyo-night/nord hand-derived from `.config/themes/<name>.*`.

## 📦 Surface

- `.config/lazygit/` — `config-base.yml` + 10 `theme-colors-*.yml`
- `bootstrap.sh` — real-dir + per-file links + seed `config.yml` (don't-clobber)
- `theme-set.fish` — regenerate `config.yml` on flip + restart-tier note
- `scripts/test-theme-switch.sh` — `assert_lazygit_config` helper + per-theme assertions + Latte flip
- 🐳 Sandbox parity — `.dockerignore` allowlist + Dockerfile `COPY` + `stage_theme` regeneration (lazygit is in the sandbox toolset)
- `CLAUDE.md` — lazygit bullet + follower list + sandbox follower note

## ✅ Test plan

- 🟢 `scripts/test-theme-switch.sh` (with the new dir scaffolded): **94 passed, 0 failed**, including all lazygit assertions + the Latte flip.
- 🟢 All 10 `cat base + theme-colors-<name>` concatenations parse as YAML with exactly one `gui:`/`git:`.
- 🟢 `bash -n bootstrap.sh`, `fish -n theme-set.fish`, `bash -n sandbox/install-linux.sh` — clean.
- 🐳 `scripts/test-sandbox.sh` — full arm64 image build + runtime asserts passed locally (run before integrating `main`); the post-merge sandbox state is two independent additive blocks (eza + lazygit) and is re-covered by the CI sandbox workflow on this PR.

## 🔀 Note on `main` integration

Branched before `eza` (#321) and `btop` (#326) landed; both touched the same theme-set follower files. `main` is merged in and the overlapping follower lists (theme-set echo, CLAUDE.md, the smoke-test Latte block) reconciled so all three tools coexist.

## ⏭️ Post-merge

Re-run `bootstrap.sh` on the primary checkout to wire the real `config-base.yml`/`theme-colors-*.yml` symlinks + generated `config.yml`, then relaunch `<leader>gg` and eyeball the repaint for a couple of schemes.