### PR TITLE
🔁 slm: switch backend from LM Studio to oMLX

### DIFF
--- a/.config/fish/conf.d/99-secrets.fish.template
+++ b/.config/fish/conf.d/99-secrets.fish.template
@@ -5,3 +5,6 @@
 # Add API keys etc. with: set -gx KEY value
 # Example:
 # set -gx ANTHROPIC_API_KEY sk-...
+
+# oMLX API key for `slm` (see ~/.omlx/settings.json → auth.api_key):
+# set -gx SLM_API_KEY abc123

--- a/.config/fish/functions/slm.fish
+++ b/.config/fish/functions/slm.fish
@@ -1,19 +1,20 @@
-function slm --description 'One-off prompt to the local LM Studio model (lfm2.5)'
-    set -l usage "slm — one-off prompt to the local LM Studio model
+function slm --description 'One-off prompt to the local oMLX model (Llama-3.2-1B)'
+    set -l usage "slm — one-off prompt to the local oMLX model
 
 Usage:
   slm [-m <id>] [-s <prompt>] <prompt words...>
   cat file | slm [-m <id>] [-s <prompt>] [prompt words...]
 
 Flags:
-  -m, --model <id>    model id (default: \$SLM_MODEL or lfm2.5-1.2b-instruct)
+  -m, --model <id>    model id (default: \$SLM_MODEL or Llama-3.2-1B-Instruct-4bit)
   -s, --system <txt>  system prompt (default: \$SLM_SYSTEM or a terse built-in)
   -h, --help          show this help
 
 Env:
