### PR TITLE
🐛 tmux usage: keep the cluster visible when the 5h quota is idle

### DIFF
--- a/.config/tmux/bin/tmux-claude-usage
+++ b/.config/tmux/bin/tmux-claude-usage
@@ -139,7 +139,6 @@ conf_7d=${_fields[9]}
 cost_ph=${_fields[10]}
 
 [ -z "${pct_5h:-}" ]    && exit 0
-[ -z "${mins_5h:-}" ]   && exit 0
 [ -z "${pct_7d:-}" ]    && exit 0
 [ -z "${resets_7d:-}" ] && exit 0
 
@@ -158,8 +157,9 @@ now_epoch=$(/bin/date '+%s')
 mins_7d=$(( (resets_epoch - now_epoch) / 60 ))
 [ "$mins_7d" -lt 0 ] && mins_7d=0
 
-# Format both reset strings via the formatter from Task 4.
-reset_5h=$(format_reset "$mins_5h")
+# Format the 7d reset string via the formatter from Task 4. The 5h reset is
+# computed lazily in the body branch below — it is absent when the 5h quota is
+# idle (minutes_to_reset: null), issue #339.
 reset_7d=$(format_reset "$mins_7d")
 
 # ── Chip rendering ──────────────────────────
@@ -183,11 +183,21 @@ calendar=$(printf '\xef\x91\x95')   # U+F455 nf-oct-calendar
 # 7d auto-expand threshold (inclusive — pct == 80 expands).
 threshold=80
 
-# 5h body: always full (rendered in the yellow chip).
-body_5h=$(printf '%s %d%%%s • %s' \
-  "$hourglass" "$pct_5h" \
-  "$(format_overreach_suffix "$over_5h" "$proj_5h" "$conf_5h")" \
-  "$reset_5h")
+# 5h body (rendered in the yellow chip): pct + optional overreach decoration,
+# plus " • <reset>" only when the 5h window has a countdown. ccpulse reports
+# minutes_to_reset: null while the 5h quota is idle (0% utilization, just after
+# a reset) — a legitimate state, not missing data — so render the chip without a
+# reset suffix rather than hiding the whole cluster (issue #339). The overreach
+# decoration is independent of the countdown and shows in both branches.
+over_5h_suffix=$(format_overreach_suffix "$over_5h" "$proj_5h" "$conf_5h")
+if [ -n "$mins_5h" ]; then
+  reset_5h=$(format_reset "$mins_5h")
+  body_5h=$(printf '%s %d%%%s • %s' \
+    "$hourglass" "$pct_5h" "$over_5h_suffix" "$reset_5h")
+else
+  body_5h=$(printf '%s %d%%%s' \
+    "$hourglass" "$pct_5h" "$over_5h_suffix")
+fi
 
 # 7d body: robot + calendar + pct, with optional reset when pct >= threshold.
 # Robot glyph is the cluster's "this is Claude" anchor (was its own chip

--- a/.config/tmux/bin/tmux-claude-usage
+++ b/.config/tmux/bin/tmux-claude-usage
@@ -101,9 +101,9 @@ command -v ccpulse >/dev/null 2>&1 || exit 0
 json=$(ccpulse status --json --index 2>/dev/null) || exit 0
 [ -z "$json" ] && exit 0
 
-# Parse the four required fields with jq. Any null/missing field -> empty
+# Parse the three required fields with jq. Any null/missing field -> empty
 # string here, then we abort. Atomic: both chips render or neither.
