### PR TITLE
🪝 worktrunk: trust mise after copy-ignored (fix gitignored-config race)

### DIFF
--- a/.config/worktrunk/config.toml
+++ b/.config/worktrunk/config.toml
@@ -250,9 +250,18 @@ worktree-path = "{{ repo_path }}/.claude/worktrees/{{ branch | sanitize }}"
 # Copy gitignored content from the primary worktree into each new
 # worktree at start. Picks up `.superpowers/`, `.autonomo/`, and any
 # other gitignored paths automatically — no per-path hooks needed.
+#
+# `mise trust` is chained onto this *same* hook (not a second post-start
+# entry) on purpose: a repo's mise config can itself be gitignored —
+# chopin's `mise.local.toml` is — so a fresh worktree's git checkout
+# doesn't contain it; `wt step copy-ignored` is what delivers it. As two
+# separate background post-start hooks the trust raced the copy and ran
+# before the config landed, leaving the worktree untrusted (mise warns on
+# the next shell/pane). Chaining guarantees trust runs after the file
+# exists. `--all` trusts the worktree config plus parents (post-start cwd
+# is the new worktree); errors swallowed so a mise-less repo is a no-op.
 [post-start]
-copy = "wt step copy-ignored"
-trust-mise = "mise trust --yes 2>/dev/null || true"
+copy = "wt step copy-ignored; mise trust --all 2>/dev/null || true"
 
 # Before wt remove deletes a worktree, save any new gitignored
 # content (planning artefacts under .superpowers/, autonomo logs

--- a/.gitignore_global
+++ b/.gitignore_global
@@ -13,6 +13,9 @@
 .scratch
 .secrets
 
+# mise local config
+mise.local.toml
+
 # CI/code-quality tooling state
 .codacy
 .github/instructions/codacy.instructions.md


### PR DESCRIPTION
## Summary

Fixes a race in the worktrunk post-start hooks that left new worktrees with a gitignored mise config untrusted (e.g. chopin mise.local.toml).

`trust-mise` was a separate background post-start hook from `copy = "wt step copy-ignored"`. Since a gitignored mise config is not in a fresh worktree git checkout — it arrives only via copy-ignored — `mise trust` could run before the file existed, leaving the worktree untrusted. The next shell/pane then hit the mise untrusted-config warning.

The hook predates the affected worktrees, so it was running and still lost the race.

## Changes

- `.config/worktrunk/config.toml`: chain `mise trust --all` onto the `copy` post-start hook so trust runs only after copy-ignored delivers the config; removes the separate `trust-mise` hook.
- `.gitignore_global`: add `mise.local.toml` so machine-local mise config is never committed.

## Verification

- `wt hook show` reflects the single chained hook.
- Untrusted a worktree mise.local.toml, ran the exact chained command (cwd = worktree), confirmed it returns to trusted.