### PR TITLE
🎨 tealdeer: per-theme tldr palette following theme-set

### DIFF
--- a/.config/fish/conf.d/00-env.fish
+++ b/.config/fish/conf.d/00-env.fish
@@ -39,6 +39,12 @@ end
 # export is a harmless no-op when eza is absent.
 set -gx EZA_CONFIG_DIR $HOME/.config/eza
 
+# tealdeer reads config.toml from ~/Library/Application Support/tealdeer on
+# macOS by default; redirect it into ~/.config/tealdeer so the theme-set
+# symlink lives with the other followers. Absolute path required (tealdeer
+# does no variable expansion). Harmless no-op when tealdeer is absent.
+set -gx TEALDEER_CONFIG_DIR $HOME/.config/tealdeer
+
 fish_add_path -gPm $HOME/.local/bin $HOME/.cargo/bin
 
 # nvimpager as the general $PAGER — smooth, colored paging (e.g. glow's

--- a/.config/fish/functions/theme-set.fish
+++ b/.config/fish/functions/theme-set.fish
@@ -109,6 +109,8 @@ function theme-set --description 'Switch colour scheme; bare = show current, --s
         ; and ln -sfn $btop_theme.theme ~/.config/btop/themes/current.theme
     test -f ~/.config/eza/eza-$name.yml \
         ; and ln -sfn eza-$name.yml ~/.config/eza/theme.yml
+    test -f ~/.config/tealdeer/config-$name.toml \
+        ; and ln -sfn config-$name.toml ~/.config/tealdeer/config.toml
 
     # gh-dash live config is a generated real file, not a symlink.
     # base.yml has no `theme:` key; theme-colors-$name.yml has only `theme:` —
@@ -141,7 +143,7 @@ function theme-set --description 'Switch colour scheme; bare = show current, --s
     end
 
     echo "theme → $name"
-    echo "  live:    tmux + helpers, starship (next prompt), glow, delta, eza"
+    echo "  live:    tmux + helpers, starship (next prompt), glow, delta, eza, tealdeer"
     echo "  restart: bat + ls colors (new shells for \$BAT_THEME / \$VIVID_THEME), nvim, gh-dash, lnav, btop"
     # Ghostty 1.3 limitation: reload_config does NOT repaint existing surfaces
     # when `theme` changes — only NEW windows/tabs/splits opened after reload

--- a/.config/tealdeer/config-dracula.toml
+++ b/.config/tealdeer/config-dracula.toml
@@ -1,0 +1,19 @@
+# .config/tealdeer/config-dracula.toml — Dracula palette for tldr.
+# Follows theme-set; flipped to config.toml by the theme-set function.
+# Roles: command_name = bold header accent, description = muted text,
+# example_code = the literal command, example_variable = highlighted + underlined.
+# example_text intentionally unset → inherits terminal default (neutral prose).
+
+[style.command_name]
+foreground = { rgb = { r = 189, g = 147, b = 249 } }
+bold = true
+
+[style.description]
+foreground = { rgb = { r = 98, g = 114, b = 164 } }
+
+[style.example_code]
+foreground = { rgb = { r = 80, g = 250, b = 123 } }
+
+[style.example_variable]
+foreground = { rgb = { r = 241, g = 250, b = 140 } }
+underline = true

--- a/.config/tealdeer/config-frappe.toml
+++ b/.config/tealdeer/config-frappe.toml
@@ -1,0 +1,19 @@
+# .config/tealdeer/config-frappe.toml — Catppuccin Frappé palette for tldr.
+# Follows theme-set; flipped to config.toml by the theme-set function.
+# Roles: command_name = bold header accent, description = muted text,
+# example_code = the literal command, example_variable = highlighted + underlined.
+# example_text intentionally unset → inherits terminal default (neutral prose).
+
+[style.command_name]
+foreground = { rgb = { r = 202, g = 158, b = 230 } }
+bold = true
+
+[style.description]
+foreground = { rgb = { r = 165, g = 173, b = 206 } }
+
+[style.example_code]
+foreground = { rgb = { r = 166, g = 209, b = 137 } }
+
+[style.example_variable]
+foreground = { rgb = { r = 229, g = 200, b = 144 } }
+underline = true

