### PR TITLE
🔖 i: feature-bead id mirrors the GitHub issue number

### DIFF
--- a/bin/i
+++ b/bin/i
@@ -4,8 +4,9 @@
 #   i <issue> [slug]
 #
 # From inside a project repo:
-#   1. pulls GitHub issue <issue> into beads — PULL-ONLY, never `bd github sync`
-#      (a bare sync would push your local/stealth beads to GitHub).
+#   1. fetches GitHub issue <issue> via `gh` and creates a feature bead whose id
+#      mirrors the issue number: <prefix>-<n> (e.g. gruppo-42). We choose the id
+#      at creation time because bd ids are immutable (no per-bead rename).
 #   2. shapes the bead for the /mc:* workflow: type=feature + a `branch:<name>`
 #      label, set in the MAIN .beads/ *before* the worktree is made so
 #      worktrunk's post-start copy-ignored carries the labelled bead in.
@@ -13,8 +14,9 @@
 #      claude seeded with `/mc:brainstorm` (no issue number — it loads the
 #      issue from the branch's feature bead).
 #
-# One-time per repo:  bd config set github.repository <owner/repo>
-# (GITHUB_TOKEN is auto-sourced from `gh auth token` below — no manual token.)
+# One-time per repo:  bd init --stealth --prefix <repo>-   (sets issue_prefix)
+# gh infers owner/repo from the repo's git remote; no bd github.repository or
+# GITHUB_TOKEN needed.
 # Requires: bd, wt, sesh, tmux, jq, gh, fish, `s` on PATH (claude for the seeded
 # session, `slm` for the slug).
 #
@@ -27,9 +29,8 @@
 # or the model is unreachable. Override: `i <n> <slug>`.
 #
 # CONFIRM ON FIRST RUN (couldn't verify without GitHub creds + network):
-#   • `bd github pull "$n"` arg form — if a bare number isn't recognised as a
-#     GitHub ref, try `github:$n` or the issue URL (the github tracker matches
-#     /issues/<n> and a github:<n> shorthand).
+#   • `gh issue view "$n" --json title,body,url` resolves against the repo's
+#     remote — run `i` from inside the project checkout (it does by design).
 #   • `claude "/mc:brainstorm"` — confirm this starts an INTERACTIVE session
 #     seeded with that command (vs `-p`, which is headless).
 set -euo pipefail
@@ -74,25 +75,31 @@ common=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || {
 main=$(cd "$(dirname "$common")" && pwd -P)
 
 bd -C "$main" status >/dev/null 2>&1 || {
-  echo "i: beads not initialised in $main (run 'bd init' + set github.repository once)" >&2; exit 1; }
+  echo "i: beads not initialised in $main (run 'bd init --stealth --prefix <repo>- ' once)" >&2; exit 1; }
 
-# GitHub token for the bd github bridge — sourced fresh from gh, never stored.
-export GITHUB_TOKEN="${GITHUB_TOKEN:-$(gh auth token 2>/dev/null)}"
+# 1. Fetch the issue via gh (gh infers owner/repo from the repo we're in) and
+#    create the feature bead with a number-mirroring id <prefix>-<n>.
+#    Replaces `bd github pull` so we control the id (bd ids are immutable —
+#    there's no rename, so the id must be chosen at creation time).
+prefix=$(bd -C "$main" config get issue_prefix 2>/dev/null | tail -n1)
+[[ -n "$prefix" ]] || { echo "i: no issue_prefix configured in $main (run 'bd init --prefix <repo>-' once)" >&2; exit 1; }
+id="${prefix}-${n}"
 
-# 1. PULL-ONLY ingest.
-echo "i: pulling issue #$n into beads…" >&2
-bd -C "$main" github pull "$n" >/dev/null
+meta=$(gh issue view "$n" --json title,body,url 2>/dev/null) || {
+  echo "i: gh issue view #$n failed (check 'gh auth status' and that #$n exists)" >&2; exit 1; }
+title=$(jq -r '.title // ""' <<<"$meta")
+desc=$( jq -r '.body  // ""' <<<"$meta")
+url=$(  jq -r '.url   // ""' <<<"$meta")
 
-# Resolve the pulled bead by its GitHub external_ref (issue URL, or github:<n>
-# shorthand fallback). bd --json output is an array.
-id=$(bd -C "$main" list --json 2>/dev/null \
-  | jq -r --arg n "$n" '[.[] | select((.external_ref // "") | test("(/issues/|github:)" + $n + "$"))][0].id // empty')
-[[ -n "$id" ]] || { echo "i: couldn't find the pulled bead for issue #$n (check github config / pull arg form)" >&2; exit 1; }
+echo "i: issue #$n → bead $id" >&2
+if ! bd -C "$main" show "$id" --json >/dev/null 2>&1; then
+  # `bd create --id` on an existing id is a silent destructive upsert, so only
+  # create when the bead is absent; otherwise adopt it as-is below.
+  bd -C "$main" create --id "$id" --type feature \
+    --external-ref "$url" --description "$desc" "$title" >/dev/null
+fi
 
 # 2. Branch name + shape the bead for /mc:* — in MAIN, before the worktree snapshot.
-bead_json=$(bd -C "$main" show "$id" --json 2>/dev/null)
-title=$(jq -r '.[0].title // ""'       <<<"$bead_json")
-desc=$( jq -r '.[0].description // ""' <<<"$bead_json")
 slug="${2:-$(local_slug "$title" "$desc")}"   # explicit arg wins; else local slm model
 branch="$n${slug:+-$slug}"             # <n>-<slug>, or just <n> if no slug
 


### PR DESCRIPTION
## 🎯 What
`i <issue>` now creates the feature bead with id `<prefix>-<issue>` (e.g. `gruppo-42`) instead of `bd github pull`'s opaque timestamp id.

## 🔧 Changes
- 🔁 Replace `bd github pull "$n"` + external_ref resolution with `gh issue view --json title,body,url` → `bd create --id <prefix>-<n>`.
- 🛡️ `bd show` guard before create (`bd create --id <existing>` is a silent destructive upsert).
- 🧹 Drop the `GITHUB_TOKEN` export and `bd github.repository` requirement — `gh` infers the repo from the remote. Header/setup/error-hint comments updated.

## 🔗 Companion
Pairs with gruppo PR #69, which documents the convention and aligns the manual `/mc:brainstorm <N>` path.

## 🧪 Test plan
- ✅ `bash -n` + `shellcheck` clean.
- ✅ bd id creation + adopt-guard + `issue_type=feature` smoke-tested in a throwaway `bd init --stealth` store.
- ⏳ First live run: `i <real-issue>` → bead `<prefix>-<issue>`; re-run adopts, doesn't clobber.

🤖 Generated with [Claude Code](https://claude.com/claude-code)