### PR TITLE
⚡ tmux usage: cost chip after the 5h block (red bg, drop speedometer)

### DIFF
--- a/.config/tmux/bin/tmux-claude-usage
+++ b/.config/tmux/bin/tmux-claude-usage
@@ -1,7 +1,11 @@
 #!/opt/homebrew/bin/bash
-# Renders two left-cluster tmux chips for Claude Code usage:
+# Renders the left-cluster tmux chips for Claude Code usage:
 #   - 7d weekly chip (violet, compact body, auto-expands when pct >= 80)
 #   - 5h block chip  (yellow, always full body)
+#   - cost chip      (red, "$xx/h" throughput) — appended after the 5h
+#                     chip; emitted only when ccpulse reports throughput.
+#                     Older builds omit it and the 5h chip closes straight
+#                     into the bar.
 # Source: `ccpulse status --json --index` (--index tails new JSONL into
 # the cache before reporting, so throughput reflects live activity).
 # Helper hides (empty output, exit 0) whenever any required field is
@@ -34,14 +38,12 @@ format_reset() {
   fi
 }
 
-# Fire and speed glyphs used by the sourced formatters
-# (format_overreach_suffix, format_cost_throughput). Defined above the
-# source guard so the helper is fully usable when sourced for testing
+# Fire glyph used by format_overreach_suffix. Defined above the source
+# guard so the helper is fully usable when sourced for testing
 # (TMUX_CLAUDE_USAGE_NO_RUN=1). Other glyphs (robot, hourglass, calendar,
 # tri_l, tri_r) live in the runtime block — they are only needed by the
-# chip-rendering printfs.
+# chip-rendering printfs. The cost chip is plain text ("$xx/h"), no glyph.
 fire=$(printf '\xef\x81\xad')      # U+F06D nf-fa-fire
-speed=$(printf '\xf3\xb0\x93\x85') # U+F04C5 nf-md-speedometer
 
 # Returns the overreach decoration to insert after a chip's percentage.
 # Output is meant to be appended directly to a chip body (leading space
@@ -67,22 +69,23 @@ format_overreach_suffix() {
   fi
 }
 
-# Returns the cost-throughput segment inserted after the robot on the 7d
-# chip. The leading space is baked in (like format_overreach_suffix) so it
-# concatenates directly; empty when ccpulse omits throughput (older builds)
-# so the robot falls straight through to the calendar. $0/h still renders
-# when the rate is exactly 0 (idle) — only an absent field hides it.
+# Returns the cost-throughput body ("$N/h") for the standalone red cost
+# chip rendered after the 5h chip. No glyph and no leading space — the chip
+# printf supplies its own padding. Empty when ccpulse omits throughput
+# (older builds), in which case no cost chip is emitted and the 5h chip
+# closes straight into the bar. $0/h still renders when the rate is exactly
+# 0 (idle) — only an absent field hides it.
 #
 # LC_ALL=C on the printf is mandatory: this machine's LC_NUMERIC=pl_PL.UTF-8
 # (decimal comma) would otherwise mis-parse jq's dot-decimal and truncate
 # instead of rounding (e.g. 14.6 -> $14 + an "invalid number" error).
 #
 #   args:   $1 = cost_per_hour_usd (number string, or "" when null/absent)
-#   stdout: " <speed> $N/h"  when $1 non-empty   |   ""  when $1 empty
+#   stdout: "$N/h"  when $1 non-empty   |   ""  when $1 empty
 format_cost_throughput() {
   local cost=$1
   [ -n "$cost" ] || { printf ''; return 0; }
-  LC_ALL=C printf ' %s $%.0f/h' "$speed" "$cost"
+  LC_ALL=C printf '$%.0f/h' "$cost"
 }
 
 # When sourced for testing, return early without running the chip
@@ -167,6 +170,8 @@ violet="$(tmux    show-option -gv @color_accent_violet 2>/dev/null)"; : "${viole
 yellow="$(tmux    show-option -gv @color_accent_yellow 2>/dev/null)"; : "${yellow:=#b58900}"
 fg_violet="$(tmux show-option -gv @color_light_fg      2>/dev/null)"; : "${fg_violet:=#fdf6e3}"
 fg_yellow="$(tmux show-option -gv @color_bar_bg        2>/dev/null)"; : "${fg_yellow:=#073642}"
+red="$(tmux       show-option -gv @color_accent_red    2>/dev/null)"; : "${red:=#dc322f}"
+fg_red="$(tmux    show-option -gv @color_light_fg      2>/dev/null)"; : "${fg_red:=#fdf6e3}"
 
 # Glyphs as raw UTF-8 byte sequences (editor-independent literal).
 tri_l=$(printf '\xee\x82\xb6')      # U+E0B6 left rounded cap (filled)