--- a/.config/tealdeer/config-gruvbox.toml
+++ b/.config/tealdeer/config-gruvbox.toml
@@ -1,0 +1,19 @@
+# .config/tealdeer/config-gruvbox.toml — Gruvbox Dark palette for tldr.
+# Follows theme-set; flipped to config.toml by the theme-set function.
+# Roles: command_name = bold header accent, description = muted text,
+# example_code = the literal command, example_variable = highlighted + underlined.
+# example_text intentionally unset → inherits terminal default (neutral prose).
+
+[style.command_name]
+foreground = { rgb = { r = 211, g = 134, b = 155 } }
+bold = true
+
+[style.description]
+foreground = { rgb = { r = 146, g = 131, b = 116 } }
+
+[style.example_code]
+foreground = { rgb = { r = 184, g = 187, b = 38 } }
+
+[style.example_variable]
+foreground = { rgb = { r = 250, g = 189, b = 47 } }
+underline = true

--- a/.config/tealdeer/config-latte.toml
+++ b/.config/tealdeer/config-latte.toml
@@ -1,0 +1,20 @@
+# .config/tealdeer/config-latte.toml — Catppuccin Latte palette for tldr.
+# Follows theme-set; flipped to config.toml by the theme-set function.
+# Only light theme — muted/description darkened for contrast on a light bg.
+# Roles: command_name = bold header accent, description = muted text,
+# example_code = the literal command, example_variable = highlighted + underlined.
+# example_text intentionally unset → inherits terminal default (neutral prose).
+
+[style.command_name]
+foreground = { rgb = { r = 136, g = 57, b = 239 } }
+bold = true
+
+[style.description]
+foreground = { rgb = { r = 108, g = 111, b = 133 } }
+
+[style.example_code]
+foreground = { rgb = { r = 64, g = 160, b = 43 } }
+
+[style.example_variable]
+foreground = { rgb = { r = 223, g = 142, b = 29 } }
+underline = true

--- a/.config/tealdeer/config-mocha.toml
+++ b/.config/tealdeer/config-mocha.toml
@@ -1,0 +1,19 @@
+# .config/tealdeer/config-mocha.toml — Catppuccin Mocha palette for tldr.
+# Follows theme-set; flipped to config.toml by the theme-set function.
+# Roles: command_name = bold header accent, description = muted text,
+# example_code = the literal command, example_variable = highlighted + underlined.
+# example_text intentionally unset → inherits terminal default (neutral prose).
+
+[style.command_name]
+foreground = { rgb = { r = 203, g = 166, b = 247 } }
+bold = true
+
+[style.description]
+foreground = { rgb = { r = 166, g = 173, b = 200 } }
+
+[style.example_code]
+foreground = { rgb = { r = 166, g = 227, b = 161 } }
+
+[style.example_variable]
+foreground = { rgb = { r = 249, g = 226, b = 175 } }
+underline = true

--- a/.config/tealdeer/config-nord.toml
+++ b/.config/tealdeer/config-nord.toml
@@ -1,0 +1,19 @@
+# .config/tealdeer/config-nord.toml — Nord palette for tldr.
+# Follows theme-set; flipped to config.toml by the theme-set function.
+# Roles: command_name = bold header accent, description = muted text,
+# example_code = the literal command, example_variable = highlighted + underlined.
+# example_text intentionally unset → inherits terminal default (neutral prose).
+
+[style.command_name]
+foreground = { rgb = { r = 180, g = 142, b = 173 } }
+bold = true
+
+[style.description]
+foreground = { rgb = { r = 97, g = 110, b = 136 } }
+
+[style.example_code]
+foreground = { rgb = { r = 163, g = 190, b = 140 } }
+
+[style.example_variable]
+foreground = { rgb = { r = 235, g = 203, b = 139 } }
+underline = true

