### PR TITLE
🎛️ i: seed brainstorm with the default model, keep max effort

### DIFF
--- a/bin/i
+++ b/bin/i
@@ -86,10 +86,11 @@ bd -C "$main" update "$id" --type feature >/dev/null
 bd -C "$main" label add "$id" "branch:$branch" >/dev/null
 
 # 3. Hand off to `s` (worktree + tmux + seeded claude). `s` runs
-#    ${S_CLAUDE_CMD:-claude} in window 1; we seed Phase 1 (Opus, max effort).
+#    ${S_CLAUDE_CMD:-claude} in window 1; we seed Phase 1 (default model, max
+#    effort).
 project=$(sesh list -c -j 2>/dev/null | jq -r --arg p "$main" '.[] | select(.Path == $p) | .Name' | head -n1)
 [[ -n "$project" ]] || { echo "i: $main is not in your sesh config" >&2; exit 1; }
 
 echo "i: issue #$n → bead $id → branch $branch" >&2
-S_CLAUDE_CMD='CLAUDE_CODE_EFFORT_LEVEL=max claude --model opus "/mc:brainstorm"' \
+S_CLAUDE_CMD='CLAUDE_CODE_EFFORT_LEVEL=max claude "/mc:brainstorm"' \
   exec s "$project" "$branch"


### PR DESCRIPTION
## 🧭 What

- 🪄 `bin/i` no longer pins `--model opus` in the seeded `/mc:brainstorm` session — the launched `claude` resolves the configured default model (settings.json `model`, currently Fable 5) instead.
- 🔥 `CLAUDE_CODE_EFFORT_LEVEL=max` is kept, so the seeded Phase 1 session still runs at max effort regardless of the global `effortLevel` setting.
- 📝 Updated the hand-off comment to match ("default model, max effort").

## 🤔 Why

The model pick should follow the machine's configured default rather than a hardcoded model name in the launcher; effort stays the explicit knob.

## ✅ Test plan

- 🚀 Run `i <issue>` and confirm window 1 launches claude on the default model with max effort, seeded with `/mc:brainstorm`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)