@@ -186,22 +191,20 @@ body_5h=$(printf '%s %d%%%s • %s' \
 
 # 7d body: robot + calendar + pct, with optional reset when pct >= threshold.
 # Robot glyph is the cluster's "this is Claude" anchor (was its own chip
-# pre-merge); calendar remains the 7d-window anchor.
+# pre-merge); calendar remains the 7d-window anchor. Cost-throughput is no
+# longer inlined here — it renders as its own red chip after the 5h chip.
 over_7d_suffix=$(format_overreach_suffix "$over_7d" "$proj_7d" "$conf_7d")
-# Cost-throughput element ($xx/h) sits between the robot and the calendar.
-# Empty under graceful degradation (older ccpulse without throughput).
-cost_seg=$(format_cost_throughput "$cost_ph")
 if [ "$pct_7d" -ge "$threshold" ]; then
   # Expanded body: pct + (optional overreach decoration) + • <reset>.
-  body_7d=$(printf '%s%s %s %d%%%s • %s' \
-    "$robot" "$cost_seg" "$calendar" "$pct_7d" "$over_7d_suffix" "$reset_7d")
+  body_7d=$(printf '%s %s %d%%%s • %s' \
+    "$robot" "$calendar" "$pct_7d" "$over_7d_suffix" "$reset_7d")
 elif [ -n "$over_7d_suffix" ]; then
   # Compact-with-overreach: pct + overreach decoration, no reset.
-  body_7d=$(printf '%s%s %s %d%%%s' \
-    "$robot" "$cost_seg" "$calendar" "$pct_7d" "$over_7d_suffix")
+  body_7d=$(printf '%s %s %d%%%s' \
+    "$robot" "$calendar" "$pct_7d" "$over_7d_suffix")
 else
   # Compact: pct only.
-  body_7d=$(printf '%s%s %s %d%%' "$robot" "$cost_seg" "$calendar" "$pct_7d")
+  body_7d=$(printf '%s %s %d%%' "$robot" "$calendar" "$pct_7d")
 fi
 
 # Render: violet chip — 7d body (left cap closes bar_bg, right cap forwards into yellow).
@@ -210,9 +213,28 @@ printf '#[fg=%s,bg=%s]%s#[fg=%s,bg=%s,bold] %s ' \
   "$fg_violet" "$violet" \
   "$body_7d"
 
-# Yellow chip — 5h body (left cap forwards from violet, right cap closes into bar_bg).
-printf '#[bg=%s,fg=%s]%s#[fg=%s,bg=%s,bold] %s #[fg=%s,bg=%s]%s' \
-  "$yellow" "$violet" "$tri_r" \
-  "$fg_yellow" "$yellow" \
-  "$body_5h" \
-  "$yellow" "$bar_bg" "$tri_r"
+# Cost chip body ("$xx/h"); empty under graceful degradation (older ccpulse
+# without throughput), in which case the 5h chip closes into the bar.
+cost_body=$(format_cost_throughput "$cost_ph")
+
+if [ -n "$cost_body" ]; then
+  # Yellow chip — 5h body, right cap forwards into the red cost chip.
+  printf '#[bg=%s,fg=%s]%s#[fg=%s,bg=%s,bold] %s ' \
+    "$yellow" "$violet" "$tri_r" \
+    "$fg_yellow" "$yellow" \
+    "$body_5h"
+  # Red chip — cost throughput (left cap fuses yellow into red, right cap
+  # closes into bar_bg).
+  printf '#[bg=%s,fg=%s]%s#[fg=%s,bg=%s,bold] %s #[fg=%s,bg=%s]%s' \
+    "$red" "$yellow" "$tri_r" \
+    "$fg_red" "$red" \
+    "$cost_body" \
+    "$red" "$bar_bg" "$tri_r"
+else
+  # No throughput: yellow chip closes straight into bar_bg (original layout).
+  printf '#[bg=%s,fg=%s]%s#[fg=%s,bg=%s,bold] %s #[fg=%s,bg=%s]%s' \
+    "$yellow" "$violet" "$tri_r" \
+    "$fg_yellow" "$yellow" \
+    "$body_5h" \
+    "$yellow" "$bar_bg" "$tri_r"
+fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,8 +41,8 @@ bootstrap defaults. See "Switchable themes" / "Switchable Ghostty fonts" below.
   Don't add language patterns — those belong in per-language `.gitignore`.
 - **tmux status bar hand-rolled** (`.config/tmux/tmux.conf`, Solarized base16,
   no theme plugins). Each **pin** uses a unique Solarized accent (session=blue,
-  active window=green, git chips=violet/yellow, PR=orange); new pins pick an
-  unused accent (red/magenta/cyan). Palette reuse across left (usage cluster)
+  active window=green, git chips=violet/yellow, PR=orange, usage-cost=red);
+  new pins pick an unused accent (magenta/cyan). Palette reuse across left (usage cluster)
   and right (git chips) clusters is by design — positional, not paired.
   Mode/message/border/inline colors aren't pins.
 - **SSH indicator on the session chip** (`tmux-ssh-indicator`). Walks each