--- a/.config/tealdeer/config-rose-pine-moon.toml
+++ b/.config/tealdeer/config-rose-pine-moon.toml
@@ -1,0 +1,20 @@
+# .config/tealdeer/config-rose-pine-moon.toml — Rosé Pine Moon palette for tldr.
+# Follows theme-set; flipped to config.toml by the theme-set function.
+# Shares Rosé Pine's accent ring (iris/foam/gold); only the base differs.
+# Roles: command_name = bold header accent, description = muted text,
+# example_code = the literal command, example_variable = highlighted + underlined.
+# example_text intentionally unset → inherits terminal default (neutral prose).
+
+[style.command_name]
+foreground = { rgb = { r = 196, g = 167, b = 231 } }
+bold = true
+
+[style.description]
+foreground = { rgb = { r = 110, g = 106, b = 134 } }
+
+[style.example_code]
+foreground = { rgb = { r = 156, g = 207, b = 216 } }
+
+[style.example_variable]
+foreground = { rgb = { r = 246, g = 193, b = 119 } }
+underline = true

--- a/.config/tealdeer/config-rose-pine.toml
+++ b/.config/tealdeer/config-rose-pine.toml
@@ -1,0 +1,19 @@
+# .config/tealdeer/config-rose-pine.toml — Rosé Pine palette for tldr.
+# Follows theme-set; flipped to config.toml by the theme-set function.
+# Roles: command_name = bold header accent, description = muted text,
+# example_code = the literal command, example_variable = highlighted + underlined.
+# example_text intentionally unset → inherits terminal default (neutral prose).
+
+[style.command_name]
+foreground = { rgb = { r = 196, g = 167, b = 231 } }
+bold = true
+
+[style.description]
+foreground = { rgb = { r = 110, g = 106, b = 134 } }
+
+[style.example_code]
+foreground = { rgb = { r = 156, g = 207, b = 216 } }
+
+[style.example_variable]
+foreground = { rgb = { r = 246, g = 193, b = 119 } }
+underline = true

--- a/.config/tealdeer/config-solarized.toml
+++ b/.config/tealdeer/config-solarized.toml
@@ -1,0 +1,19 @@
+# .config/tealdeer/config-solarized.toml — Solarized Dark palette for tldr.
+# Follows theme-set; flipped to config.toml by the theme-set function.
+# Roles: command_name = bold header accent, description = muted text,
+# example_code = the literal command, example_variable = highlighted + underlined.
+# example_text intentionally unset → inherits terminal default (neutral prose).
+
+[style.command_name]
+foreground = { rgb = { r = 108, g = 113, b = 196 } }
+bold = true
+
+[style.description]
+foreground = { rgb = { r = 147, g = 161, b = 161 } }
+
+[style.example_code]
+foreground = { rgb = { r = 133, g = 153, b = 0 } }
+
+[style.example_variable]
+foreground = { rgb = { r = 181, g = 137, b = 0 } }
+underline = true

--- a/.config/tealdeer/config-tokyo-night.toml
+++ b/.config/tealdeer/config-tokyo-night.toml
@@ -1,0 +1,19 @@
+# .config/tealdeer/config-tokyo-night.toml — Tokyo Night Storm palette for tldr.
+# Follows theme-set; flipped to config.toml by the theme-set function.
+# Roles: command_name = bold header accent, description = muted text,
+# example_code = the literal command, example_variable = highlighted + underlined.
+# example_text intentionally unset → inherits terminal default (neutral prose).
+
+[style.command_name]
+foreground = { rgb = { r = 187, g = 154, b = 247 } }
+bold = true
+
+[style.description]
+foreground = { rgb = { r = 86, g = 95, b = 137 } }
+
+[style.example_code]
+foreground = { rgb = { r = 158, g = 206, b = 106 } }
+
+[style.example_variable]
+foreground = { rgb = { r = 224, g = 175, b = 104 } }
+underline = true

--- a/.dockerignore
+++ b/.dockerignore
@@ -10,6 +10,7 @@
 !.config/themes
 !.config/glow
 !.config/eza
