### PR TITLE
🔓 mise: trust ccpulse worktree configs by path prefix

### DIFF
--- a/.config/worktrunk/config.toml
+++ b/.config/worktrunk/config.toml
@@ -260,6 +260,13 @@ worktree-path = "{{ repo_path }}/.claude/worktrees/{{ branch | sanitize }}"
 # the next shell/pane). Chaining guarantees trust runs after the file
 # exists. `--all` trusts the worktree config plus parents (post-start cwd
 # is the new worktree); errors swallowed so a mise-less repo is a no-op.
+#
+# Note this background trust races the first shells in the new worktree
+# (`s` attaches a tmux session ~0.2s before it lands). For known repos the
+# race is defused by `trusted_config_paths` in mise.global.toml — a path
+# prefix needs no per-worktree trust at all. The chained trust here stays
+# as a catch-all for mise repos not yet in that list (one untrusted-config
+# error blip on first prompt, clean after).
 [post-start]
 copy = "wt step copy-ignored; mise trust --all 2>/dev/null || true"
 

--- a/.config/worktrunk/config.toml
+++ b/.config/worktrunk/config.toml
@@ -263,10 +263,12 @@ worktree-path = "{{ repo_path }}/.claude/worktrees/{{ branch | sanitize }}"
 #
 # Note this background trust races the first shells in the new worktree
 # (`s` attaches a tmux session ~0.2s before it lands). For known repos the
-# race is defused by `trusted_config_paths` in mise.global.toml — a path
-# prefix needs no per-worktree trust at all. The chained trust here stays
-# as a catch-all for mise repos not yet in that list (one untrusted-config
-# error blip on first prompt, clean after).
+# race is defused by `trusted_config_paths` in the machine-local
+# ~/.config/mise/config.local.toml (seeded from
+# mise.config.local.toml.template) — a path prefix needs no per-worktree
+# trust at all. The chained trust here stays as a catch-all for mise repos
+# not in that machine's list (one untrusted-config error blip on first
+# prompt, clean after).
 [post-start]
 copy = "wt step copy-ignored; mise trust --all 2>/dev/null || true"
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -360,6 +360,9 @@ fi
 # Stored as mise.global.toml at repo root (not under .config/mise/) to avoid
 # mise auto-discovering it as a local project config when inside the dotfiles dir.
 link "mise.global.toml" "$HOME/.config/mise/config.toml"
+# Machine-local settings (trusted_config_paths etc.) — settings REPLACE
+# across mise config files (no list merge), hence a per-machine file.
+seed_local "mise.config.local.toml.template" "$HOME/.config/mise/config.local.toml"
 mise install
 echo "$G_OK  mise runtimes installed"
 

--- a/mise.config.local.toml.template
+++ b/mise.config.local.toml.template
@@ -1,0 +1,25 @@
+# Machine-local mise settings — seeded once by bootstrap.sh to
+# ~/.config/mise/config.local.toml, never committed. Edit freely.
+#
+# NOTE: a setting here REPLACES the same key from the shared config.toml
+# (mise.global.toml) — lists don't merge — so list settings must carry
+# this machine's complete value.
+#
+# Kept at repo root as mise.config.local.toml.template (not under
+# .config/mise/) for the same reason as mise.global.toml: mise would
+# auto-discover .config/mise/ files as project config inside this repo.
+
+[settings]
+# Auto-trust worktree mise configs by path prefix. mise trust is
+# per-absolute-path, so every new worktree starts untrusted; the worktrunk
+# background post-start trust hook races the first shells of the tmux
+# session `s` attaches (~0.2s) — fish prompts error with "config not
+# trusted" until it lands. A trusted prefix has no timing: any config under
+# it is trusted the moment it exists, including gitignored ones
+# (mise.local.toml) delivered later by copy-ignored. Globs don't work
+# (mise 2026.5.18) — one literal entry per mise-using repo's worktrees dir.
+# Security-equivalent to the repo's already-trusted primary checkout.
+#
+# trusted_config_paths = [
+#   "~/code/<repo>/.claude/worktrees",
+# ]

--- a/mise.global.toml
+++ b/mise.global.toml
@@ -10,20 +10,10 @@ go = "1.25.10"
 [settings]
 legacy_version_file = true
 idiomatic_version_file_enable_tools = ["node", "ruby"]
