### PR TITLE
🗂️ fish: spec-last + plan-last — open the newest spec/plan in the pager

### DIFF
--- a/.config/fish/functions/plan-last.fish
+++ b/.config/fish/functions/plan-last.fish
@@ -1,0 +1,15 @@
+# Open the newest plan in .superpowers/plans with mdp.
+#
+# "Newest" = creation (birth) time via eza --sort=created, so the plan written
+# most recently wins even if an older one was edited later. Relative to the
+# current directory — run from the repo root. Plan filenames are date-prefixed,
+# so `--sort=name` would usually agree, but creation time also orders multiple
+# plans from the same day correctly.
+function plan-last --description 'Open the newest .superpowers/plans doc in the pager'
+    set -l files .superpowers/plans/*.md
+    if not count $files >/dev/null
+        echo "plan-last: no plans in .superpowers/plans/" >&2
+        return 1
+    end
+    mdp (eza --sort=created --reverse $files | head -1)
+end

--- a/.config/fish/functions/spec-last.fish
+++ b/.config/fish/functions/spec-last.fish
@@ -1,0 +1,15 @@
+# Open the newest spec in .superpowers/specs with mdp.
+#
+# "Newest" = creation (birth) time via eza --sort=created, so the spec written
+# most recently wins even if an older one was edited later. Relative to the
+# current directory — run from the repo root. Spec filenames are date-prefixed,
+# so `--sort=name` would usually agree, but creation time also orders multiple
+# specs from the same day correctly.
+function spec-last --description 'Open the newest .superpowers/specs doc in the pager'
+    set -l files .superpowers/specs/*.md
+    if not count $files >/dev/null
+        echo "spec-last: no specs in .superpowers/specs/" >&2
+        return 1
+    end
+    mdp (eza --sort=created --reverse $files | head -1)
+end

--- a/docs/terminal-cheatsheet.html
+++ b/docs/terminal-cheatsheet.html
@@ -403,6 +403,7 @@
       <tr><td class="key"><code>md README.md</code></td><td class="desc">render to terminal</td></tr>
       <tr><td class="key"><code>md -p README.md</code></td><td class="desc">paged (uses <code>$PAGER</code> / less)</td></tr>
       <tr><td class="key"><code>mdp README.md</code></td><td class="desc">same as <code>md -p</code> (dedicated alias)</td></tr>
+      <tr><td class="key"><code>spec-last</code> / <code>plan-last</code></td><td class="desc">open the newest <code>.superpowers/specs|plans</code> doc via <code>mdp</code> (creation-time sort; run from repo root)</td></tr>
       <tr><td class="key"><code>md -w 100 README.md</code></td><td class="desc">override width (later flag wins)</td></tr>
       <tr><td class="key"><code>cat foo.md | md -</code></td><td class="desc">render from stdin</td></tr>
       <tr><td class="key"><code>command glow ...</code></td><td class="desc">bypass <code>md</code> (no <code>--style</code>/width)</td></tr>
@@ -842,7 +843,7 @@
 <span class="cmd">git log -p</span> | <span class="cmd">head</span>                 <span class="c"># should look styled</span></pre>
 
 <footer>
-  Built from <code>~/.config/fish/</code>, <code>Brewfile</code>, and project CLAUDE.md on 2026-05-29.
+  Built from <code>~/.config/fish/</code>, <code>Brewfile</code>, and project CLAUDE.md on 2026-06-10.
   Refresh after meaningful color-tooling changes.
 </footer>
 


### PR DESCRIPTION
## 📦 What

Two autoloaded fish functions:

- 🗂️ `spec-last` — opens the newest doc in the local gitignored `specs/` dir via `mdp`
- 🗺️ `plan-last` — same for `plans/`

Both pick "newest" by **creation (birth) time** (`eza --sort=created --reverse`), so the doc written most recently wins even if an older one was edited later. Date-prefixed filenames mean name-sort would usually agree; creation time also orders same-day docs correctly.

## 🛡️ Edge handling

- Empty/missing dir → friendly message on stderr, exit 1 (fish allows unmatched globs in `set`, so no glob error leaks)
- Calls `eza` by name (Brewfile-guaranteed; alias-independent), `command`-free since no alias shadows it

## 📚 Docs

- Cheatsheet: usage row added to the md/glow card in `docs/terminal-cheatsheet.html`, footer date bumped

## ✅ Test plan

- 🧪 `scripts/test-fish-loads.sh` — config loads clean
- 🧪 Happy path with stubbed `mdp`: both functions resolve the newest doc in this repo
- 🧪 Guard path in an empty temp dir: message + exit 1 for both