@@ -56,18 +56,19 @@ bootstrap defaults. See "Switchable themes" / "Switchable Ghostty fonts" below.
   a branch switch shows nothing; next 5s tick renders (never blocks on `gh`).
 - **tmux Claude usage cluster** in `status-left` (`tmux-claude-usage`, parses
   `ccpulse status --json --index` each 5s tick; `--index` tails new JSONL so
-  throughput is live). Two chips: violet 7d weekly + yellow
-  5h block, each showing `<pct>%` + reset. Overreach decoration (fire +
-  projected %) when `projection.<window>.will_overreach` **and**
+  throughput is live). Two always-on chips: violet 7d weekly + yellow
+  5h block, each showing `<pct>%` + reset, plus a red cost chip rendered
+  **after** the 5h block when ccpulse reports throughput. Overreach decoration
+  (fire + projected %) when `projection.<window>.will_overreach` **and**
   `projection.<window>.confidence != "low"` — a low-confidence projection
   (noisy early-window extrapolation) neither decorates nor auto-expands;
   default-to-ok when the field is absent (older ccpulse). 7d chip auto-expands
-  at pct≥80 or on a trusted overreach. 7d chip also shows a cost-throughput
-  element between robot and calendar — speedometer glyph + `$xx/h` from
-  `throughput.cost_per_hour_usd` (`LC_ALL=C printf '$%.0f/h'`, rounded, `$0/h`
-  when idle). Graceful degradation: missing `projection` keeps the cluster
-  (drops the decoration); missing `throughput` drops only the cost element;
-  missing any of the 4 core fields hides it atomically.
+  at pct≥80 or on a trusted overreach. The red cost chip shows `$xx/h` (plain
+  text, no glyph) from `throughput.cost_per_hour_usd` (`LC_ALL=C printf
+  '$%.0f/h'`, rounded, `$0/h` when idle); the 5h chip's right cap fuses into
+  it. Graceful degradation: missing `projection` keeps the cluster (drops the
+  decoration); missing `throughput` drops the red cost chip (5h closes straight
+  into the bar); missing any of the 4 core fields hides it atomically.
 - **tmux prefix `C-a`** (`C-Space` clashes with macOS input-source switch).
   Pane nav `<prefix> h/j/k/l`; splits `|` `-`. **Cycling pairs are
   single-canonical** (one combo per motion): windows `,`/`.`, sessions

--- a/scripts/test-tmux-claude-usage.sh
+++ b/scripts/test-tmux-claude-usage.sh
@@ -168,23 +168,21 @@ unset fire_glyph arrow_glyph
 
 # format_cost_throughput — direct unit tests.
 # Returns:
-#   - " <speed> $N/h"  when $1 is a non-empty number string (N = whole
-#                       dollars; $0/h still renders when the rate is 0)
-#   - ""                when $1 is empty (graceful degrade: older ccpulse
-#                       without a throughput.cost_per_hour_usd field).
+#   - "$N/h"  when $1 is a non-empty number string (N = whole dollars;
+#              $0/h still renders when the rate is 0). No glyph, no leading
+#              space — the red cost chip's printf supplies its own padding.
+#   - ""       when $1 is empty (graceful degrade: older ccpulse without a
+#              throughput.cost_per_hour_usd field).
 # Rounding uses LC_ALL=C printf '%.0f' (round-half-to-even). LC_ALL=C is
 # mandatory: this machine's LC_NUMERIC=pl_PL.UTF-8 (decimal comma) would
 # otherwise truncate jq's dot-decimals instead of rounding them.
