### PR TITLE
🐛 nvim: fix flashing treesitter endwise error on main branch

### DIFF
--- a/.config/nvim/lua/plugins/treesitter.lua
+++ b/.config/nvim/lua/plugins/treesitter.lua
@@ -7,11 +7,13 @@ return {
     end,
   },
   {
+    -- endwise auto-inits via its own plugin/ file ("no configuration required").
+    -- Load on the filetypes it ships endwise queries for; `ft` makes lazy.nvim
+    -- re-fire FileType so the current buffer attaches immediately. Do NOT add a
+    -- `config` calling nvim-treesitter.configs.setup() — that module is gone on
+    -- the nvim-treesitter `main` branch and throws on InsertEnter.
     "RRethy/nvim-treesitter-endwise",
-    event = "InsertEnter",
+    ft = { "ruby", "lua", "bash", "fish", "vim", "elixir", "julia", "luau", "verilog" },
     dependencies = { "nvim-treesitter/nvim-treesitter" },
-    config = function()
-      require("nvim-treesitter.configs").setup({ endwise = { enable = true } })
-    end,
   },
 }


### PR DESCRIPTION
## 🐛 Problem

`nvim-treesitter` is pinned to the `main` branch, where the `nvim-treesitter.configs` module no longer exists. The `nvim-treesitter-endwise` spec called it in its `config`:

    require("nvim-treesitter.configs").setup({ endwise = { enable = true } })

That threw `module nvim-treesitter.configs not found` on the first `InsertEnter`. LazyVim renders it through the snacks notifier, so it appeared as a toast that flashed and vanished — it never reached `:messages`, which is why it was hard to catch.

## 🔧 Fix

- 🗑️ Drop the `config`. Modern endwise auto-initialises via its own `plugin/` file (README: "no configuration is required") and attaches through a FileType autocmd.
- 🔁 Load via `ft = { ... }` (the languages endwise ships endwise queries for) instead of `event = "InsertEnter"`. Using `ft` makes lazy.nvim re-fire FileType on load, so the current buffer attaches immediately.

## ✅ Verification

- 🧪 Real-PTY repro: open a buffer containing `def foo`, enter insert and press Enter → the buffer becomes `def foo` / blank / `end`. endwise now inserts `end` — it never attached before because the crash aborted setup.
- 🔕 No error or warn entries in the snacks notifier history; `:messages` is clean.
- 📋 Root cause proof: on the installed `main` branch, `require("nvim-treesitter.configs")` returns not found and `require("nvim-treesitter").define_modules` is nil.

## ⚠️ Out of scope

Noticed separately while debugging: `mason` is stuck mid-install on `haskell-language-server` (from the `lang.haskell` extra) on every launch, which contradicts the repo LSPs-off default. Not addressed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)