+!.config/tealdeer
 !.config/lnav
 !.config/git
 !.config/starship-solarized.toml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,7 +140,7 @@ bootstrap defaults. See "Switchable themes" / "Switchable Ghostty fonts" below.
   includes (see the gh-dash bullet). **Adding a theme:** drop the variant files
   in (existence-guarded `test -f` in `theme-set.fish` auto-engages — partial
   coverage is fine; Latte is the only light theme and ships ghostty/tmux/
-  starship/eza/btop only, #215) **and** add the `starship-<theme>.toml` `link` line in
+  starship/eza/btop/tealdeer only, #215) **and** add the `starship-<theme>.toml` `link` line in
   `bootstrap.sh` (the one tool not covered by `link_tracked_entries`) **and**
   add a `case` in `theme-set.fish`'s `switch $name` block setting `btop_theme`
   (btop names differ: e.g. `tokyo-night`→`tokyo-storm`, `gruvbox`→`gruvbox_dark`;
@@ -188,7 +188,9 @@ bootstrap defaults. See "Switchable themes" / "Switchable Ghostty fonts" below.
   `ll` is themed; needs `EZA_CONFIG_DIR=~/.config/eza` exported in
   `00-env.fish` — eza 0.23 ignores the documented `~/.config/eza` default and
   only reads `theme.yml` from `$EZA_CONFIG_DIR`; sandbox themes it at creation
-  via `stage_theme`), fzf, atuin, `btop`. Stay
+  via `stage_theme`), fzf, atuin, `btop`, `tealdeer` (`tldr`; live tier —
+  re-reads config each invocation; `TEALDEER_CONFIG_DIR` redirect mirrors eza's
+  `EZA_CONFIG_DIR`). Stay
   Solarized-only: `procs`, `tailspin` (`tspin`), `xh`. `bat --theme="Solarized
   (dark)"` is the unset fallback. No `tail` alias. Don't introduce alternatives
   (`exa`/`lsd`/`diff-so-fancy`/`mdcat`). Delta git config: README → Setup.
@@ -218,6 +220,17 @@ bootstrap defaults. See "Switchable themes" / "Switchable Ghostty fonts" below.
   `btop.conf.template` (mixed-dir, seed-only), so runtime sort/UI toggles
   don't dirty the repo. Edit the template to change the baked default;
   `current.theme` defaults to `solarized_dark.theme`.
+- **`tldr` → `tealdeer`** (follows `theme-set` across all 10 themes; live tier —
+  re-reads config each invocation, no reload). Mixed-dir `.config/tealdeer/`:
+  per-theme `config-<name>.toml` symlinked, active `config.toml` a machine-local
+  symlink flipped by `theme-set`. Four `[style.*]` blocks per theme
+  (`command_name` bold, `description`, `example_code`, `example_variable`
+  underlined); `example_text` left default. **Colors are `{ rgb = { r,g,b } }`
+  tables, not `"#hex"`** — tealdeer 1.8's `[style]` parser rejects hex strings.
+  macOS reads `~/Library/Application Support/tealdeer` by default, so
+  `00-env.fish` exports `TEALDEER_CONFIG_DIR=~/.config/tealdeer` (absolute;
+  eza-style). Sandbox parity via Dockerfile COPY + `.dockerignore` allowlist +
+  `stage_theme` floor/overlay. Smoke: `scripts/test-theme-switch.sh`.
 - **`ctop` is the container-metrics TUI** (`bcicen/ctop`; raw, no `theme-set`,
   no alias). Live per-container CPU/mem/net/IO; `enter` expands one container.
   Needs a running Docker daemon — OrbStack on this machine; empty table

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -162,6 +162,16 @@ link_tracked_entries ".config/eza" "$HOME/.config/eza"
 [ -L "$HOME/.config/eza/theme.yml" ] \
     || ln -sfn eza-solarized.yml "$HOME/.config/eza/theme.yml"
 