-speed_glyph=$'\xf3\xb0\x93\x85'
-
-assert_eq "$(format_cost_throughput 14.46)"      " ${speed_glyph} \$14/h" "format_cost_throughput(14.46) — rounds down"
-assert_eq "$(format_cost_throughput 14.6)"       " ${speed_glyph} \$15/h" "format_cost_throughput(14.6) — rounds up (LOCALE GUARD)"
-assert_eq "$(format_cost_throughput 17.1138645)" " ${speed_glyph} \$17/h" "format_cost_throughput(17.1138645) — issue sample"
-assert_eq "$(format_cost_throughput 0)"          " ${speed_glyph} \$0/h"  "format_cost_throughput(0) — zero always shows"
-assert_eq "$(format_cost_throughput 14.5)"       " ${speed_glyph} \$14/h" "format_cost_throughput(14.5) — round-half-to-even under LC_ALL=C"
-assert_eq "$(format_cost_throughput '')"         ""                       "format_cost_throughput('') — graceful degrade"
+assert_eq "$(format_cost_throughput 14.46)"      '$14/h' "format_cost_throughput(14.46) — rounds down"
+assert_eq "$(format_cost_throughput 14.6)"       '$15/h' "format_cost_throughput(14.6) — rounds up (LOCALE GUARD)"
+assert_eq "$(format_cost_throughput 17.1138645)" '$17/h' "format_cost_throughput(17.1138645) — issue sample"
+assert_eq "$(format_cost_throughput 0)"          '$0/h'  "format_cost_throughput(0) — zero always shows"
+assert_eq "$(format_cost_throughput 14.5)"       '$14/h' "format_cost_throughput(14.5) — round-half-to-even under LC_ALL=C"
+assert_eq "$(format_cost_throughput '')"         ''      "format_cost_throughput('') — graceful degrade"
 unset -f format_cost_throughput
-unset speed_glyph
 
 unset TMUX_CLAUDE_USAGE_NO_RUN
 
@@ -509,8 +507,10 @@ fi
 teardown_sandbox
 
 # ─── Cost throughput ($xx/h) ─────────────────
-# Case: throughput present, 7d compact (pct 21 < 80). Expect the speed
-# glyph + "$14/h" between robot and calendar: "🤖 󰓅 $14/h <cal> 21%".
+# Cost throughput now renders as a standalone red chip AFTER the 5h chip,
+# with no glyph: the 5h yellow chip's right cap fuses into the red bg and
+# the red chip closes into bar_bg. (Solarized: yellow #b58900, red #dc322f,
+# light fg #fdf6e3, bar bg #073642.)
 setup_sandbox
 cat > "$TEST_BIN/ccpulse" <<'STUB'
 #!/opt/homebrew/bin/bash
@@ -520,13 +520,25 @@ JSON
 STUB
 chmod +x "$TEST_BIN/ccpulse"
 got=$(run_helper)
-assert_contains "$got" '$14/h'                                        "cost compact: \$14/h rendered (rounded, no cents)"
-assert_contains "$got" $'\xf3\xb0\x93\x85'                            "cost compact: speed glyph (U+F04C5) present"
-assert_contains "$got" $'\xf3\xb0\x93\x85'' $14/h '$'\xef\x91\x95'    "cost compact: speed → \$14/h → calendar ordering"
+assert_contains     "$got" '$14/h'                          "cost compact: \$14/h rendered (rounded, no cents)"
+assert_not_contains "$got" $'\xf3\xb0\x93\x85'              "cost compact: speedometer glyph dropped"
+assert_contains     "$got" "#[bg=#dc322f,fg=#b58900]"       "cost compact: left cap fuses yellow into red"
+assert_contains     "$got" "#[fg=#fdf6e3,bg=#dc322f,bold]"  "cost compact: red chip body uses light fg on red bold"
+assert_contains     "$got" "#[fg=#dc322f,bg=#073642]"       "cost compact: red chip closes into bar bg"
+# Positional: the cost body ($14/h) must come AFTER the 5h reset (3h37m),
+# confirming the cost chip sits to the right of the 5h chip.
+pos_5h=$(printf '%s' "$got" | grep -boF '3h37m' | head -1 | cut -d: -f1)
+pos_cost=$(printf '%s' "$got" | grep -boF '$14/h' | head -1 | cut -d: -f1)
+if [ -n "$pos_5h" ] && [ -n "$pos_cost" ] && [ "$pos_cost" -gt "$pos_5h" ]; then
+  pass=$((pass+1)); echo "  PASS  cost compact: cost chip renders after the 5h chip"
+else
+  fail=$((fail+1)); fail_msgs+=("FAIL  cost compact: cost chip should render after the 5h chip (5h@${pos_5h:-?} cost@${pos_cost:-?})")
+  echo "  FAIL  cost compact: cost chip renders after the 5h chip"
+fi
 teardown_sandbox
 
