### PR TITLE
🎨 difftastic: follow theme-set light/dark axis via DFT_BACKGROUND (#319)

### DIFF
--- a/.config/fish/functions/theme-set.fish
+++ b/.config/fish/functions/theme-set.fish
@@ -35,6 +35,7 @@ function theme-set --description 'Switch colour scheme; bare = show current, --s
     set -l bat_theme
     set -l vivid_theme
     set -l btop_theme
+    set -l dft_background dark   # difftastic light/dark hint; latte overrides below
     switch $name
         case mocha
             set bat_theme "Catppuccin Mocha"
@@ -67,6 +68,7 @@ function theme-set --description 'Switch colour scheme; bare = show current, --s
             set bat_theme "Catppuccin Latte"
             set vivid_theme "catppuccin-latte"
             set btop_theme "catppuccin_latte"
+            set dft_background light   # the only light theme
         case rose-pine
             # bat 0.26 has no rose-pine syntax theme; fall back to
             # Catppuccin Mocha (closest pastel-on-dark; Tokyo Night
@@ -130,6 +132,12 @@ function theme-set --description 'Switch colour scheme; bare = show current, --s
     # 16-color palette — no env var needed.
     set -Ux BAT_THEME $bat_theme
     set -Ux VIVID_THEME $vivid_theme
+    # difftastic (aliased to `diff`) has no named palettes — only a light/dark
+    # background hint + syntax-highlight on/off. Follow the light/dark axis;
+    # pin syntax-highlight on (matches difftastic's current default, guards
+    # against a future default flip). New shells pick these up (restart tier).
+    set -Ux DFT_BACKGROUND $dft_background
+    set -Ux DFT_SYNTAX_HIGHLIGHT on
 
     # tmux: re-source config + force status redraw (silent if no server).
     # Gated on FISH_DOTFILES_TEST so the test harness doesn't repaint the
@@ -142,7 +150,7 @@ function theme-set --description 'Switch colour scheme; bare = show current, --s
 
     echo "theme → $name"
     echo "  live:    tmux + helpers, starship (next prompt), glow, delta, eza"
-    echo "  restart: bat + ls colors (new shells for \$BAT_THEME / \$VIVID_THEME), nvim, gh-dash, lnav, btop"
+    echo "  restart: bat + ls colors + difftastic (new shells for \$BAT_THEME / \$VIVID_THEME / \$DFT_BACKGROUND), nvim, gh-dash, lnav, btop"
     # Ghostty 1.3 limitation: reload_config does NOT repaint existing surfaces
     # when `theme` changes — only NEW windows/tabs/splits opened after reload
     # pick up the new palette. Existing windows keep their old theme until a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,7 +241,9 @@ bootstrap defaults. See "Switchable themes" / "Switchable Ghostty fonts" below.
   tokens contradicting this repo's TodoWrite/auto-memory/PR conventions);
   remove if a prior install left them. Skip `bd setup claude --global`.
 - **`diff` → `difft`** (guarded; ad-hoc non-git only — git/vimdiff unaffected).
-  Escape `command diff`. Don't pin flags.
+  Follows the light/dark axis via `DFT_BACKGROUND` (`light` on Latte, `dark`
+  elsewhere) + pins `DFT_SYNTAX_HIGHLIGHT=on` — coarse only, no named palette;
+  restart tier (new shells). Escape `command diff`. Don't pin flags.
 - **`xh` is the HTTP client** (`xh`/`xhs`; `--style=solarized` in
   `.config/xh/config.json`). Don't alias `curl`. No `http`/`https` alias.
 - **`slm` pipes any prompt to the local LM Studio model** (fish function

--- a/scripts/test-theme-switch.sh
+++ b/scripts/test-theme-switch.sh
@@ -22,6 +22,25 @@ assert_link() {
     fi
 }
 
+# Universal-var assertion: theme-set writes DFT_BACKGROUND / DFT_SYNTAX_HIGHLIGHT
+# via `set -Ux` (fish universal vars). Those are NOT visible mid-run inside the
+# run_theme_set subshell, so read them through a fresh `fish -c` — what a new
+# shell would see. Plain `fish -c` loads universal vars; do NOT add --no-config
+# (verified: --no-config skips universal-var loading).
+assert_env_var() {
+    local var="$1" want="$2" desc="$3"
+    local got
+    got="$(fish -c "echo \$$var" 2>/dev/null)"
+    if [ "$got" = "$want" ]; then
+        pass=$((pass+1))
+        echo "  PASS  $desc"
+    else
+        fail=$((fail+1))
+        fail_msgs+=("FAIL  $desc"$'\n'"        var:  \$$var"$'\n'"        got:  $got"$'\n'"        want: $want")
+        echo "  FAIL  $desc"
+    fi
+}
+
 # gh-dash's live config.yml is a generated real file (cat base + theme-colors)
 # rather than a symlink. Assert: (1) it is NOT a symlink, (2) it contains the
 # expected per-theme `text.primary` hex, (3) exactly one `theme:` key (catches
@@ -91,6 +110,8 @@ assert_gh_dash_config "#cdd6f4" "gh-dash config.yml ← base + theme-colors-moch
 assert_link "$HOME/.config/lnav/configs/installed/theme.json" "theme-mocha.json"         "lnav theme.json → theme-mocha.json"
 assert_link "$HOME/.config/btop/themes/current.theme" "catppuccin_mocha.theme" "btop current.theme → catppuccin_mocha.theme"
 assert_link "$HOME/.config/eza/theme.yml"                     "eza-mocha.yml"            "eza theme.yml → eza-mocha.yml"
+assert_env_var "DFT_BACKGROUND" "dark" "DFT_BACKGROUND=dark (mocha)"
+assert_env_var "DFT_SYNTAX_HIGHLIGHT" "on" "DFT_SYNTAX_HIGHLIGHT=on (uniform)"
 
 # Forward: mocha → frappe
 run_theme_set frappe
@@ -103,6 +124,7 @@ assert_gh_dash_config "#c6d0f5" "gh-dash config.yml ← base + theme-colors-frap
 assert_link "$HOME/.config/lnav/configs/installed/theme.json" "theme-frappe.json"          "lnav theme.json → theme-frappe.json"
 assert_link "$HOME/.config/btop/themes/current.theme" "catppuccin_frappe.theme" "btop current.theme → catppuccin_frappe.theme"
 assert_link "$HOME/.config/eza/theme.yml"                     "eza-frappe.yml"           "eza theme.yml → eza-frappe.yml"
+assert_env_var "DFT_BACKGROUND" "dark" "DFT_BACKGROUND=dark (frappe)"
 
 # Forward: frappe → dracula
 run_theme_set dracula
@@ -115,6 +137,7 @@ assert_gh_dash_config "#f8f8f2" "gh-dash config.yml ← base + theme-colors-drac
 assert_link "$HOME/.config/lnav/configs/installed/theme.json" "theme-dracula.json"         "lnav theme.json → theme-dracula.json"
 assert_link "$HOME/.config/btop/themes/current.theme" "dracula.theme" "btop current.theme → dracula.theme"
 assert_link "$HOME/.config/eza/theme.yml"                     "eza-dracula.yml"          "eza theme.yml → eza-dracula.yml"
+assert_env_var "DFT_BACKGROUND" "dark" "DFT_BACKGROUND=dark (dracula)"
 
 # Forward: dracula → gruvbox
 run_theme_set gruvbox
@@ -127,6 +150,7 @@ assert_gh_dash_config "#ebdbb2" "gh-dash config.yml ← base + theme-colors-gruv
 assert_link "$HOME/.config/lnav/configs/installed/theme.json" "theme-gruvbox.json"         "lnav theme.json → theme-gruvbox.json"
 assert_link "$HOME/.config/btop/themes/current.theme" "gruvbox_dark.theme" "btop current.theme → gruvbox_dark.theme"
 assert_link "$HOME/.config/eza/theme.yml"                     "eza-gruvbox.yml"          "eza theme.yml → eza-gruvbox.yml"
+assert_env_var "DFT_BACKGROUND" "dark" "DFT_BACKGROUND=dark (gruvbox)"
 
 # Forward: gruvbox → tokyo-night
 run_theme_set tokyo-night
@@ -139,6 +163,7 @@ assert_gh_dash_config "#c0caf5" "gh-dash config.yml ← base + theme-colors-toky
 assert_link "$HOME/.config/lnav/configs/installed/theme.json" "theme-tokyo-night.json"         "lnav theme.json → theme-tokyo-night.json"
 assert_link "$HOME/.config/btop/themes/current.theme" "tokyo-storm.theme" "btop current.theme → tokyo-storm.theme"
 assert_link "$HOME/.config/eza/theme.yml"                     "eza-tokyo-night.yml"      "eza theme.yml → eza-tokyo-night.yml"
+assert_env_var "DFT_BACKGROUND" "dark" "DFT_BACKGROUND=dark (tokyo-night)"
 
 # Forward: tokyo-night → nord
 run_theme_set nord
@@ -151,6 +176,7 @@ assert_gh_dash_config "#d8dee9" "gh-dash config.yml ← base + theme-colors-nord
 assert_link "$HOME/.config/lnav/configs/installed/theme.json" "theme-nord.json"         "lnav theme.json → theme-nord.json"
 assert_link "$HOME/.config/btop/themes/current.theme" "nord.theme" "btop current.theme → nord.theme"
 assert_link "$HOME/.config/eza/theme.yml"                     "eza-nord.yml"             "eza theme.yml → eza-nord.yml"
+assert_env_var "DFT_BACKGROUND" "dark" "DFT_BACKGROUND=dark (nord)"
 
 # Forward: nord → rose-pine
 run_theme_set rose-pine
@@ -163,6 +189,7 @@ assert_gh_dash_config "#e0def4" "gh-dash config.yml ← base + theme-colors-rose
 assert_link "$HOME/.config/lnav/configs/installed/theme.json" "theme-rose-pine.json"         "lnav theme.json → theme-rose-pine.json"
 assert_link "$HOME/.config/btop/themes/current.theme" "rose-pine.theme" "btop current.theme → rose-pine.theme"
 assert_link "$HOME/.config/eza/theme.yml"                     "eza-rose-pine.yml"        "eza theme.yml → eza-rose-pine.yml"
+assert_env_var "DFT_BACKGROUND" "dark" "DFT_BACKGROUND=dark (rose-pine)"
 
 # Forward: rose-pine → rose-pine-moon
 run_theme_set rose-pine-moon
@@ -175,6 +202,7 @@ assert_gh_dash_config "#e0def4" "gh-dash config.yml ← base + theme-colors-rose
 assert_link "$HOME/.config/lnav/configs/installed/theme.json" "theme-rose-pine-moon.json"         "lnav theme.json → theme-rose-pine-moon.json"
 assert_link "$HOME/.config/btop/themes/current.theme" "rose-pine-moon.theme" "btop current.theme → rose-pine-moon.theme"
 assert_link "$HOME/.config/eza/theme.yml"                     "eza-rose-pine-moon.yml"   "eza theme.yml → eza-rose-pine-moon.yml"
+assert_env_var "DFT_BACKGROUND" "dark" "DFT_BACKGROUND=dark (rose-pine-moon)"
 
 # Forward: rose-pine-moon → latte (partial-coverage theme — only ghostty/tmux/starship
 # flip; delta/glow/lnav/gh-dash stay on nord by design, see spec).
@@ -185,6 +213,7 @@ assert_link "$HOME/.config/ghostty/theme.ghostty"             "theme-latte.ghost
 assert_link "$HOME/.config/starship.toml"                     "starship-latte.toml"      "starship.toml → starship-latte.toml"
 assert_link "$HOME/.config/btop/themes/current.theme" "catppuccin_latte.theme" "btop current.theme → catppuccin_latte.theme (full coverage incl. Latte)"
 assert_link "$HOME/.config/eza/theme.yml"                     "eza-latte.yml"            "eza theme.yml → eza-latte.yml (latte ships eza)"
+assert_env_var "DFT_BACKGROUND" "light" "DFT_BACKGROUND=light (latte)"
 # Negative contract — what does NOT flip (partial coverage stays on previous theme = rose-pine-moon):
 assert_link "$HOME/.config/themes/delta-current.gitconfig"    "delta-rose-pine-moon.gitconfig"    "delta stays on rose-pine-moon (no delta-latte.gitconfig)"
 assert_link "$HOME/.config/glow/glamour.json"                 "glamour-rose-pine-moon.json"       "glow stays on rose-pine-moon (no glamour-latte.json)"
@@ -197,6 +226,7 @@ assert_link "$HOME/.config/themes/current.tmux"               "solarized.tmux"  
 assert_link "$HOME/.config/ghostty/theme.ghostty"             "theme-solarized.ghostty"    "ghostty theme.ghostty → theme-solarized.ghostty (reverse)"
 assert_link "$HOME/.config/starship.toml"                     "starship-solarized.toml"    "starship.toml → starship-solarized.toml (reverse)"
 assert_link "$HOME/.config/btop/themes/current.theme" "solarized_dark.theme" "btop current.theme → solarized_dark.theme (reverse)"
+assert_env_var "DFT_BACKGROUND" "dark" "DFT_BACKGROUND=dark (solarized, reverse)"
 
 # Restore starting state.
 run_theme_set "$start_theme"


### PR DESCRIPTION
## 🎨 What

Makes `difftastic` (aliased to `diff`) follow `theme-set`'s light/dark axis. difftastic has no named palettes — only a coarse light/dark background hint plus a syntax-highlight on/off toggle — so it follows the *binary* axis rather than joining the full per-theme "Follow" set.

- 🌗 `theme-set` now exports `DFT_BACKGROUND` as a fish universal var: `light` on **Latte** (the only light theme), `dark` on the other nine.
- 🖍️ Pins `DFT_SYNTAX_HIGHLIGHT=on` (uniform) — matches difftastic's current default and guards against a future default flip.
- ♻️ Restart tier: new shells pick the values up (same mechanism as `BAT_THEME` / `VIVID_THEME`).
- 📄 Extends the `restart:` readout line and the `diff → difft` doc bullet; the top-level "Follow:" list is intentionally left unchanged.

## 🔧 How

One `dft_background` local in `theme-set.fish` (default `dark`, overridden to `light` only in the `latte` arm), exported next to the existing `set -Ux BAT_THEME` / `VIVID_THEME` lines.

## ✅ Test plan

- 🧪 `scripts/test-theme-switch.sh` — added an `assert_env_var` helper (reads universal vars through a fresh `fish -c`) plus 11 new assertions: 9 dark + 1 light (Latte) for `DFT_BACKGROUND`, and 1 for `DFT_SYNTAX_HIGHLIGHT`. RED before the export wiring, **96 passed / 0 failed** after.
- 🐟 `scripts/test-fish-loads.sh` — passes (fish loads the edited function cleanly).
- 🔬 Feature smoke: with `DFT_BACKGROUND=light` vs `dark`, `difft --color always` produces different ANSI output — difftastic genuinely honors the var. Manual flips (sourcing the branch function): Latte → `light`, Solarized/Nord → `dark`, `DFT_SYNTAX_HIGHLIGHT=on` throughout.

## ⚠️ Notes / risk

- Low risk: additive env exports only; the `diff → difft` alias, Brewfile, and bootstrap are untouched.
- Existing shells keep their current `DFT_BACKGROUND` until restart (documented restart-tier behavior).

Closes #319