-  SLM_URL     base URL (default http://localhost:1234/v1)
-  SLM_MODEL   default model id
-  SLM_SYSTEM  default system prompt"
+  SLM_URL      base URL (default http://localhost:8000/v1)
+  SLM_MODEL    default model id
+  SLM_SYSTEM   default system prompt
+  SLM_API_KEY  oMLX API key, sent as 'Authorization: Bearer' (oMLX requires it)"
 
     argparse m/model= s/system= h/help -- $argv
     or return 2
@@ -25,7 +26,7 @@ Env:
 
     # Config: flag > env > built-in default.
     set -l url $SLM_URL
-    test -n "$url"; or set url http://localhost:1234/v1
+    test -n "$url"; or set url http://localhost:8000/v1
 
     set -l model
     if set -q _flag_model
@@ -33,7 +34,7 @@ Env:
     else if set -q SLM_MODEL; and test -n "$SLM_MODEL"
         set model $SLM_MODEL
     else
-        set model lfm2.5-1.2b-instruct
+        set model Llama-3.2-1B-Instruct-4bit
     end
 
     set -l system
@@ -44,6 +45,13 @@ Env:
     else
         set system "You are a terse assistant. Reply with only the answer, no preamble."
     end
+
+    # oMLX requires an API key (LM Studio didn't). Read it from $SLM_API_KEY —
+    # seeded in the untracked 99-secrets.fish, never committed. Build the auth
+    # header only when set, so the same code path still works against a keyless
+    # endpoint (e.g. an older LM Studio at $SLM_URL).
+    set -l auth
+    test -n "$SLM_API_KEY"; and set auth -H "Authorization: Bearer $SLM_API_KEY"
 
     # User message = args and/or piped stdin (instruction first, then the blob).
     # Read stdin only when it is not a TTY (mirrors less.fish). NOTE: in a
@@ -79,11 +87,11 @@ Env:
     set -l resp (jq -n --arg m "$model" --arg s "$system" --arg u "$content" \
         '{model:$m, messages:((if $s=="" then [] else [{role:"system",content:$s}] end)+[{role:"user",content:$u}]), temperature:0.3, stream:false}' \
         | curl -s --connect-timeout 5 --max-time 120 \
-            "$url/chat/completions" -H 'Content-Type: application/json' --data @-)
+            "$url/chat/completions" -H 'Content-Type: application/json' $auth --data @-)
     set -l rc $status
 
     if test $rc -eq 7
-        echo "slm: LM Studio not reachable at $url — run 'lms server start'" >&2
+        echo "slm: oMLX not reachable at $url — is the oMLX server running?" >&2
         return 1
     else if test $rc -ne 0
         echo "slm: request failed (curl exit $rc)" >&2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -285,17 +285,21 @@ bootstrap defaults. See "Switchable themes" / "Switchable Ghostty fonts" below.
   restart tier (new shells). Escape `command diff`. Don't pin flags.
 - **`xh` is the HTTP client** (`xh`/`xhs`; `--style=solarized` in
   `.config/xh/config.json`). Don't alias `curl`. No `http`/`https` alias.
-- **`slm` pipes any prompt to the local LM Studio model** (fish function
-  `.config/fish/functions/slm.fish`; LM-Studio-only, Mac-only). One-shot,
-  buffered: args and/or stdin → one `curl` POST to `$SLM_URL/chat/completions`
-  (default `:1234/v1`) with `$SLM_MODEL` (default `lfm2.5-1.2b-instruct`) →
-  prints `.choices[0].message.content`. Uses **`curl`, not `xh`** — raw JSON
-  body via `jq`, the documented exception. Flags `-m`/`-s`/`-h`; env
-  `SLM_URL`/`SLM_MODEL`/`SLM_SYSTEM` (precedence flag > env > built-in). Server
-  not always-on → friendly `lms server start` error on connection refusal, no
-  auto-start. 1.2B model: quick/cheap, not authoritative. **Out of sandbox
-  scope** (LM Studio is a Mac desktop app; in-container `localhost` isn't the
-  host). Smoke: `scripts/test-slm.sh`.
+- **`slm` pipes any prompt to the local oMLX model** (fish function
+  `.config/fish/functions/slm.fish`; oMLX-only, Mac-only). One-shot, buffered:
+  args and/or stdin → one `curl` POST to `$SLM_URL/chat/completions` (default
+  `:8000/v1`) with `$SLM_MODEL` (default `Llama-3.2-1B-Instruct-4bit`) → prints
+  `.choices[0].message.content`. oMLX **requires an API key**: sends
+  `Authorization: Bearer $SLM_API_KEY` when set (seeded in untracked
+  `99-secrets.fish`), header omitted when empty so a keyless endpoint still
+  works. Uses **`curl`, not `xh`** — raw JSON body via `jq`, the documented
+  exception. Flags `-m`/`-s`/`-h`; env
+  `SLM_URL`/`SLM_MODEL`/`SLM_SYSTEM`/`SLM_API_KEY` (precedence flag > env >
+  built-in). Server not always-on → friendly `oMLX not reachable` error on
+  connection refusal, no auto-start (the `omlx` CLI wrapper is broken on this
+  machine anyway — server runs separately). 1B model: quick/cheap, not
+  authoritative. **Out of sandbox scope** (oMLX is a Mac server; in-container
+  `localhost` isn't the host). Smoke: `scripts/test-slm.sh`.
 - **`hyperfine`** for benchmarks (warmups / A-B), additive to `time`. Raw.
 - **`duf`/`dust`/`dua` are modern `df`/`du`/`du`-aggregate companions** (raw, no
   alias; `du`/`df` stay for scripts). `dua i` opens a TUI deleter.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -296,8 +296,8 @@ bootstrap defaults. See "Switchable themes" / "Switchable Ghostty fonts" below.
   exception. Flags `-m`/`-s`/`-h`; env
   `SLM_URL`/`SLM_MODEL`/`SLM_SYSTEM`/`SLM_API_KEY` (precedence flag > env >
   built-in). Server not always-on → friendly `oMLX not reachable` error on
-  connection refusal, no auto-start (the `omlx` CLI wrapper is broken on this
-  machine anyway — server runs separately). 1B model: quick/cheap, not
+  connection refusal, no auto-start (start it with `omlx serve <model> --port
+  8000` or the oMLX menubar app). 1B model: quick/cheap, not
   authoritative. **Out of sandbox scope** (oMLX is a Mac server; in-container
   `localhost` isn't the host). Smoke: `scripts/test-slm.sh`.
 - **`hyperfine`** for benchmarks (warmups / A-B), additive to `time`. Raw.

--- a/bin/i
+++ b/bin/i
@@ -53,11 +53,11 @@ local_slug() {                       # $1 = title, $2 = description (optional)
   command -v fish >/dev/null 2>&1 || return 0
   local slm_fn="${XDG_CONFIG_HOME:-$HOME/.config}/fish/functions/slm.fish"
   [[ -f "$slm_fn" ]] || return 0
-  # Cap description to keep latency sane on the 1.2B model.
+  # Cap description to keep latency sane on the 1B model.
   local desc="${2:-}"
   desc="${desc:0:1500}"
   # `|| true`: under `set -euo pipefail` a non-zero anywhere in this pipeline —
-  # slm failing (LM Studio down) or `head -n1` closing the pipe early on a
+  # slm failing (oMLX down) or `head -n1` closing the pipe early on a
   # multi-line reply — would otherwise abort `i`. Swallow it so empty output
   # falls through to the bare issue number.
   printf 'Title: %s\n\nDescription: %s' "$1" "$desc" \

--- a/docs/terminal-cheatsheet.html
+++ b/docs/terminal-cheatsheet.html
@@ -514,11 +514,12 @@
   <div class="card">
     <h3>Env &amp; notes</h3>
     <table>
-      <tr><td class="key"><code>SLM_URL</code></td><td class="desc">base URL (default <code>http://localhost:1234/v1</code>)</td></tr>
-      <tr><td class="key"><code>SLM_MODEL</code></td><td class="desc">default model (<code>lfm2.5-1.2b-instruct</code>); persist via <code>set -Ux</code></td></tr>
+      <tr><td class="key"><code>SLM_URL</code></td><td class="desc">base URL (default <code>http://localhost:8000/v1</code>)</td></tr>
+      <tr><td class="key"><code>SLM_MODEL</code></td><td class="desc">default model (<code>Llama-3.2-1B-Instruct-4bit</code>); persist via <code>set -Ux</code></td></tr>
       <tr><td class="key"><code>SLM_SYSTEM</code></td><td class="desc">default system prompt (terse built-in otherwise)</td></tr>
+      <tr><td class="key"><code>SLM_API_KEY</code></td><td class="desc">oMLX API key, sent as <code>Authorization: Bearer</code> (seeded in <code>99-secrets.fish</code>)</td></tr>
     </table>
-    <p class="note">Talks to LM Studio's OpenAI-compatible endpoint via <code>curl</code>. Server isn't always-on — start it with <code>lms server start</code>. It's a 1.2B model: quick &amp; free, not authoritative.</p>
+    <p class="note">Talks to oMLX's OpenAI-compatible endpoint via <code>curl</code> (needs <code>SLM_API_KEY</code>). Server isn't always-on — start the oMLX server if it's not running. It's a 1B model: quick &amp; free, not authoritative.</p>
   </div>
 </div>
 

--- a/scripts/test-slm.sh
+++ b/scripts/test-slm.sh
@@ -1,7 +1,7 @@
 #!/opt/homebrew/bin/bash
 # Smoke test for the `slm` fish function (.config/fish/functions/slm.fish).
 # Covers the deterministic no-server paths; the live happy-path is gated on
-# LM Studio being reachable so CI (no LM Studio) still passes.
+# oMLX being reachable (and SLM_API_KEY set) so CI (no oMLX) still passes.
 set -uo pipefail
 
 DOTFILES="$(cd "$(dirname "$0")/.." && pwd)"
@@ -63,7 +63,7 @@ assert_contains "$err" "Usage:" "no prompt prints usage to stderr"
 #    call's stdin read gets EOF instead of blocking on an open pipe.)
 err=$(SLM_URL=http://localhost:1/v1 fish --no-config -c "source '$SLM_FN'; slm hi" </dev/null 2>&1 >/dev/null); rc=$?
 assert_eq "$rc" "1" "server-down exits 1"
-assert_contains "$err" "lms server start" "server-down suggests 'lms server start'"
+assert_contains "$err" "oMLX not reachable" "server-down reports oMLX unreachable"
 
 # 4. Multi-line stdin where lines begin with `-` must not be misread as flags
 #    to the internal `string join` calls. Regression for a bug where
@@ -80,16 +80,17 @@ Description:
 EOF
 ); rc=$?
 assert_eq "$rc" "1" "leading-dash stdin doesn't crash slm"
-assert_contains "$err" "lms server start" "leading-dash stdin still reaches friendly server-down error"
+assert_contains "$err" "oMLX not reachable" "leading-dash stdin still reaches friendly server-down error"
 if printf '%s' "$err" | grep -q "string join:.*unknown option"; then
   fail=$((fail+1)); fail_msgs+=("FAIL  leading-dash stdin leaked to string join as a flag"); echo "  FAIL  leading-dash stdin no string-join flag leak"
 else
   pass=$((pass+1)); echo "  PASS  leading-dash stdin no string-join flag leak"
 fi
 
-# 4. Live happy-path — only if LM Studio is reachable.
-SLM_URL_DEFAULT="${SLM_URL:-http://localhost:1234/v1}"
-if curl -sf -o /dev/null --max-time 2 "$SLM_URL_DEFAULT/models" 2>/dev/null; then
+# 4. Live happy-path — only if oMLX is reachable and SLM_API_KEY is set (oMLX
+#    needs the Bearer header; the probe + slm both inherit it from the env).
+SLM_URL_DEFAULT="${SLM_URL:-http://localhost:8000/v1}"
+if curl -sf -o /dev/null --max-time 2 -H "Authorization: Bearer ${SLM_API_KEY:-}" "$SLM_URL_DEFAULT/models" 2>/dev/null; then
   out=$(fish --no-config -c "source '$SLM_FN'; slm reply with only the word OK" </dev/null 2>/dev/null); rc=$?
   assert_eq "$rc" "0" "live: exits 0"
   if [ -n "$out" ]; then
@@ -98,7 +99,7 @@ if curl -sf -o /dev/null --max-time 2 "$SLM_URL_DEFAULT/models" 2>/dev/null; the
     fail=$((fail+1)); fail_msgs+=("FAIL  live: empty completion"); echo "  FAIL  live: non-empty completion"
   fi
 else
-  echo "  SKIP — LM Studio not reachable at $SLM_URL_DEFAULT, skipping live happy-path"
+  echo "  SKIP — oMLX not reachable at $SLM_URL_DEFAULT (or SLM_API_KEY unset), skipping live happy-path"
 fi
 
 echo


### PR DESCRIPTION
## 🔁 What

Switches the `slm` one-shot prompt helper from **LM Studio** (`:1234`) to **oMLX** — the native macOS MLX inference server (`:8000`).

## ✨ Changes

- 🔌 **Backend** — default URL `:1234/v1` → `:8000/v1`; default model `lfm2.5-1.2b-instruct` → `Llama-3.2-1B-Instruct-4bit` (keeps slm's quick/cheap, not-authoritative role).
- 🔑 **Auth** — oMLX requires an API key (LM Studio didn't). `slm` now sends `Authorization: Bearer $SLM_API_KEY` **only when set**, sourced from the untracked `99-secrets.fish`. Header is omitted when empty, so a keyless endpoint (older LM Studio) still works. The key never lands in the public repo — the tracked template only carries a commented example.
- 💬 **Error text** — connection-refused message reworded to `oMLX not reachable` (dropped `lms server start`; the `omlx` CLI wrapper is broken on this machine anyway, so it points at "is the server running?").
- 📝 **Docs/tests** — smoke test (`:8000` + authed `/models` probe + new assertions), `CLAUDE.md` slm bullet, terminal cheatsheet env table (added `SLM_API_KEY` row), and stale `bin/i` comments.

## 🧪 Test plan

- ✅ `scripts/test-slm.sh` (with `SLM_API_KEY` set): **11/11 pass**, including the live happy-path against oMLX.
- ✅ `fish -c 'slm capital of France?'` → `Paris.` (conf.d auto-loads the key; new defaults reached with no flags).
- ✅ `scripts/test-fish-loads.sh` → clean.

## ⚠️ Notes

- The smoke test's live path is **skipped** unless `SLM_API_KEY` is exported into the env that runs it (it uses `fish --no-config`), so CI (no oMLX) stays green.