### PR TITLE
🍺 bootstrap: machine-local Brewfile.local overlay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,10 @@
 .config/fish/conf.d/15-local.fish
 .config/fish/conf.d/99-secrets.fish
 
+# machine-local brew overlay — packages for one machine only, not every
+# machine that shares this repo; bundled after the shared Brewfile by bootstrap.sh
+Brewfile.local
+
 # fish runtime state (universal vars, history, generated completions)
 .config/fish/fish_variables
 .config/fish/fish_history

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,9 @@ bootstrap defaults. See "Switchable themes" / "Switchable Ghostty fonts" below.
   palette theme (auto-adapts, no `theme-set` coupling). Failed commands shown,
   not hidden. Revert: delete the file. First run: `atuin import fish`.
 - **`Brewfile` installed by bootstrap** unconditionally before symlinks;
-  aborts on failure.
+  aborts on failure. **`Brewfile.local`** (gitignored, optional) is a
+  machine-local overlay bundled right after, for packages wanted on one
+  machine only; absent ⇒ skipped (no-op).
 - **Global gitignore symlinked from `.gitignore_global`** → `~/.gitignore_global`.
   Cross-repo never-commit set (Claude state, `.superpowers/`, `.autonomo/`).
   Don't add language patterns — those belong in per-language `.gitignore`.

--- a/README.md
+++ b/README.md
@@ -86,6 +86,17 @@ Safe to re-run (idempotent for already-imported rows). After this,
 Ctrl-R opens atuin's picker (config at `.config/atuin/config.toml`).
 Up stays on fish's native history-search.
 
+**5. `Brewfile.local` (optional, per machine).** For brew packages you want on
+*this* machine only — not every machine that shares this repo — create a
+`Brewfile.local` next to `Brewfile`. It is gitignored; `bootstrap.sh` runs
+`brew bundle` against it right after the shared `Brewfile` when the file
+exists, and silently skips it otherwise. Same syntax as `Brewfile`:
+
+```ruby
+cask "some-app"
+brew "some-tool"
+```
+
 ## What's where
 
 | Tool         | Source path                          | Target              |

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -27,6 +27,12 @@ echo "$G_ROCKET dotfiles bootstrap"
 echo
 echo "$G_BREW brew bundle install:"
 brew bundle --file="$DOTFILES/Brewfile"
+# machine-local package overlay: gitignored Brewfile.local, absent on most
+# machines. Safe under `set -e` — a false `[ -f ]` short-circuits the && list
+# (left side of && is exempt from set -e), so the script does NOT abort when
+# the file is missing; it just skips. When present, brew bundle failure aborts
+# like the shared Brewfile above (desired).
+[ -f "$DOTFILES/Brewfile.local" ] && brew bundle --file="$DOTFILES/Brewfile.local"
 
 # link <source-relative-to-DOTFILES> <target-absolute>
 link() {


### PR DESCRIPTION
## 🍺 What

Adds an optional, gitignored `Brewfile.local` that `bootstrap.sh` bundles
right after the shared `Brewfile`. Lets a single machine carry extra brew
packages without pushing them to every machine that shares this repo.

## 🔧 How

- 🧩 `bootstrap.sh`: one guarded line — `[ -f "$DOTFILES/Brewfile.local" ] && brew bundle --file=...`. Safe under `set -e` (a missing file short-circuits the `&&` list and does not abort); when present, a `brew bundle` failure aborts like the shared `Brewfile`.
- 🙈 `.gitignore`: ignore `Brewfile.local`.
- 📝 `README.md` / `CLAUDE.md`: document the convention.

## ✅ Test plan

- ✔️ `bash -n bootstrap.sh` passes.
- ✔️ Guard logic verified with a stubbed `brew`: file absent ⇒ no call, no abort under `set -e`; file present ⇒ `brew bundle --file=<...>/Brewfile.local` invoked exactly once.
- ✔️ `git check-ignore Brewfile.local` matches.

## ⚠️ Risk

Minimal — additive, no behavior change on any machine without a `Brewfile.local`.