-# Read the eight ccpulse fields via mapfile + line-per-value jq output.
+# Read the eleven ccpulse fields via mapfile + line-per-value jq output.
 # `read -r ... <<< @tsv` does NOT preserve empty fields between two tabs:
 # bash collapses adjacent IFS-whitespace separators (POSIX rule) — and
 # tab is IFS-whitespace, so even `IFS=$'\t'` does not help. Boolean

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ bootstrap defaults. See "Switchable themes" / "Switchable Ghostty fonts" below.
   '$%.0f/h'`, rounded, `$0/h` when idle); the 5h chip's right cap fuses into
   it. Graceful degradation: missing `projection` keeps the cluster (drops the
   decoration); missing `throughput` drops the red cost chip (5h closes straight
-  into the bar); missing any of the 4 core fields hides it atomically.
+  into the bar); missing any of the 3 core fields hides it atomically (an idle 5h — `minutes_to_reset: null` — drops just the 5h reset suffix, not the whole cluster, #339).
 - **tmux prefix `C-a`** (`C-Space` clashes with macOS input-source switch).
   Pane nav `<prefix> h/j/k/l`; splits `|` `-`. **Cycling pairs are
   single-canonical** (one combo per motion): windows `,`/`.`, sessions

--- a/scripts/test-tmux-claude-usage.sh
+++ b/scripts/test-tmux-claude-usage.sh
@@ -586,6 +586,49 @@ assert_contains     "$got" "21%"               "degrade: 7d pct still visible (c
 assert_contains     "$got" "3h37m"             "degrade: 5h reset still visible (chip body intact)"
 teardown_sandbox
 
+# ─── 5h idle: minutes_to_reset null (issue #339) ─────
+# ccpulse reports minutes_to_reset: null while the 5h quota is idle (0%
+# utilization, just after a reset). The cluster must STAY VISIBLE and the 5h
+# chip render "<hourglass> 0%" with no • reset suffix. Previously line 142 hid
+# both chips. The helper keys off TOP-LEVEL .percent / .minutes_to_reset (the
+# five_hour block below is realistic but not read); 7d is low + non-overreaching
+# so the only possible " • " source is the 5h reset suffix, which must be absent.
+setup_sandbox
+cat > "$TEST_BIN/ccpulse" <<'STUB'
+#!/opt/homebrew/bin/bash
+cat <<'JSON'
+{"percent":0,"minutes_to_reset":null,"quota":{"five_hour":{"utilization":0,"resets_at":null},"seven_day":{"utilization":11,"resets_at":"2099-12-31T00:00:00Z"}}}
+JSON
+STUB
+chmod +x "$TEST_BIN/ccpulse"
+got=$(run_helper)
+if [ -n "$got" ]; then
+  pass=$((pass+1)); echo "  PASS  5h idle: cluster renders (non-empty)"
+else
+  fail=$((fail+1)); fail_msgs+=("FAIL  5h idle: cluster hidden (empty output) — issue #339 regression")
+  echo "  FAIL  5h idle: cluster hidden (empty output)"
+fi
+assert_contains     "$got" $'\xef\x89\x92' "5h idle: hourglass glyph (U+F252) present"
+assert_contains     "$got" "0%"            "5h idle: 5h pct 0% visible"
+assert_not_contains "$got" " • "           "5h idle: no • reset suffix (compact 7d emits none)"
+teardown_sandbox
+
+# Case: 5h idle AND 5h overreach. The overreach decoration is independent of the
+# reset countdown — it must still render, but with NO • reset suffix.
+setup_sandbox
+cat > "$TEST_BIN/ccpulse" <<'STUB'
+#!/opt/homebrew/bin/bash
+cat <<'JSON'
+{"percent":0,"minutes_to_reset":null,"quota":{"five_hour":{"utilization":0,"resets_at":null},"seven_day":{"utilization":11,"resets_at":"2099-12-31T00:00:00Z"}},"projection":{"five_hour":{"will_overreach":true,"projected_pct_at_reset":120,"confidence":"ok"},"seven_day":{"will_overreach":false,"projected_pct_at_reset":15,"confidence":"ok"}}}
+JSON
+STUB
+chmod +x "$TEST_BIN/ccpulse"
+got=$(run_helper)
+assert_contains     "$got" $'\xef\x81\xad'                              "5h idle + overreach: fire glyph (U+F06D) present"
+assert_contains     "$got" "0% "$'\xef\x81\xad'" "$'\xe2\x86\x92'" 120%" "5h idle + overreach: '0% 🔥 → 120%' shown"
+assert_not_contains "$got" " • "                                        "5h idle + overreach: still no • reset suffix"
+teardown_sandbox
+
 # ─── Summary ────────────────────────────────
 echo
 echo "─────────────────"


### PR DESCRIPTION
## 🐛 Problem

ccpulse reports `minutes_to_reset: null` while the 5h quota is **idle** (0%
utilization, just after a reset) — a legitimate state, not missing data. The
helper treated it as a hard-required field (`[ -z "$mins_5h" ] && exit 0`),
so the **entire** Claude usage cluster vanished from the tmux status bar
whenever the 5h window was quiet. Closes #339.

## 🔧 Fix

`.config/tmux/bin/tmux-claude-usage`:

- 🗑️ Drop the `mins_5h` guard — `minutes_to_reset: null` is a valid idle
  state, not a reason to hide the cluster. `pct_5h` / `pct_7d` / `resets_7d`
  stay required.
- 🔀 Branch the 5h chip body on whether `mins_5h` is present: full
  `… • <reset>` when there's a countdown, `…` (pct + optional overreach
  decoration) when idle. Mirrors the existing 7d compact/expanded branching.
- 🔥 The overreach decoration is independent of the reset countdown, so it
  still renders in the idle branch (`over_5h_suffix` computed once, used in
  both).

## ✅ Test plan

- 🧪 Two regression fixtures added to `scripts/test-tmux-claude-usage.sh`
  (idle-renders, idle + overreach). Suite is **green** (100 passed, 0 failed)
  under Solarized — the helper's baked color expectation.
- 🎨 Note: when run in a non-Solarized session the 8 color-assertion tests
  read the live theme's `@color_*` and fail against the Solarized-hex needles
  — pre-existing and orthogonal to this change (they pass under Solarized).
- 👀 Live smoke against a stubbed `ccpulse`:
  - idle 5h → `🤖 11%` · `⧗ 0%` (no ` • ` reset suffix) · `$1/h`
  - idle 5h + overreach → `⧗ 0% 🔥 → 120%` (decoration kept, no reset suffix)
  - normal 5h → `⧗ 8% • 3h37m` (reset suffix unchanged — no regression)