### PR TITLE
📐 glow: md/mdp wrap to the current terminal width

### DIFF
--- a/.config/fish/conf.d/30-aliases.fish
+++ b/.config/fish/conf.d/30-aliases.fish
@@ -8,10 +8,8 @@ if command -q eza
     alias la='ll -a'
 end
 
-if command -q glow
-    alias md='glow --style $HOME/.config/glow/glamour.json'
-    alias mdp='md -p'
-end
+# md / mdp live in functions/ (functions/md.fish) — they wrap glow at the
+# current terminal width, which an alias can't compute per-invocation.
 
 if command -q procs
     alias ps='procs'

--- a/.config/fish/functions/md.fish
+++ b/.config/fish/functions/md.fish
@@ -1,0 +1,18 @@
+# glow-backed markdown renderer, word-wrapped to the current terminal/pane width.
+#
+# glow reads its wrap width once at launch (one-shot + pager modes render and
+# exit), so the width reflects the pane size at the moment `md` runs — resize
+# the pane and re-run to re-flow. Passing the full $COLUMNS is safe: glow keeps
+# a 2-col gutter, so output never hugs the edge. A later user `-w`/`--width`
+# wins (cobra takes the last flag), so `md -w 100 file` still overrides.
+#
+# Piped/redirected output (no tty) drops --width so renders stay deterministic,
+# falling back to glow.yml's configured width.
+function md --description 'Render markdown via glow, wrapped to the current terminal width'
+    set -l style $HOME/.config/glow/glamour.json
+    set -l width
+    if isatty stdout; and set -q COLUMNS; and test "$COLUMNS" -gt 0
+        set width --width $COLUMNS
+    end
+    glow --style $style $width $argv
+end

--- a/.config/fish/functions/mdp.fish
+++ b/.config/fish/functions/mdp.fish
@@ -1,0 +1,4 @@
+# md through the pager (glow -p → $PAGER). Inherits md's terminal-width wrap.
+function mdp --description 'md through the pager (glow -p)' --wraps md
+    md -p $argv
+end

--- a/.config/worktrunk/config.toml
+++ b/.config/worktrunk/config.toml
@@ -250,9 +250,18 @@ worktree-path = "{{ repo_path }}/.claude/worktrees/{{ branch | sanitize }}"
 # Copy gitignored content from the primary worktree into each new
 # worktree at start. Picks up `.superpowers/`, `.autonomo/`, and any
 # other gitignored paths automatically — no per-path hooks needed.
+#
+# `mise trust` is chained onto this *same* hook (not a second post-start
+# entry) on purpose: a repo's mise config can itself be gitignored —
+# chopin's `mise.local.toml` is — so a fresh worktree's git checkout
+# doesn't contain it; `wt step copy-ignored` is what delivers it. As two
+# separate background post-start hooks the trust raced the copy and ran
+# before the config landed, leaving the worktree untrusted (mise warns on
+# the next shell/pane). Chaining guarantees trust runs after the file
+# exists. `--all` trusts the worktree config plus parents (post-start cwd
+# is the new worktree); errors swallowed so a mise-less repo is a no-op.
 [post-start]
-copy = "wt step copy-ignored"
-trust-mise = "mise trust --yes 2>/dev/null || true"
+copy = "wt step copy-ignored; mise trust --all 2>/dev/null || true"
 
 # Before wt remove deletes a worktree, save any new gitignored
 # content (planning artefacts under .superpowers/, autonomo logs

--- a/.gitignore_global
+++ b/.gitignore_global
@@ -13,6 +13,9 @@
 .scratch
 .secrets
 
+# mise local config
+mise.local.toml
+
 # CI/code-quality tooling state
 .codacy
 .github/instructions/codacy.instructions.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,9 +204,16 @@ bootstrap defaults. See "Switchable themes" / "Switchable Ghostty fonts" below.
 - **Interactive `less` is a `bat` wrapper** (`functions/less.fish`); piped input
   uses `--plain`. `command less` for `+F`/`-R`. Don't `alias less=bat` or set
   `$PAGER=bat`.