-# Auto-trust mise configs under these path prefixes. mise trust is
-# per-absolute-path, so every new worktree starts untrusted; the worktrunk
-# post-start hook grants trust but runs in the background, and `s` spawns
-# the tmux session ~0.2s before it lands — the first fish prompts (and the
-# claude launch) hit "config not trusted" errors. A trusted prefix has no
-# timing: any config under it is trusted the moment it exists, including
-# gitignored ones (mise.local.toml) delivered later by copy-ignored.
-# Globs don't work (verified on 2026.5.18) — one literal entry per
-# mise-using repo's worktrees dir. Security-equivalent to the repo's
-# already-trusted primary checkout.
-trusted_config_paths = [
-  "~/code/ccpulse/.claude/worktrees",
-  # chopin (other machine): add its .claude/worktrees path here
-]
+# trusted_config_paths is machine-specific — it lives in the untracked
+# ~/.config/mise/config.local.toml (seeded from mise.config.local.toml.template).
+# Don't add it here: settings REPLACE across config files (no merge), so a
+# value here would be silently overridden on any machine with a local file.
 
 [settings.ruby]
 compile = false

--- a/mise.global.toml
+++ b/mise.global.toml
@@ -10,6 +10,20 @@ go = "1.25.10"
 [settings]
 legacy_version_file = true
 idiomatic_version_file_enable_tools = ["node", "ruby"]
+# Auto-trust mise configs under these path prefixes. mise trust is
+# per-absolute-path, so every new worktree starts untrusted; the worktrunk
+# post-start hook grants trust but runs in the background, and `s` spawns
+# the tmux session ~0.2s before it lands — the first fish prompts (and the
+# claude launch) hit "config not trusted" errors. A trusted prefix has no
+# timing: any config under it is trusted the moment it exists, including
+# gitignored ones (mise.local.toml) delivered later by copy-ignored.
+# Globs don't work (verified on 2026.5.18) — one literal entry per
+# mise-using repo's worktrees dir. Security-equivalent to the repo's
+# already-trusted primary checkout.
+trusted_config_paths = [
+  "~/code/ccpulse/.claude/worktrees",
+  # chopin (other machine): add its .claude/worktrees path here
+]
 
 [settings.ruby]
 compile = false


### PR DESCRIPTION
## 🐛 Problem

Creating a new ccpulse worktree via `s` spews `mise ERROR … Config files in ….claude/worktrees/<branch>/.mise.toml are not trusted` (×3) in the fresh tmux session.

## 🔍 Root cause

- mise trust is per-absolute-path — every new worktree starts untrusted.
- The worktrunk `[post-start]` hook does grant trust, but post-start runs in the **background**: `wt switch` returns immediately and `s` attaches the tmux session ~0.2s before trust lands. The first fish prompts (and the `claude` launch) run `mise hook-env` against the still-untrusted config and error.
- #332 (June 1) made the loss reliable: it chained `mise trust` **after** `copy-ignored` (to cover gitignored `mise.local.toml` configs), so trust now waits for the full copy instead of running as a parallel ms-fast hook that usually won the race.

Reproduced: `mise hook-env` failed with the exact reported error immediately after `wt switch` returned; trust landed 0.18s later.

## 🔧 Fix

- ➕ `trusted_config_paths = ["~/code/<repo>/.claude/worktrees"]` in the **machine-local** `~/.config/mise/config.local.toml`, seeded by bootstrap from a new repo-root `mise.config.local.toml.template`. A path prefix has no timing — any config under it is trusted the moment it exists, including gitignored ones delivered later by copy-ignored. Security-equivalent to the already-trusted primary checkout.
- 🏠 Machine-local on purpose: mise settings **replace** across config files (lists don't merge — verified on 2026.5.18), so a shared-file value would be silently overridden on any machine with a local override. The shared `mise.global.toml` carries a pointer comment instead.
- 📍 Template sits at repo root for the same reason as `mise.global.toml` — anything under `.config/mise/` would be auto-discovered as project config inside this repo.
- 📝 The chained post-start trust stays as a catch-all for repos not in a machine's list; worktrunk comment documents the two layers.

## ✅ Verification

- 🧪 `mise settings trusted_config_paths` resolves from `config.local.toml`; `mise config ls` loads both files.
- 🧪 Existing worktree with per-path trust explicitly stripped (`mise trust --untrust`): `mise hook-env -s fish` exits 0 with no error output — trusted purely via the prefix.
- 🧪 `bash -n bootstrap.sh` passes; `seed_local` only fires when the target is absent, so existing machine files are never clobbered.

## 📌 Follow-up

On the chopin machine: bootstrap seeds the stub — uncomment `trusted_config_paths` there and add `~/…/chopin/.claude/worktrees` (globs don't work; one literal entry per repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