-# Case: throughput present, 7d expanded (pct 85 >= 80). Cost element also
-# appears in the expanded body, still ahead of the calendar.
+# Case: throughput present, 7d expanded (pct 85 >= 80). The cost chip is
+# independent of 7d expansion — it still renders as the trailing red chip.
 setup_sandbox
 cat > "$TEST_BIN/ccpulse" <<'STUB'
 #!/opt/homebrew/bin/bash
@@ -536,9 +548,9 @@ JSON
 STUB
 chmod +x "$TEST_BIN/ccpulse"
 got=$(run_helper)
-assert_contains "$got" '$14/h'                                        "cost expanded: \$14/h rendered"
-assert_contains "$got" "85% • "                                       "cost expanded: 7d auto-expanded (pct>=80)"
-assert_contains "$got" $'\xf3\xb0\x93\x85'' $14/h '$'\xef\x91\x95'    "cost expanded: speed → \$14/h → calendar ordering"
+assert_contains "$got" '$14/h'                           "cost expanded: \$14/h rendered"
+assert_contains "$got" "85% • "                          "cost expanded: 7d auto-expanded (pct>=80)"
+assert_contains "$got" "#[fg=#fdf6e3,bg=#dc322f,bold]"   "cost expanded: red cost chip still present"
 teardown_sandbox
 
 # Case: throughput present but rate is exactly 0 (idle window). Expect
@@ -556,7 +568,7 @@ assert_contains "$got" '$0/h' "cost zero: \$0/h still rendered when rate is 0"
 teardown_sandbox
 
 # Case: graceful degradation — core fields present but NO throughput key
-# (older ccpulse). Expect no cost element (no "/h", no speed glyph) yet
+# (older ccpulse). Expect no cost element (no "/h", no red cost chip) yet
 # BOTH chips still render.
 setup_sandbox
 cat > "$TEST_BIN/ccpulse" <<'STUB'
@@ -568,7 +580,7 @@ STUB
 chmod +x "$TEST_BIN/ccpulse"
 got=$(run_helper)
 assert_not_contains "$got" "/h"                "degrade: no cost element (no /h) when throughput absent"
-assert_not_contains "$got" $'\xf3\xb0\x93\x85' "degrade: no speed glyph when throughput absent"
+assert_not_contains "$got" "bg=#dc322f"        "degrade: no red cost chip when throughput absent"
 assert_contains     "$got" "8%"                "degrade: 5h pct still visible (cluster not hidden)"
 assert_contains     "$got" "21%"               "degrade: 7d pct still visible (cluster not hidden)"
 assert_contains     "$got" "3h37m"             "degrade: 5h reset still visible (chip body intact)"


### PR DESCRIPTION
## ⚡ What

Reworks the tmux Claude usage cluster so the **cost throughput renders as its own chip after the 5h block, on a red background**, and drops the speedometer glyph.

Previously `$xx/h` was inlined inside the violet 7d chip (between the robot and calendar) with a `󰓅` speedometer glyph. Now it's a standalone red pin to the right of the yellow 5h chip, shown as plain `$xx/h` text.

## 🎨 Layout

```
🤖 7% 🔥 → 182%  [violet 7d]    ⏳ 3% • 4h28m  [yellow 5h]    $14/h  [red cost]
```

- 🟣 7d chip back to robot + calendar + pct (no inline cost).
- 🟡 5h chip's right cap **fuses yellow into red** when throughput is present.
- 🔴 New red cost chip (`@color_accent_red`, light fg) closes into the bar.
- `usage-cost=red` recorded in the pin-accent list (remaining unused: magenta/cyan).

## 🔁 Compatibility

- Graceful degradation unchanged: when ccpulse omits `throughput` (older builds), **no cost chip is emitted** and the 5h chip closes straight into the bar — identical to the prior layout.
- `$0/h` still renders when the rate is exactly 0 (idle); only an absent field hides it.
- `LC_ALL=C` rounding guard retained (locale decimal-comma).

## 🧪 Test plan

- ✅ `scripts/test-tmux-claude-usage.sh` — **93 passed, 0 failed** against a throwaway Solarized tmux server.
- ✅ Updated unit tests for bare `$N/h` output and the standalone red chip; added a positional assertion that the cost chip sits to the right of the 5h chip; swapped the stale speed-glyph guard for a "no red chip" guard.
- ✅ Live render verified on the active theme (rose-pine-moon): violet 7d, yellow 5h, red `$xx/h`.

> ℹ️ The suite hardcodes Solarized hex, so it must run with the Solarized palette loaded (the helper reads live `@color_*` from the running server). This coupling predates this change.