-- **`md` renders markdown via `glow`** (`--style .config/glow/glamour.json`,
-  because glow reads from `~/Library/Preferences/glow/` on macOS). **`mdp` =
-  `md -p`** through `$PAGER`. Don't swap to `mdcat`/`frogmouth`.
+- **`md` renders markdown via `glow`** (fish function `functions/md.fish`, not
+  an alias; `--style .config/glow/glamour.json`, because glow reads from
+  `~/Library/Preferences/glow/` on macOS). **Wraps to the current terminal/pane
+  width** — passes `--width $COLUMNS` when stdout is a tty (glow reads width
+  once at launch; resize + re-run to re-flow — one-shot/pager modes don't
+  re-render), and drops `--width` for piped output so redirected renders stay
+  deterministic (glow.yml's width). A later user `-w`/`--width` overrides
+  (cobra takes the last flag), so `md -w 100 file` still works. **`mdp` =
+  `md -p`** through `$PAGER` (inherits the width). Don't swap to
+  `mdcat`/`frogmouth`.
 - **`nvimpager` is the global `$PAGER`** (`00-env.fish`, guarded). Loads its own
   `~/.config/nvimpager/init.lua` (not the nvim config), reusing nvim's lazy
   `snacks.nvim` for scroll (existence-guarded — fresh machine works without

--- a/docs/terminal-cheatsheet.html
+++ b/docs/terminal-cheatsheet.html
@@ -63,7 +63,7 @@
       <tr><td class="key"><a href="https://github.com/sharkdp/bat"><code>bat</code></a></td><td class="desc">syntax-highlighted cat / man pager backend</td></tr>
       <tr><td class="key"><a href="https://github.com/dandavison/delta"><code>git-delta</code></a></td><td class="desc">git diff/log/blame pager</td></tr>
       <tr><td class="key"><a href="https://difftastic.wilfred.me.uk/"><code>difftastic</code></a></td><td class="desc">syntactic diff for ad-hoc compares (non-git)</td></tr>
-      <tr><td class="key"><a href="https://github.com/charmbracelet/glow"><code>glow</code></a></td><td class="desc">render markdown to ANSI (powers <code>md</code> alias)</td></tr>
+      <tr><td class="key"><a href="https://github.com/charmbracelet/glow"><code>glow</code></a></td><td class="desc">render markdown to ANSI (powers <code>md</code>)</td></tr>
       <tr><td class="key"><a href="https://github.com/sharkdp/vivid"><code>vivid</code></a></td><td class="desc">generates LS_COLORS palettes</td></tr>
       <tr><td class="key"><a href="https://github.com/dalance/procs"><code>procs</code></a></td><td class="desc">modern ps replacement (Rust)</td></tr>
       <tr><td class="key"><a href="https://github.com/bensadeh/tailspin"><code>tailspin</code></a></td><td class="desc">live-log highlighter (<code>tspin</code>); Solarized via <code>~/.config/tailspin/theme.toml</code></td></tr>
@@ -93,8 +93,8 @@
     <table>
       <tr><td class="key"><code>cat</code></td><td class="desc">→ <code>bat --paging=never</code></td></tr>
       <tr><td class="key"><code>less</code></td><td class="desc">function → <code>bat</code> wrapper (file = full decoration; pipe = <code>--plain</code>)</td></tr>
-      <tr><td class="key"><code>md</code></td><td class="desc">→ <code>glow --style ~/.config/glow/glamour.json</code></td></tr>
-      <tr><td class="key"><code>mdp</code></td><td class="desc">→ <code>md -p</code> (paged via real <code>less</code>)</td></tr>
+      <tr><td class="key"><code>md</code></td><td class="desc">→ <code>glow --style ~/.config/glow/glamour.json --width $COLUMNS</code> (fish fn; wraps to pane width)</td></tr>
+      <tr><td class="key"><code>mdp</code></td><td class="desc">→ <code>md -p</code> (paged via <code>$PAGER</code>)</td></tr>
       <tr><td class="key"><code>ls</code></td><td class="desc">→ <code>eza --group-directories-first --icons</code></td></tr>
       <tr><td class="key"><code>ll</code></td><td class="desc">→ <code>eza -lh --git --icons --group-directories-first</code></td></tr>
       <tr><td class="key"><code>la</code></td><td class="desc">→ <code>ll -a</code></td></tr>
@@ -365,16 +365,22 @@
 
 <div class="grid">
   <div class="card">
-    <h3>The <code>md</code> alias</h3>
+    <h3>The <code>md</code> function</h3>
     <p>
-      <code>md</code> renders markdown to ANSI via <code>glow</code> with a pinned Solarized
-      style:
+      <code>md</code> (a fish function, <code>functions/md.fish</code>) renders markdown to
+      ANSI via <code>glow</code> with a pinned Solarized style, word-wrapped to the
+      current terminal/pane width:
     </p>
-    <pre><span class="kw">alias</span> <span class="cmd">md</span>=<span class="str">'glow --style $HOME/.config/glow/glamour.json'</span></pre>
+    <pre><span class="kw">function</span> <span class="cmd">md</span>
+    glow --style <span class="str">$HOME/.config/glow/glamour.json</span> --width <span class="str">$COLUMNS</span> $argv
+<span class="kw">end</span></pre>
     <p>
-      <code>bat</code> / <code>less</code> / <code>cat</code> still show the source with
-      syntax highlighting; <code>md</code> shows the rendered output (headings, lists,
-      code-block themes).
+      glow reads the width once at launch (one-shot and pager modes render then exit),
+      so the wrap reflects the pane size at the moment <code>md</code> runs — resize and
+      re-run to re-flow. Piped output drops <code>--width</code> (glow.yml default) so
+      redirected renders stay deterministic. <code>bat</code> / <code>less</code> /
+      <code>cat</code> still show the source with syntax highlighting; <code>md</code>
+      shows the rendered output (headings, lists, code-block themes).
     </p>
   </div>
 
@@ -382,7 +388,7 @@
     <h3>Why <code>--style</code>, not <code>glow.yml</code></h3>
     <p>
       glow on macOS reads its yaml from <code>~/Library/Preferences/glow/</code>, not
-      <code>~/.config/glow/</code>. The alias passes <code>--style</code> directly so the
+      <code>~/.config/glow/</code>. The function passes <code>--style</code> directly so the
       Solarized JSON in this repo (<code>.config/glow/glamour.json</code>) is used regardless.
     </p>
     <p class="note">
@@ -397,9 +403,9 @@
       <tr><td class="key"><code>md README.md</code></td><td class="desc">render to terminal</td></tr>
       <tr><td class="key"><code>md -p README.md</code></td><td class="desc">paged (uses <code>$PAGER</code> / less)</td></tr>
       <tr><td class="key"><code>mdp README.md</code></td><td class="desc">same as <code>md -p</code> (dedicated alias)</td></tr>
-      <tr><td class="key"><code>md -w 100 README.md</code></td><td class="desc">force width 100</td></tr>
+      <tr><td class="key"><code>md -w 100 README.md</code></td><td class="desc">override width (later flag wins)</td></tr>
       <tr><td class="key"><code>cat foo.md | md -</code></td><td class="desc">render from stdin</td></tr>
-      <tr><td class="key"><code>command glow ...</code></td><td class="desc">bypass alias (no <code>--style</code>)</td></tr>
+      <tr><td class="key"><code>command glow ...</code></td><td class="desc">bypass <code>md</code> (no <code>--style</code>/width)</td></tr>
     </table>
     <p class="note">Don't swap to <code>mdcat</code> / <code>frogmouth</code> without an explicit ask — <code>mdcat</code> was archived upstream 2025-01-10.</p>
   </div>


### PR DESCRIPTION
## Summary

`md` was an alias hardcoded to glow.yml's `width: 80`, so rendered markdown ignored the pane size. This converts `md`/`mdp` to fish functions that wrap to the **current terminal/pane width**.

```
mdp file → md -p file → glow --style …/glamour.json --width $COLUMNS -p file
```

## Behaviour

- **Interactive** (stdout is a tty) → passes `--width $COLUMNS`, so the wrap matches the pane width at the moment `md` runs.
- **Piped/redirected** → drops `--width`, keeping glow.yml's width so redirected renders stay deterministic.
- **Override** → a later `-w`/`--width` wins (cobra takes the last flag), so `md -w 100 file` still works.
- **`mdp`** (= `md -p`) inherits the width.

glow reads the wrap width **once at launch** — one-shot and pager modes render then exit, so live re-flow on resize isn't possible without glow's full-screen TUI. Resize the pane and re-run to re-flow.

## Changes

- `.config/fish/functions/md.fish`, `mdp.fish` — new width-aware functions
- `.config/fish/conf.d/30-aliases.fish` — drop the old `glow` alias block
- `CLAUDE.md`, `docs/terminal-cheatsheet.html` — doc updates

## Verification

- `scripts/test-fish-loads.sh` ✅
- Functions autoload; width-selection logic confirmed (`--width $COLUMNS` when tty + COLUMNS>0, dropped when piped)
- Confirmed `--width` overrides glow.yml, scales uncapped, leaves a 2-col gutter, and a later `-w` wins