+# --- tealdeer (tldr; config.toml follows theme-set)
+# ~/.config/tealdeer/ is a real dir; tracked config-<name>.toml are individually
+# symlinked. Active config.toml is a machine-local symlink. tldr finds the dir
+# via TEALDEER_CONFIG_DIR (set in 00-env.fish). link_tracked_entries covers the
+# per-theme files, so no per-theme link line is needed.
+prepare_real_dir "$HOME/.config/tealdeer"
+link_tracked_entries ".config/tealdeer" "$HOME/.config/tealdeer"
+[ -L "$HOME/.config/tealdeer/config.toml" ] \
+    || ln -sfn config-solarized.toml "$HOME/.config/tealdeer/config.toml"
+
 # --- tailspin (tspin) — Solarized theme.toml
 link ".config/tailspin" "$HOME/.config/tailspin"
 

--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -55,6 +55,7 @@ RUN bash /home/${USER}/.sandbox/install-linux.sh config
 COPY --chown=${USER}:${USER} .config/themes /home/${USER}/.config/themes
 COPY --chown=${USER}:${USER} .config/glow /home/${USER}/.config/glow
 COPY --chown=${USER}:${USER} .config/eza /home/${USER}/.config/eza
+COPY --chown=${USER}:${USER} .config/tealdeer /home/${USER}/.config/tealdeer
 COPY --chown=${USER}:${USER} .config/lnav/configs/installed /home/${USER}/.config/lnav/configs/installed
 COPY --chown=${USER}:${USER} .config/starship-*.toml /home/${USER}/.config/
 # --- shared git aliases (theme-independent static file; the include is wired

--- a/sandbox/install-linux.sh
+++ b/sandbox/install-linux.sh
@@ -137,6 +137,7 @@ stage_theme() {
   ln -sfn glamour-solarized.json    "$cfg/glow/glamour.json"
   ln -sfn theme-solarized.json      "$cfg/lnav/configs/installed/theme.json"
   ln -sfn eza-solarized.yml         "$cfg/eza/theme.yml"
+  ln -sfn config-solarized.toml     "$cfg/tealdeer/config.toml"
 
   # Active theme overlay where its assets exist (Latte degrades to the floor).
   [ -f "$cfg/themes/$name.tmux" ] \
@@ -150,6 +151,8 @@ stage_theme() {
     && ln -sfn "theme-$name.json" "$cfg/lnav/configs/installed/theme.json"
   [ -f "$cfg/eza/eza-$name.yml" ] \
     && ln -sfn "eza-$name.yml" "$cfg/eza/theme.yml"
+  [ -f "$cfg/tealdeer/config-$name.toml" ] \
+    && ln -sfn "config-$name.toml" "$cfg/tealdeer/config.toml"
 
   # git wiring — write a minimal ~/.gitconfig only if absent (the sandbox ships
   # the delta binary but never wires it as git's pager; mirrors README step 3).

--- a/scripts/test-sandbox.sh
+++ b/scripts/test-sandbox.sh
@@ -48,6 +48,7 @@ theme_flip_test() {
   cp -R .config/glow "$tmp/.config/glow"
   cp -R .config/lnav/configs/installed "$tmp/.config/lnav/configs/installed"
   cp -R .config/eza "$tmp/.config/eza"
+  cp -R .config/tealdeer "$tmp/.config/tealdeer"
   cp .config/starship-*.toml "$tmp/.config/"
   cp -R .config/git "$tmp/.config/git"
 
@@ -82,6 +83,8 @@ theme_flip_test() {
     || { echo "❌ nord lnav"; rm -rf "$tmp"; exit 1; }
   [ "$(readlink "$tmp/.config/eza/theme.yml")" = "eza-nord.yml" ] \
     || { echo "❌ nord eza"; rm -rf "$tmp"; exit 1; }
+  [ "$(readlink "$tmp/.config/tealdeer/config.toml")" = "config-nord.toml" ] \
+    || { echo "❌ nord tealdeer"; rm -rf "$tmp"; exit 1; }
   grep -q 'pager = delta' "$tmp/.gitconfig" \
     || { echo "❌ nord gitconfig missing delta"; rm -rf "$tmp"; exit 1; }
   grep -q 'path = ~/.config/git/aliases.gitconfig' "$tmp/.gitconfig" \
@@ -104,6 +107,9 @@ theme_flip_test() {
   # eza ships a latte variant → overlays (does NOT hold the solarized floor, unlike glow/delta).
   [ "$(readlink "$tmp/.config/eza/theme.yml")" = "eza-latte.yml" ] \
     || { echo "❌ latte eza overlay"; rm -rf "$tmp"; exit 1; }
+  # tealdeer ships a latte variant → overlays (full coverage, like eza).
+  [ "$(readlink "$tmp/.config/tealdeer/config.toml")" = "config-latte.toml" ] \
+    || { echo "❌ latte tealdeer overlay"; rm -rf "$tmp"; exit 1; }
   [ "$(readlink "$tmp/.config/themes/delta-current.gitconfig")" = "delta-solarized.gitconfig" ] \
     || { echo "❌ latte delta floor"; rm -rf "$tmp"; exit 1; }
   # Latte's bat name has a space; fish 4.x encodes spaces as \x20 in the file.

--- a/scripts/test-theme-switch.sh
+++ b/scripts/test-theme-switch.sh
@@ -91,6 +91,7 @@ assert_gh_dash_config "#cdd6f4" "gh-dash config.yml ← base + theme-colors-moch
 assert_link "$HOME/.config/lnav/configs/installed/theme.json" "theme-mocha.json"         "lnav theme.json → theme-mocha.json"
 assert_link "$HOME/.config/btop/themes/current.theme" "catppuccin_mocha.theme" "btop current.theme → catppuccin_mocha.theme"
 assert_link "$HOME/.config/eza/theme.yml"                     "eza-mocha.yml"            "eza theme.yml → eza-mocha.yml"
+assert_link "$HOME/.config/tealdeer/config.toml"             "config-mocha.toml"        "tealdeer config.toml → config-mocha.toml"
 
 # Forward: mocha → frappe
 run_theme_set frappe
@@ -103,6 +104,7 @@ assert_gh_dash_config "#c6d0f5" "gh-dash config.yml ← base + theme-colors-frap
 assert_link "$HOME/.config/lnav/configs/installed/theme.json" "theme-frappe.json"          "lnav theme.json → theme-frappe.json"
 assert_link "$HOME/.config/btop/themes/current.theme" "catppuccin_frappe.theme" "btop current.theme → catppuccin_frappe.theme"
 assert_link "$HOME/.config/eza/theme.yml"                     "eza-frappe.yml"           "eza theme.yml → eza-frappe.yml"
+assert_link "$HOME/.config/tealdeer/config.toml"             "config-frappe.toml"       "tealdeer config.toml → config-frappe.toml"
 
 # Forward: frappe → dracula
 run_theme_set dracula
@@ -115,6 +117,7 @@ assert_gh_dash_config "#f8f8f2" "gh-dash config.yml ← base + theme-colors-drac
 assert_link "$HOME/.config/lnav/configs/installed/theme.json" "theme-dracula.json"         "lnav theme.json → theme-dracula.json"
 assert_link "$HOME/.config/btop/themes/current.theme" "dracula.theme" "btop current.theme → dracula.theme"
 assert_link "$HOME/.config/eza/theme.yml"                     "eza-dracula.yml"          "eza theme.yml → eza-dracula.yml"
+assert_link "$HOME/.config/tealdeer/config.toml"             "config-dracula.toml"      "tealdeer config.toml → config-dracula.toml"
 
 # Forward: dracula → gruvbox
 run_theme_set gruvbox
@@ -127,6 +130,7 @@ assert_gh_dash_config "#ebdbb2" "gh-dash config.yml ← base + theme-colors-gruv
 assert_link "$HOME/.config/lnav/configs/installed/theme.json" "theme-gruvbox.json"         "lnav theme.json → theme-gruvbox.json"
 assert_link "$HOME/.config/btop/themes/current.theme" "gruvbox_dark.theme" "btop current.theme → gruvbox_dark.theme"
 assert_link "$HOME/.config/eza/theme.yml"                     "eza-gruvbox.yml"          "eza theme.yml → eza-gruvbox.yml"
+assert_link "$HOME/.config/tealdeer/config.toml"             "config-gruvbox.toml"      "tealdeer config.toml → config-gruvbox.toml"
 
 # Forward: gruvbox → tokyo-night
 run_theme_set tokyo-night
@@ -139,6 +143,7 @@ assert_gh_dash_config "#c0caf5" "gh-dash config.yml ← base + theme-colors-toky
 assert_link "$HOME/.config/lnav/configs/installed/theme.json" "theme-tokyo-night.json"         "lnav theme.json → theme-tokyo-night.json"
 assert_link "$HOME/.config/btop/themes/current.theme" "tokyo-storm.theme" "btop current.theme → tokyo-storm.theme"
 assert_link "$HOME/.config/eza/theme.yml"                     "eza-tokyo-night.yml"      "eza theme.yml → eza-tokyo-night.yml"
+assert_link "$HOME/.config/tealdeer/config.toml"             "config-tokyo-night.toml"  "tealdeer config.toml → config-tokyo-night.toml"
 
 # Forward: tokyo-night → nord
 run_theme_set nord
@@ -151,6 +156,7 @@ assert_gh_dash_config "#d8dee9" "gh-dash config.yml ← base + theme-colors-nord
 assert_link "$HOME/.config/lnav/configs/installed/theme.json" "theme-nord.json"         "lnav theme.json → theme-nord.json"
 assert_link "$HOME/.config/btop/themes/current.theme" "nord.theme" "btop current.theme → nord.theme"
 assert_link "$HOME/.config/eza/theme.yml"                     "eza-nord.yml"             "eza theme.yml → eza-nord.yml"
+assert_link "$HOME/.config/tealdeer/config.toml"             "config-nord.toml"         "tealdeer config.toml → config-nord.toml"
 
 # Forward: nord → rose-pine
 run_theme_set rose-pine
@@ -163,6 +169,7 @@ assert_gh_dash_config "#e0def4" "gh-dash config.yml ← base + theme-colors-rose
 assert_link "$HOME/.config/lnav/configs/installed/theme.json" "theme-rose-pine.json"         "lnav theme.json → theme-rose-pine.json"
 assert_link "$HOME/.config/btop/themes/current.theme" "rose-pine.theme" "btop current.theme → rose-pine.theme"
 assert_link "$HOME/.config/eza/theme.yml"                     "eza-rose-pine.yml"        "eza theme.yml → eza-rose-pine.yml"
+assert_link "$HOME/.config/tealdeer/config.toml"             "config-rose-pine.toml"    "tealdeer config.toml → config-rose-pine.toml"
 
 # Forward: rose-pine → rose-pine-moon
 run_theme_set rose-pine-moon
@@ -175,6 +182,7 @@ assert_gh_dash_config "#e0def4" "gh-dash config.yml ← base + theme-colors-rose
 assert_link "$HOME/.config/lnav/configs/installed/theme.json" "theme-rose-pine-moon.json"         "lnav theme.json → theme-rose-pine-moon.json"
 assert_link "$HOME/.config/btop/themes/current.theme" "rose-pine-moon.theme" "btop current.theme → rose-pine-moon.theme"
 assert_link "$HOME/.config/eza/theme.yml"                     "eza-rose-pine-moon.yml"   "eza theme.yml → eza-rose-pine-moon.yml"
+assert_link "$HOME/.config/tealdeer/config.toml"             "config-rose-pine-moon.toml" "tealdeer config.toml → config-rose-pine-moon.toml"
 
 # Forward: rose-pine-moon → latte (partial-coverage theme — only ghostty/tmux/starship
 # flip; delta/glow/lnav/gh-dash stay on nord by design, see spec).
@@ -185,6 +193,7 @@ assert_link "$HOME/.config/ghostty/theme.ghostty"             "theme-latte.ghost
 assert_link "$HOME/.config/starship.toml"                     "starship-latte.toml"      "starship.toml → starship-latte.toml"
 assert_link "$HOME/.config/btop/themes/current.theme" "catppuccin_latte.theme" "btop current.theme → catppuccin_latte.theme (full coverage incl. Latte)"
 assert_link "$HOME/.config/eza/theme.yml"                     "eza-latte.yml"            "eza theme.yml → eza-latte.yml (latte ships eza)"
+assert_link "$HOME/.config/tealdeer/config.toml"             "config-latte.toml"        "tealdeer config.toml → config-latte.toml (full coverage incl. Latte)"
 # Negative contract — what does NOT flip (partial coverage stays on previous theme = rose-pine-moon):
 assert_link "$HOME/.config/themes/delta-current.gitconfig"    "delta-rose-pine-moon.gitconfig"    "delta stays on rose-pine-moon (no delta-latte.gitconfig)"
 assert_link "$HOME/.config/glow/glamour.json"                 "glamour-rose-pine-moon.json"       "glow stays on rose-pine-moon (no glamour-latte.json)"


### PR DESCRIPTION
## 🎯 What

Gives `tldr` (tealdeer) a deliberate per-theme color palette that follows
`theme-set`, joining the live-tier follower set alongside `eza`/`glow`/`bat`.
Before this, `tldr` rendered with tealdeer's stock defaults regardless of the
active theme.

Closes #320.

## 🧩 How

- 🎨 **10 per-theme `config-<name>.toml`** in a mixed-dir `.config/tealdeer/`
  — four `[style.*]` blocks each: `command_name` (bold accent), `description`
  (muted), `example_code`, `example_variable` (underlined). `example_text` left
  default so body prose inherits the terminal foreground.
- 🔁 **`theme-set` flips** a machine-local `config.toml` symlink to the active
  theme (existence-guarded, mirrors the `eza` flip); `tealdeer` added to the
  `live:` readout.
- 🐟 **`TEALDEER_CONFIG_DIR`** exported in `00-env.fish` → `~/.config/tealdeer`
  (macOS otherwise reads `~/Library/Application Support/tealdeer`; absolute path,
  eza-style).
- 🔗 **`bootstrap.sh`** mixed-dir block (`prepare_real_dir` +
  `link_tracked_entries` + Solarized-default `config.toml` symlink).
- 🐳 **Sandbox parity** — Dockerfile COPY, `.dockerignore` allowlist,
  `stage_theme` floor + existence-guarded overlay (mirrors `eza`).
- 📄 **CLAUDE.md** — follow-tier list, Latte coverage sentence, standalone bullet.

## ⚠️ Deviation from the plan

The plan specified `foreground = "#rrggbb"` hex strings, but **tealdeer 1.8.1's
`[style]` parser rejects hex** (`unknown variant '#…', expected one of black, …,
ansi, rgb`). Colors are encoded as `{ rgb = { r, g, b } }` tables instead —
**the exact same colors**, just the encoding the tool actually accepts. Caught at
the plan's TOML-parse step; documented in the CLAUDE.md bullet so the next theme
addition doesn't repeat the hex mistake.

## ✅ Test plan

- 🧪 All 10 configs parse in `tealdeer 1.8.1` (the consumer is the parser).
- 🧪 `scripts/test-theme-switch.sh` (worktree-scaffolded, `REPO=$PWD`):
  **94 passed, 0 failed** — including 9 new tealdeer asserts (8 dark blocks +
  Latte positive-contract).
- 👁️ Eyeball render of `tldr tar` per theme: each produces exactly its four
  configured 24-bit colors, visibly distinct across themes, zero white-fallback
  (proves the rgb tables are honored, not silently dropped).
- 🐟 `scripts/test-fish-loads.sh` passes; `TEALDEER_CONFIG_DIR` exported.
- 🔁 No collisions with `origin/main` (no other follower landed since branch base).
- 🐳 Sandbox: `bash -n` clean; image build deferred to CI (`sandbox.yml` runs on
  sandbox-path PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
